### PR TITLE
run crons inside docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,10 @@ services:
       - db
       - redis
     logging: *default-logging
+    labels:
+      ofelia.enabled: "true"
+      ofelia.job-exec.runcrons.schedule: 0 * * * * *
+      ofelia.job-exec.runcrons.command: python manage.py runcrons
 
   web:
     build:
@@ -121,6 +125,14 @@ services:
       - db
       - redis
       - app
+
+  ofelia:
+    image: mcuadros/ofelia:v0.3.4
+    depends_on:
+      - app
+    command: daemon --docker
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
 
 volumes:
   postgres_data:


### PR DESCRIPTION
So that we don't need to manually setup cronjobs on the host (easier to inspect, easier to deploy, easier to test)