### PR TITLE
Fix docker-compose.override.local.yml Syntax Error

### DIFF
--- a/docker-compose.override.local.yml
+++ b/docker-compose.override.local.yml
@@ -102,8 +102,7 @@ services:
   createbuckets:
     image: minio/mc
     depends_on:
-      minio:
-        condition: service_healthy
+      - minio
     entrypoint: >
       /bin/sh -c "
       /usr/bin/mc config host add myminio ${STORAGE_ENDPOINT_URL} ${STORAGE_ACCESS_KEY_ID} ${STORAGE_SECRET_ACCESS_KEY};


### PR DESCRIPTION
This will fix a syntax error in `docker-compose.override.local.yml` mentioned in #211 

Referring to the documentation, the depends_on condition is not supported anymore in docker-compose 3.x.

I cannot estimate if there are any side effects by removing this, but i don't think so.