### PR TITLE
Make sure pyyaml is installed dependency

### DIFF
--- a/scripts/check_envvars.sh
+++ b/scripts/check_envvars.sh
@@ -1,3 +1,4 @@
 #!/bin/bash -e
 
-pipenv run python3 scripts/check_envvars.py .env.example --docker-compose-dir .
+pipenv run pip install pyyaml
+pipenv run python scripts/check_envvars.py .env.example --docker-compose-dir .


### PR DESCRIPTION
Now it is expected that the system python already has it. It is not always the case.