### PR TITLE
Faster list files using list_objects and list_object_versions

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -542,6 +542,7 @@ class Project(models.Model):
     """
 
     objects = ProjectQueryset.as_manager()
+    _cache_files_count = None
 
     class Meta:
         ordering = ["owner__username", "name"]
@@ -626,7 +627,10 @@ class Project(models.Model):
 
     @property
     def files_count(self):
-        return utils.get_project_files_count(self.id)
+        if self._cache_files_count is None:
+            self._cache_files_count = utils.get_project_files_count(self.id)
+
+        return self._cache_files_count
 
 
 @receiver(pre_delete, sender=Project)

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -3,7 +3,7 @@ import secrets
 import string
 import uuid
 from enum import Enum
-from typing import Any, Type
+from typing import Any, Iterable, Type
 
 import qfieldcloud.core.utils2.storage
 from django.contrib.auth.models import AbstractUser, UserManager
@@ -622,8 +622,8 @@ class Project(models.Model):
         return not self.is_public
 
     @property
-    def files(self):
-        return utils.get_project_files(self.id)
+    def files(self) -> Iterable[utils.S3ObjectWithVersions]:
+        return utils.get_project_files_with_versions(self.id)
 
     @property
     def files_count(self):

--- a/docker-app/qfieldcloud/core/utils.py
+++ b/docker-app/qfieldcloud/core/utils.py
@@ -326,18 +326,6 @@ def list_versions(
         yield S3ObjectVersion(name, v)
 
 
-def get_prev_string_for_sorting(s: str) -> str:
-    """Get a string that is one string before the given string, if sorted alphabetically."""
-    if len(s) == 0:
-        return s
-
-    s, c = s[:-1], ord(s[-1])
-    if c > 0:
-        s += chr(c - 1)
-    s += "".join(["\u7FFF" for _ in range(10)])
-    return s
-
-
 def list_files_with_versions(
     bucket: mypy_boto3_s3.service_resource.Bucket,
     prefix: str,

--- a/docker-app/qfieldcloud/core/utils.py
+++ b/docker-app/qfieldcloud/core/utils.py
@@ -5,7 +5,7 @@ import os
 import posixpath
 from datetime import datetime
 from pathlib import PurePath
-from typing import IO, Dict, List, Optional, TypedDict, Union
+from typing import IO, Iterable, List, NamedTuple, Optional, TypedDict, Union
 
 import boto3
 import jsonschema
@@ -16,6 +16,50 @@ from django.core.files.uploadedfile import InMemoryUploadedFile, TemporaryUpload
 from redis import Redis, exceptions
 
 logger = logging.getLogger(__name__)
+
+
+class S3PrefixPath(NamedTuple):
+    Key: str
+
+
+class S3Object(NamedTuple):
+    Key: str
+    LastModified: datetime
+    Size: int
+    ETag: str
+
+
+class S3ObjectVersion:
+    def __init__(
+        self, name: str, data: mypy_boto3_s3.service_resource.ObjectVersion
+    ) -> None:
+        self.name = name
+        self._data = data
+
+    @property
+    def key(self) -> str:
+        return self._data.key
+
+    @property
+    def last_modified(self) -> datetime:
+        return self._data.last_modified
+
+    @property
+    def size(self) -> int:
+        return self._data.size
+
+    @property
+    def e_tag(self) -> str:
+        return self._data.e_tag
+
+    @property
+    def is_latest(self) -> bool:
+        return self._data.is_latest
+
+
+class S3ObjectWithVersions(NamedTuple):
+    latest: S3ObjectVersion
+    versions: List[S3ObjectVersion]
 
 
 def redis_is_running() -> bool:
@@ -227,58 +271,26 @@ class ProjectFile(TypedDict):
     versions: List[ProjectFileVersion]
 
 
-def get_project_files(project_id: str) -> Dict[str, ProjectFile]:
+def get_project_files_with_versions(project_id: str) -> Iterable[S3ObjectWithVersions]:
     """Returns a list of files and their versions.
 
     Args:
         project_id (str): the project id
 
     Returns:
