### PR TITLE
Change github workflow to push containers to public registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
           context: ./docker-caddy
           file: ./docker-caddy/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: opengischprivate/qfieldcloud-caddy:${{ steps.prepare.outputs.tag }}
+          tags: opengisch/qfieldcloud-caddy:${{ steps.prepare.outputs.tag }}
 
       # Application
       - name: Docker Test Application
@@ -79,7 +79,7 @@ jobs:
           context: ./docker-app
           file: ./docker-app/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: opengischprivate/qfieldcloud-application:${{ steps.prepare.outputs.tag }}
+          tags: opengisch/qfieldcloud-app:${{ steps.prepare.outputs.tag }}
 
       # Redis
       - name: Docker Test Redis
@@ -98,7 +98,7 @@ jobs:
           context: ./docker-redis
           file: ./docker-redis/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: opengischprivate/qfieldcloud-redis:${{ steps.prepare.outputs.tag }}
+          tags: opengisch/qfieldcloud-redis:${{ steps.prepare.outputs.tag }}
 
       # QGIS
       - name: Docker Test QGIS
@@ -117,4 +117,4 @@ jobs:
           context: ./docker-qgis
           file: ./docker-qgis/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: opengischprivate/qfieldcloud-qgis:${{ steps.prepare.outputs.tag }}
+          tags: opengisch/qfieldcloud-qgis:${{ steps.prepare.outputs.tag }}


### PR DESCRIPTION
The goal of this PR is to build the public containers and push to public registry.

We will use the public application container as a base for our private containers.


In order to make it work completely we need to set following secrets inside the github secrets settings:

- DOCKER_HUB_USERNAME
- DOCKER_HUB_ACCESS_TOKEN