### PR TITLE
Get all the users involved into a project with their roles and role origins

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -25,8 +25,116 @@ from qfieldcloud.core.utils import get_s3_object_url
 # http://springmeblog.com/2018/how-to-implement-multiple-user-types-with-django/
 
 
+class UserQueryset(models.QuerySet):
+    """Adds for_project(user) method to the user's querysets, allowing to filter only users part of a project.
+
+    Users are annotated with the user's project role (`project_role`) and the origin of this role (`project_role_origin`).
+    If the project is public, it will return only the directly collaborated users.
+
+    Args:
+        project:               project to find users for
+
+    Usage:
+    ```
+    # List all users that are involved in OpenKebabMap.
+    Users.object.for_project(OpenKebabMap)
+    ```
+    """
+
+    def for_project(self, project: "Project"):
+        permissions_config = [
+            # Project owner
+            (
+                Q(pk=project.owner.pk, user_type=User.TYPE_USER),
+                V(ProjectCollaborator.Roles.ADMIN),
+                V(ProjectQueryset.RoleOrigins.PROJECTOWNER),
+            ),
+            # Organization memberships - owner
+            (
+                Q(
+                    pk__in=Organization.objects.filter(pk=project.owner).values(
+                        "organization_owner"
+                    )
+                ),
+                V(ProjectCollaborator.Roles.ADMIN),
+                V(ProjectQueryset.RoleOrigins.ORGANIZATIONOWNER),
+            ),
+            # Organization memberships - admin
+            (
+                Q(
+                    pk__in=OrganizationMember.objects.filter(
+                        organization=project.owner,
+                        role=OrganizationMember.Roles.ADMIN,
+                    ).values("member")
+                ),
+                V(ProjectCollaborator.Roles.ADMIN),
+                V(ProjectQueryset.RoleOrigins.ORGANIZATIONADMIN),
+            ),
+            # Role through ProjectCollaborator
+            (
+                Exists(
+                    ProjectCollaborator.objects.filter(
+                        project=project,
+                        collaborator=OuterRef("pk"),
+                    ).exclude(
+                        collaborator__user_type=User.TYPE_TEAM,
+                    )
+                ),
+                ProjectCollaborator.objects.filter(
+                    project=project,
+                    collaborator=OuterRef("pk"),
+                )
+                .exclude(
+                    collaborator__user_type=User.TYPE_TEAM,
+                )
+                .values_list("role"),
+                V(ProjectQueryset.RoleOrigins.COLLABORATOR),
+            ),
+            # Role through Team membership
+            (
+                Exists(
+                    ProjectCollaborator.objects.filter(
+                        project=project,
+                        collaborator__team__members__member=OuterRef("pk"),
+                    )
+                ),
+                ProjectCollaborator.objects.filter(
+                    project=project,
+                    collaborator__team__members__member=OuterRef("pk"),
+                ).values_list("role"),
+                V(ProjectQueryset.RoleOrigins.TEAMMEMBER),
+            ),
+        ]
+
+        qs = User.objects.annotate(
+            project_role=Case(
+                *[When(perm[0], perm[1]) for perm in permissions_config],
+                default=None,
+                output_field=models.CharField(),
+            ),
+            project_role_origin=Case(
+                *[When(perm[0], perm[2]) for perm in permissions_config],
+                default=None,
+            ),
+        )
+        # Exclude those without role (invisible)
+        qs = qs.exclude(project_role__isnull=True)
+
+        return qs
+
+
+class QFieldCloudUserManager(UserManager):
+    def get_queryset(self):
+        return UserQueryset(self.model, using=self._db)
+
+    def for_project(self, project):
+        return self.get_queryset().for_project(project)
+
+
 # TODO change types to Enum
 class User(AbstractUser):
+    objects = QFieldCloudUserManager()
+
     TYPE_USER = 1
     TYPE_ORGANIZATION = 2
     TYPE_TEAM = 3
@@ -627,6 +735,10 @@ class Project(models.Model):
     @property
     def files_count(self):
         return utils.get_project_files_count(self.id)
+
+    @property
+    def users(self):
+        return User.objects.for_project(self)
 
 
 @receiver(pre_delete, sender=Project)

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -39,6 +39,9 @@ class UserQueryset(models.QuerySet):
     # List all users that are involved in OpenKebabMap.
     Users.object.for_project(OpenKebabMap)
     ```
+
+    Note:
+    This query is very similar to `ProjectQueryset.for_user`, don't forget to update it too.
     """
 
     def for_project(self, project: "Project"):
@@ -554,6 +557,9 @@ class ProjectQueryset(models.QuerySet):
     # List Olivier's projects that are visible to Ivan (olivier/ivan are User instances)
     olivier.projects.for_user(ivan)
     ```
