### PR TITLE
Permission fixes when adding collaborators

### DIFF
--- a/docker-app/qfieldcloud/core/permissions_utils.py
+++ b/docker-app/qfieldcloud/core/permissions_utils.py
@@ -4,6 +4,7 @@ from qfieldcloud.core.models import (
     Delta,
     Organization,
     OrganizationMember,
+    OrganizationQueryset,
     Project,
     ProjectCollaborator,
     ProjectQueryset,
@@ -39,6 +40,18 @@ def user_has_organization_roles(
     return (
         _organization_of_owner(user, organization)
         .filter(membership_role__in=roles)
+        .exists()
+    )
+
+
+def user_has_organization_role_origins(
+    user: QfcUser,
+    organization: Organization,
+    origins: List[OrganizationQueryset.RoleOrigins],
+):
+    return (
+        _organization_of_owner(user, organization)
+        .filter(membership_role_origin__in=origins)
         .exists()
     )
 
@@ -449,10 +462,13 @@ def can_delete_geodb(user: QfcUser, profile: QfcUser) -> bool:
 
 
 def can_become_member(user: QfcUser, organization: Organization) -> bool:
-    return not user_has_organization_roles(
+    return not user_has_organization_role_origins(
         user,
         organization,
-        [OrganizationMember.Roles.ADMIN, OrganizationMember.Roles.MEMBER],
+        [
+            OrganizationQueryset.RoleOrigins.ORGANIZATIONOWNER,
+            OrganizationQueryset.RoleOrigins.ORGANIZATIONMEMBER,
+        ],
     )
 
 

--- a/docker-app/qfieldcloud/core/permissions_utils.py
+++ b/docker-app/qfieldcloud/core/permissions_utils.py
@@ -407,20 +407,16 @@ def can_delete_members(user: QfcUser, organization: Organization) -> bool:
 
 
 def can_become_collaborator(user: QfcUser, project: Project) -> bool:
-    if user_has_project_role_origins(
-        user, project, [ProjectQueryset.RoleOrigins.PUBLIC]
-    ):
-        return True
+    if project.collaborators.filter(collaborator=user).count() > 0:
+        return False
 
-    return not user_has_project_roles(
+    return not user_has_project_role_origins(
         user,
         project,
         [
-            ProjectCollaborator.Roles.ADMIN,
-            ProjectCollaborator.Roles.MANAGER,
-            ProjectCollaborator.Roles.EDITOR,
-            ProjectCollaborator.Roles.REPORTER,
-            ProjectCollaborator.Roles.READER,
+            ProjectQueryset.RoleOrigins.PROJECTOWNER,
+            ProjectQueryset.RoleOrigins.COLLABORATOR,
+            ProjectQueryset.RoleOrigins.ORGANIZATIONOWNER,
         ],
     )
 


### PR DESCRIPTION
Added user_has_organization_role_origins and fix can_become_member to use role_origins
Forbid becoming a collaborator when owner, collaborator or organization owner only