### PR TITLE
Fix exception thrown when searching for user

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -215,7 +215,7 @@ class UserAdmin(admin.ModelAdmin):
         "useraccount__account_type",
     )
 
-    search_fields = ("username__icontains", "team_organization__username__iexact")
+    search_fields = ("username__icontains", "owner__username__iexact")
 
     inlines = (
         UserAccountInline,


### PR DESCRIPTION
Fix:
```
Cannot resolve keyword 'team_organization' into field. Choices are: auth_token, date_joined, email, emailaddress, first_name, geodb, groups, has_accepted_tos, has_newsletter_subscription, id, invitation, is_active, is_staff, is_superuser, job, last_login, last_name, logentry, organization, organizationmember, owner, password, projectcollaborator, projects, remaining_invitations, socialaccount, team, teammember, uploaded_deltas, user_permissions, user_type, useraccount, username
```