### PR TITLE
Only suggest teams that are part of the project-owning organization

### DIFF
--- a/docker-app/qfieldcloud/core/querysets_utils.py
+++ b/docker-app/qfieldcloud/core/querysets_utils.py
@@ -89,6 +89,15 @@ def get_users(
 
     if exclude_teams:
         users = users.exclude(user_type=User.TYPE_TEAM)
+    else:
+        if project:
+            users = users.filter(
+                ~Q(user_type=User.TYPE_TEAM)
+                | (
+                    Q(user_type=User.TYPE_TEAM)
+                    & Q(pk__in=Team.objects.filter(team_organization=project.owner))
+                )
+            )
 
     # one day conditions can be more than just pk check, please keep it for now
     conditions = []

--- a/docker-app/qfieldcloud/core/tests/test_queryset.py
+++ b/docker-app/qfieldcloud/core/tests/test_queryset.py
@@ -156,20 +156,26 @@ class QfcTestCase(APITestCase):
 
         # should get all the users, that are not members or owner of a project
         queryset = querysets_utils.get_users("", project=self.project1)
-        self.assertEqual(len(queryset), 4)
+        self.assertEqual(len(queryset), 3)
         self.assertTrue(self.user2 in queryset)
         self.assertTrue(self.user3 in queryset)
         self.assertTrue(self.organization1.user_ptr in queryset)
+
+        # should get all the users, that are not members or owner of a project
+        queryset = querysets_utils.get_users("", project=self.project5)
+        self.assertEqual(len(queryset), 4)
+        self.assertTrue(self.user1 in queryset)
+        self.assertTrue(self.user2 in queryset)
+        self.assertTrue(self.user3 in queryset)
         self.assertTrue(self.team1.user_ptr in queryset)
 
         # should get all the users, that are not members or owner of a project and are not an organization
         queryset = querysets_utils.get_users(
             "", project=self.project1, exclude_organizations=True
         )
-        self.assertEqual(len(queryset), 3)
+        self.assertEqual(len(queryset), 2)
         self.assertTrue(self.user2 in queryset)
         self.assertTrue(self.user3 in queryset)
-        self.assertTrue(self.team1.user_ptr in queryset)
 
     def test_projects_roles_and_role_origins(self):
         """


### PR DESCRIPTION
Avoid situations like this when teams from other organizations are suggested:
![image](https://user-images.githubusercontent.com/2820439/142632561-94dbb98b-f4c8-4ee5-b03f-f59425e1281d.png)
