### PR TITLE
Increase logs stored for app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,11 @@ services:
     depends_on:
       - db
       - redis
-    logging: *default-logging
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1000m"
+        max-file: "5"
     labels:
       ofelia.enabled: "true"
       ofelia.job-exec.runcrons.schedule: 0 * * * * *


### PR DESCRIPTION
Way too small for the bulk data that is printed. However, the spam from `GET /deltas/<project_id>` is way too big too. We should limit what is printed as response body to 10k.