### PR TITLE
Add MIT license - let QFieldCloud fly

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 OPENGIS.ch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
At [OPENGIS.ch](https://www.opengis.ch) we strongly believe in [giving back](https://www.opengis.ch/core-values/#give-back).

We live from open-source projects and are deeply committed to sustaining their technological and economic well-being.
We also believe everyone should have access to the best possible tools and knowledge. By committing ourselves to develop open-source applications, we give everyone access to powerful tools to plan, review and mitigate geospatial issues.

Today we're super proud to publish the results of over 18 months of development and give you QFieldCloud's sources to go and make your awesome adaptations, solutions, and hopefully contributions :)

If you want to quickly try it out, head to https://qfield.cloud

Enjoy it, 
your OPENGIS.ch [GeoNinjas](https://www.opengis.ch/#team)

![team](https://user-images.githubusercontent.com/233663/116218734-1b757380-a74b-11eb-9c38-3051deaa4639.jpg)
