### PR TITLE
Run the worker `apply_delta` without `--overwrite-conflicts`

### DIFF
--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -223,7 +223,7 @@ class DeltaApplyJobRun(JobRun):
         super().__init__(job_id)
 
         if self.job.overwrite_conflicts:
-            self.command += ["--overwrite-conflicts"]
+            self.command = [*self.command, "--overwrite-conflicts"]
 
     def _prepare_deltas(self, deltas: Iterable[Delta]):
         delta_contents = []


### PR DESCRIPTION
We need to copy the command before appending to it, because it comes as static and is appended multiple times