### PR TITLE
Update .env.example to fix 'invalid sslmode value'

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,8 @@ POSTGRES_PASSWORD=3shJDd2r7Twwkehb
 POSTGRES_DB=qfieldcloud_db
 POSTGRES_HOST=db
 POSTGRES_PORT=5432
-POSTGRES_SSLMODE=prefer # "prefer" OR "require" most of the times
+# "prefer" OR "require" most of the times
+POSTGRES_SSLMODE=prefer
 HOST_POSTGRES_PORT=5433
 
 GEODB_HOST=geodb


### PR DESCRIPTION
This will fix the "invalid sslmode value" error, when following the documentation mentioned in #211 

Docker doesn't support inline comments in `.env` files: https://docs.docker.com/compose/env-file/