### PR TITLE
Support whitespace in the filename

### DIFF
--- a/docker-qgis/Dockerfile
+++ b/docker-qgis/Dockerfile
@@ -27,4 +27,4 @@ ENV LIBC_FATAL_STDERR_=1
 ENV LANG=C.UTF-8
 ENV PYTHONPATH="/usr/src/app/lib:${PYTHONPATH}"
 
-ENTRYPOINT ["/bin/sh", "-c", "/usr/bin/xvfb-run -a $@", ""]
+ENTRYPOINT ["/bin/sh", "-c", "/usr/bin/xvfb-run -a \"$@\"", ""]


### PR DESCRIPTION
if the uplaoded project file was names as `project   filename.qgs`, qfieldcloud was failing to perform any async task on it. this is no longer the case. Hide and seek championship goes to the entrypoint and quoting "$@"