### PR TITLE
Letters, numbers, underscores, hyphens and dots are allowed in project names

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -6,6 +6,7 @@ from enum import Enum
 
 from django.contrib.auth.models import AbstractUser, UserManager
 from django.core.exceptions import ValidationError
+from django.core.validators import RegexValidator
 from django.db import models
 from django.db.models import Case, Exists, OuterRef, Q
 from django.db.models import Value as V
@@ -518,13 +519,13 @@ class Project(models.Model):
     name = models.CharField(
         max_length=255,
         validators=[
-            validators.allowed_symbols_validator,
-            validators.min_lenght_validator,
-            validators.first_symbol_validator,
-            validators.reserved_words_validator,
+            RegexValidator(
+                r"^[a-zA-Z0-9-_\.]+$",
+                _("Only letters, numbers, underscores, hyphens and dots are allowed."),
+            )
         ],
         help_text=_(
-            "Project name. Should start with a letter and contain only letters, numbers, underscores and hyphens."
+            _("Only letters, numbers, underscores, hyphens and dots are allowed.")
         ),
     )
 

--- a/docker-app/qfieldcloud/core/tests/test_project.py
+++ b/docker-app/qfieldcloud/core/tests/test_project.py
@@ -50,12 +50,12 @@ class ProjectTestCase(APITestCase):
 
         self.assertEqual(str(project.owner), "user1")
 
-    def test_create_project_reserved_name(self):
+    def test_create_project_invalid_name(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
         response = self.client.post(
             "/api/v1/projects/",
             {
-                "name": "project",
+                "name": "project$",
                 "owner": "user1",
                 "description": "desc",
                 "is_public": False,


### PR DESCRIPTION
Fix https://github.com/opengisch/qfieldcloud/issues/6