### PR TITLE
Ignore newcoming deltas with the same id

### DIFF
--- a/docker-app/qfieldcloud/core/exceptions.py
+++ b/docker-app/qfieldcloud/core/exceptions.py
@@ -101,14 +101,6 @@ class DeltafileValidationError(QFieldCloudException):
     status_code = status.HTTP_400_BAD_REQUEST
 
 
-class DeltafileDuplicationError(QFieldCloudException):
-    """Raised when a deltafile with the same id has already been uploaded"""
-
-    code = "duplicate_deltafile"
-    message = "Deltafile already uploaded"
-    status_code = status.HTTP_400_BAD_REQUEST
-
-
 class NoDeltasToApplyError(QFieldCloudException):
     """Raised when a deltafile validation fails"""
 

--- a/docker-app/qfieldcloud/core/tests/test_delta.py
+++ b/docker-app/qfieldcloud/core/tests/test_delta.py
@@ -251,7 +251,7 @@ class QfcTestCase(APITransactionTestCase):
             ],
         )
 
-        self.assertFalse(
+        self.assertTrue(
             self.upload_deltas(project, "singlelayer_singledelta_diff_content.json")
         )
 


### PR DESCRIPTION
Proved to be very quirky to manage this from QField side. Therefore, just ignore the new comming delta with the same id, instead of throwing an error.