+
+    Note:
+    This query is very similar to `UserQueryset.for_project`, don't forget to update it too.
     """
 
     class RoleOrigins(models.TextChoices):

--- a/docker-app/qfieldcloud/core/tests/test_queryset.py
+++ b/docker-app/qfieldcloud/core/tests/test_queryset.py
@@ -243,3 +243,70 @@ class QfcTestCase(APITestCase):
         self.assertEqual(p(self.project9, self.user3).user_role, ProjectCollaborator.Roles.EDITOR)
         self.assertEqual(p(self.project9, self.user3).user_role_origin, ProjectQueryset.RoleOrigins.TEAMMEMBER.value)
         # fmt: on
+
+    def test_user_roles_and_role_origins(self):
+        """
+        Checks project_role and project_role_origin are correctly defined
+        """
+
+        def p(proj, user):
+            return User.objects.for_project(proj).get(pk=user.pk)
+
+        # fmt: off
+        self.assertEqual(p(self.project1, self.user1).project_role, ProjectCollaborator.Roles.ADMIN)
+        self.assertEqual(p(self.project1, self.user1).project_role_origin, ProjectQueryset.RoleOrigins.PROJECTOWNER.value)
+        self.assertEqual(p(self.project2, self.user1).project_role, ProjectCollaborator.Roles.ADMIN)
+        self.assertEqual(p(self.project2, self.user1).project_role_origin, ProjectQueryset.RoleOrigins.PROJECTOWNER.value)
+        with self.assertRaises(User.DoesNotExist):
+            p(self.project3, self.user1)
+        with self.assertRaises(User.DoesNotExist):
+            p(self.project4, self.user1)
+        self.assertEqual(p(self.project5, self.user1).project_role, ProjectCollaborator.Roles.ADMIN)
+        self.assertEqual(p(self.project5, self.user1).project_role_origin, ProjectQueryset.RoleOrigins.ORGANIZATIONOWNER.value)
+        self.assertEqual(p(self.project6, self.user1).project_role, ProjectCollaborator.Roles.ADMIN)
+        self.assertEqual(p(self.project6, self.user1).project_role_origin, ProjectQueryset.RoleOrigins.ORGANIZATIONOWNER.value)
+        self.assertEqual(p(self.project7, self.user1).project_role, ProjectCollaborator.Roles.REPORTER)
+        self.assertEqual(p(self.project7, self.user1).project_role_origin, ProjectQueryset.RoleOrigins.COLLABORATOR.value)
+        with self.assertRaises(User.DoesNotExist):
+            p(self.project8, self.user1)
+        self.assertEqual(p(self.project9, self.user1).project_role, ProjectCollaborator.Roles.ADMIN)
+        self.assertEqual(p(self.project9, self.user1).project_role_origin, ProjectQueryset.RoleOrigins.ORGANIZATIONOWNER.value)
+
+        with self.assertRaises(User.DoesNotExist):
+            p(self.project1, self.user2)
+        with self.assertRaises(User.DoesNotExist):
+            p(self.project2, self.user2)
+        self.assertEqual(p(self.project3, self.user2).project_role, ProjectCollaborator.Roles.ADMIN)
+        self.assertEqual(p(self.project3, self.user2).project_role_origin, ProjectQueryset.RoleOrigins.PROJECTOWNER.value)
+        self.assertEqual(p(self.project4, self.user2).project_role, ProjectCollaborator.Roles.ADMIN)
+        self.assertEqual(p(self.project4, self.user2).project_role_origin, ProjectQueryset.RoleOrigins.PROJECTOWNER.value)
+        self.assertEqual(p(self.project5, self.user2).project_role, ProjectCollaborator.Roles.ADMIN)
+        self.assertEqual(p(self.project5, self.user2).project_role_origin, ProjectQueryset.RoleOrigins.ORGANIZATIONADMIN.value)
+        self.assertEqual(p(self.project6, self.user2).project_role, ProjectCollaborator.Roles.ADMIN)
+        self.assertEqual(p(self.project6, self.user2).project_role_origin, ProjectQueryset.RoleOrigins.ORGANIZATIONADMIN.value)
+        with self.assertRaises(User.DoesNotExist):
+            p(self.project7, self.user2)
+        with self.assertRaises(User.DoesNotExist):
+            p(self.project8, self.user2)
+        self.assertEqual(p(self.project9, self.user2).project_role, ProjectCollaborator.Roles.ADMIN)
+        self.assertEqual(p(self.project9, self.user2).project_role_origin, ProjectQueryset.RoleOrigins.ORGANIZATIONADMIN.value)
+
+        with self.assertRaises(User.DoesNotExist):
+            p(self.project1, self.user3)
+        with self.assertRaises(User.DoesNotExist):
+            p(self.project2, self.user3)
+        with self.assertRaises(User.DoesNotExist):
+            p(self.project3, self.user3)
+        with self.assertRaises(User.DoesNotExist):
+            p(self.project4, self.user3)
+        with self.assertRaises(User.DoesNotExist):
+            p(self.project5, self.user3)
+        with self.assertRaises(User.DoesNotExist):
+            p(self.project6, self.user3)
+        self.assertEqual(p(self.project7, self.user3).project_role, ProjectCollaborator.Roles.ADMIN)
+        self.assertEqual(p(self.project7, self.user3).project_role_origin, ProjectQueryset.RoleOrigins.PROJECTOWNER.value)
+        self.assertEqual(p(self.project8, self.user3).project_role, ProjectCollaborator.Roles.ADMIN)
+        self.assertEqual(p(self.project8, self.user3).project_role_origin, ProjectQueryset.RoleOrigins.PROJECTOWNER.value)
+        self.assertEqual(p(self.project9, self.user3).project_role, ProjectCollaborator.Roles.EDITOR)
+        self.assertEqual(p(self.project9, self.user3).project_role_origin, ProjectQueryset.RoleOrigins.TEAMMEMBER.value)
+        # fmt: on


### PR DESCRIPTION
This is the opposite of the already existing `Project.objects.for_user()`, now we add `User.objects.for_project`. It will return all the users that are somehow involved in the project: as project owner, organization owner, organiaztion admin, collaborator, member of a collaborating team. Note for a public project it will not return all the users.

Probably it is worth adding the users that have contributed in the past, but no longer are part of the project. Situation:
- `suricactus` owns a public project `OpenKebabMap`
- `suricactus` adds a few changes in the project via qfield
- `suricactus` becomes a vegan and transfers it to `kebab_destroyer_97`
- `suricactus` is no longer available in the people who contributed in the project

Easy to achive by looking in the `Delta.objects.filter(created_by=user)`

Anyway, I will add this in a follow-up PR on demand.