-        Dict[str, ProjectFile]: the list of files
+        Iterable[S3ObjectWithVersions]: the list of files
     """
     bucket = get_s3_bucket()
     prefix = f"projects/{project_id}/files/"
 
-    files = {}
-    for version in reversed(list(bucket.object_versions.filter(Prefix=prefix))):
-        files[version.key] = files.get(version.key, {"versions": []})
-
-        head = version.head()
-        path = PurePath(version.key)
-        filename = str(path.relative_to(*path.parts[:3]))
-        last_modified = version.last_modified
-
-        metadata = head["Metadata"]
-        if "sha256sum" in metadata:
-            sha256sum = metadata["sha256sum"]
-        else:
-            sha256sum = metadata["Sha256sum"]
-
-        if version.is_latest:
-            files[version.key]["name"] = filename
-            files[version.key]["size"] = version.size
-            files[version.key]["sha256"] = sha256sum
-            files[version.key]["last_modified"] = last_modified
-
-        files[version.key]["versions"].append(
-            {
-                "size": version.size,
-                "sha256": sha256sum,
-                "version_id": version.version_id,
-                "last_modified": last_modified,
-                "is_latest": version.is_latest,
-            }
-        )
-
-    return files
+    return list_files_with_versions(bucket, prefix, strip_prefix=True)
 
 
 def get_project_files_count(project_id: str) -> int:
     """Returns the number of files within a project."""
-    # there might be more optimal way to get the files count
     bucket = get_s3_bucket()
     prefix = f"projects/{project_id}/files/"
-    files = set([v.key for v in bucket.object_versions.filter(Prefix=prefix)])
+    files = list(bucket.objects.filter(Prefix=prefix))
 
     return len(files)
 
@@ -296,3 +308,69 @@ def get_s3_object_url(
         str: URL
     """
     return f"{settings.STORAGE_ENDPOINT_URL_EXTERNAL}/{bucket.name}/{key}"
+
+
+def list_versions(
+    bucket: mypy_boto3_s3.service_resource.Bucket,
+    prefix: str,
+    strip_prefix: bool = True,
+) -> Iterable[S3ObjectVersion]:
+    """Iterator that lists a bucket's objects under prefix."""
+    for v in bucket.object_versions.filter(Prefix=prefix):
+        if strip_prefix:
+            start_idx = len(prefix)
+            name = v.key[start_idx:]
+        else:
+            name = v.key
+
+        yield S3ObjectVersion(name, v)
+
+
+def get_prev_string_for_sorting(s: str) -> str:
+    """Get a string that is one string before the given string, if sorted alphabetically."""
+    if len(s) == 0:
+        return s
+
+    s, c = s[:-1], ord(s[-1])
+    if c > 0:
+        s += chr(c - 1)
+    s += "".join(["\u7FFF" for _ in range(10)])
+    return s
+
+
+def list_files_with_versions(
+    bucket: mypy_boto3_s3.service_resource.Bucket,
+    prefix: str,
+    strip_prefix: bool = True,
+) -> Iterable[S3ObjectWithVersions]:
+    """Yields an object with all it's versions
+
+    Returns:
+        Iterable[S3ObjectWithVersions]: an iterator with the objects with their versions
+
+    Yields:
+        Iterator[Iterable[S3ObjectWithVersions]]: the object with its versions
+    """
+    last_key = None
+    versions: List[S3ObjectVersion] = []
+    latest: Optional[S3ObjectVersion] = None
+
+    for v in list_versions(bucket, prefix, strip_prefix):
+        if last_key != v.key:
+            if last_key:
+                assert latest
+
+                yield S3ObjectWithVersions(latest, versions)
+
+            latest = None
+            versions = []
+            last_key = v.key
+
+        versions.append(v)
+
+        if v.is_latest:
+            latest = v
+
+    if last_key:
+        assert latest
+        yield S3ObjectWithVersions(latest, versions)


### PR DESCRIPTION
There was an extra HEAD operation for each iteration, which proved to be quite slow. Now all happens in a single (well, maybe a few since it's 1000 objects per request) request.