### PR TITLE
Purge old versions of project files

### DIFF
--- a/docker-app/qfieldcloud/core/cron.py
+++ b/docker-app/qfieldcloud/core/cron.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.core.management import call_command
 from django_cron import CronJobBase, Schedule
 from invitations.utils import get_invitation_model
 
@@ -36,15 +35,3 @@ class ResendFailedInvitationsJob(CronJobBase):
         logger.info(
             f'Resend {len(invitation_emails)} previously failed invitation(s) to: {", ".join(invitation_emails)}'
         )
-
-
-class PurgeOldFileVersions(CronJobBase):
-    """Purges old version of files of all projects using the purge_old_file_versions
-    management command.
-    """
-
-    schedule = Schedule(run_every_mins=60 * 24 * 7)
-    code = "qfieldcloud.purge_old_file_versions"
-
-    def do(self):
-        call_command("purge_old_file_versions", "--force")

--- a/docker-app/qfieldcloud/core/cron.py
+++ b/docker-app/qfieldcloud/core/cron.py
@@ -43,7 +43,7 @@ class PurgeOldFileVersions(CronJobBase):
     management command.
     """
 
-    schedule = Schedule(runs_every_mins=60 * 24 * 7)
+    schedule = Schedule(run_every_mins=60 * 24 * 7)
     code = "qfieldcloud.purge_old_file_versions"
 
     def do(self):

--- a/docker-app/qfieldcloud/core/cron.py
+++ b/docker-app/qfieldcloud/core/cron.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.core.management import call_command
 from django_cron import CronJobBase, Schedule
 from invitations.utils import get_invitation_model
 
@@ -35,3 +36,15 @@ class ResendFailedInvitationsJob(CronJobBase):
         logger.info(
             f'Resend {len(invitation_emails)} previously failed invitation(s) to: {", ".join(invitation_emails)}'
         )
+
+
+class PurgeOldFileVersions(CronJobBase):
+    """Purges old version of files of all projects using the purge_old_file_versions
+    management command.
+    """
+
+    schedule = Schedule(runs_every_mins=60 * 24 * 7)
+    code = "qfieldcloud.purge_old_file_versions"
+
+    def do(self):
+        call_command("purge_old_file_versions", "--force")

--- a/docker-app/qfieldcloud/core/management/commands/purge_old_file_versions.py
+++ b/docker-app/qfieldcloud/core/management/commands/purge_old_file_versions.py
@@ -38,6 +38,6 @@ class Command(BaseCommand):
         # Iterate through projects
         proj_instances = proj_instances.prefetch_related("owner__useraccount")
         for proj_instance in proj_instances:
-            storage.cleanup_old_file_versions(proj_instance)
+            storage.purge_old_file_versions(proj_instance)
 
         print("done !")

--- a/docker-app/qfieldcloud/core/management/commands/purge_old_file_versions.py
+++ b/docker-app/qfieldcloud/core/management/commands/purge_old_file_versions.py
@@ -83,7 +83,7 @@ class Command(BaseCommand):
                 all_count = len(old_versions)
                 topurge_count = len(old_versions_to_purge)
                 print(
-                    f"- {filename}: will purge {topurge_count} out of {all_count} old versions"
+                    f'Purging {topurge_count} out of {all_count} old versions for "{filename}"...'
                 )
 
                 # Remove the N oldest

--- a/docker-app/qfieldcloud/core/management/commands/purge_old_file_versions.py
+++ b/docker-app/qfieldcloud/core/management/commands/purge_old_file_versions.py
@@ -1,0 +1,86 @@
+from collections import defaultdict
+
+from django.core.management.base import BaseCommand, CommandError
+from qfieldcloud.core import utils
+from qfieldcloud.core.models import Project
+
+
+class Command(BaseCommand):
+    """
+    Deletes old versions of files
+    """
+
+    PROMPT_TXT = "This will purge old files for all projects. Type 'yes' to continue, or 'no' to cancel: "
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--projects",
+            type=str,
+            help="Comma separated list of ids of projects to prune. If unset, will purge all projects",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Prevent confirmation prompt when purging all projects",
+        )
+        parser.add_argument(
+            "--keep_count", type=int, default=10, help="How many versions to keep"
+        )
+
+    def handle(self, *args, **options):
+
+        # Determine project ids to work on
+        projects_ids = options.get("projects")
+        if not projects_ids:
+            if options.get("force") is not True and input(Command.PROMPT_TXT) != "yes":
+                raise CommandError("Collecting static files cancelled.")
+            projects_ids = Project.objects.values_list("id", flat=True)
+        else:
+            projects_ids = projects_ids.split(",")
+
+        # Get the affected projects
+        projects_qs = Project.objects.all()
+        if projects_ids:
+            projects_qs = projects_qs.filter(pk__in=projects_ids)
+
+        bucket = utils.get_s3_bucket()
+
+        for project_id in projects_ids:
+            print(f"Processing project {project_id}")
+
+            prefix = f"projects/{project_id}/files/"
+            keep_count = options.get("keep_count")
+
+            # All version under prefix
+            all_versions = bucket.object_versions.filter(Prefix=prefix)
+
+            # Organize the versions by file in a dict
+            old_versions_by_file = defaultdict(list)
+            for version in all_versions:
+                # The latest is not an old version
+                if version.is_latest:
+                    continue
+                old_versions_by_file[version.key].append(version)
+
+            # Process file by file
+            for filename, old_versions in old_versions_by_file.items():
+
+                # Sort by date (newest first)
+                old_versions.sort(key=lambda i: i.last_modified, reverse=True)
+
+                # Skip the newest N
+                old_versions_to_purge = old_versions[keep_count:]
+
+                # Debug print
+                all_count = len(old_versions)
+                topurge_count = len(old_versions_to_purge)
+                print(
+                    f"{filename}: will purge {topurge_count} out of {all_count} old versions"
+                )
+
+                # Remove the N oldest
+                for old_version in old_versions_to_purge:
+                    old_version.delete()
+                    # TODO: audit ? take implementation from files_views.py:211
+
+        print("done !")

--- a/docker-app/qfieldcloud/core/management/commands/purge_old_file_versions.py
+++ b/docker-app/qfieldcloud/core/management/commands/purge_old_file_versions.py
@@ -54,7 +54,7 @@ class Command(BaseCommand):
             elif account_type == UserAccount.TYPE_PRO:
                 keep_count = 10
             else:
-                print(f"⚠️ Unknown account type - skipping purge ⚠️")
+                print("⚠️ Unknown account type - skipping purge ⚠️")
                 continue
             print(f"Keeping {keep_count} versions")
 

--- a/docker-app/qfieldcloud/core/management/commands/purge_old_file_versions.py
+++ b/docker-app/qfieldcloud/core/management/commands/purge_old_file_versions.py
@@ -50,8 +50,7 @@ class Command(BaseCommand):
             elif account_type == UserAccount.TYPE_PRO:
                 keep_count = 10
             else:
-                print("⚠️ Unknown account type - skipping purge ⚠️")
-                continue
+                raise NotImplementedError(f"Unknown account type {account_type}")
             print(f"Keeping {keep_count} versions")
 
             # Process file by file
@@ -77,11 +76,9 @@ class Command(BaseCommand):
                 for old_version in old_versions_to_purge:
                     if old_version.is_latest:
                         # This is not supposed to happen, as versions were sorted above,
-                        # but leaving it here as a security measure
-                        print(
-                            "⚠️ Unexpected behaviour in purging old files - check sorting of versions ⚠️"
-                        )
-                        continue
+                        # but leaving it here as a security measure in case version
+                        # ordering changes for some reason.
+                        raise Exception("Trying to delete latest version")
                     # TODO: any way to batch those ? will probaby get slow on production
                     old_version._data.delete()
                     # TODO: audit ? take implementation from files_views.py:211

--- a/docker-app/qfieldcloud/core/management/commands/purge_old_file_versions.py
+++ b/docker-app/qfieldcloud/core/management/commands/purge_old_file_versions.py
@@ -75,6 +75,13 @@ class Command(BaseCommand):
 
                 # Remove the N oldest
                 for old_version in old_versions_to_purge:
+                    if old_version.is_latest:
+                        # This is not supposed to happen, as versions were sorted above,
+                        # but leaving it here as a security measure
+                        print(
+                            "⚠️ Unexpected behaviour in purging old files - check sorting of versions ⚠️"
+                        )
+                        continue
                     # TODO: any way to batch those ? will probaby get slow on production
                     old_version._data.delete()
                     # TODO: audit ? take implementation from files_views.py:211

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -425,7 +425,7 @@ class UserAccount(models.Model):
             return None
 
     def __str__(self):
-        return self.TYPE_CHOICES[self.account_type][1]
+        return self.get_account_type_display()
 
 
 class Geodb(models.Model):

--- a/docker-app/qfieldcloud/core/tests/test_qgis_file.py
+++ b/docker-app/qfieldcloud/core/tests/test_qgis_file.py
@@ -572,8 +572,14 @@ class QfcTestCase(APITransactionTestCase):
 
         apipath = f"/api/v1/files/{self.project1.id}/file.txt/"
 
-        def read_version(file, n):
-            """returns the content of version"""
+        def count_versions():
+            """counts the versions in first file of project1"""
+            file = list(self.project1.files)[0]
+            return len(file.versions)
+
+        def read_version(n):
+            """returns the content of version in first file of project1"""
+            file = list(self.project1.files)[0]
             return file.versions[n]._data.get()["Body"].read().decode()
 
         # Create 20 versions
@@ -582,38 +588,33 @@ class QfcTestCase(APITransactionTestCase):
             self.client.post(apipath, {"file": test_file}, format="multipart")
 
         # Ensure it worked
-        files = list(self.project1.files)
-        self.assertEqual(len(files[0].versions), 20)
-        self.assertEqual(read_version(files[0], 0), "v19")
-        self.assertEqual(read_version(files[0], 9), "v0")
+        self.assertEqual(count_versions(), 20)
+        self.assertEqual(read_version(0), "v19")
+        self.assertEqual(read_version(19), "v0")
 
         # Purge another project has no effect
-        other = Project.objects.create(name="other")
+        other = Project.objects.create(name="other", owner=self.user1)
         call_command("purge_old_file_versions", "--force", "--projects", other.pk)
-        files = list(self.project1.files)
-        self.assertEqual(len(files[0].versions), 20)
+        self.assertEqual(count_versions(), 20)
 
         # Purge pro account keeps 10 versions
         self.user1.useraccount.account_type = UserAccount.TYPE_PRO
         self.user1.useraccount.save()
         call_command("purge_old_file_versions", "--force")
-        files = list(self.project1.files)
-        self.assertEqual(len(files[0].versions), 10)
-        self.assertEqual(read_version(files[0], 0), "v19")
-        self.assertEqual(read_version(files[0], 9), "v10")
+        self.assertEqual(count_versions(), 10)
+        self.assertEqual(read_version(0), "v19")
+        self.assertEqual(read_version(9), "v10")
 
         # Purge community account keeps 3 versions
         self.user1.useraccount.account_type = UserAccount.TYPE_COMMUNITY
         self.user1.useraccount.save()
         call_command("purge_old_file_versions", "--force")
-        files = list(self.project1.files)
-        self.assertEqual(len(files[0].versions), 3)
-        self.assertEqual(read_version(files[0], 0), "v19")
-        self.assertEqual(read_version(files[0], 3), "v17")
+        self.assertEqual(count_versions(), 3)
+        self.assertEqual(read_version(0), "v19")
+        self.assertEqual(read_version(2), "v17")
 
         # Purge is idempotent
         call_command("purge_old_file_versions", "--force")
-        files = list(self.project1.files)
-        self.assertEqual(len(files[0].versions), 3)
-        self.assertEqual(read_version(files[0], 0), "v19")
-        self.assertEqual(read_version(files[0], 3), "v17")
+        self.assertEqual(count_versions(), 3)
+        self.assertEqual(read_version(0), "v19")
+        self.assertEqual(read_version(2), "v17")

--- a/docker-app/qfieldcloud/core/tests/test_qgis_file.py
+++ b/docker-app/qfieldcloud/core/tests/test_qgis_file.py
@@ -565,8 +565,52 @@ class QfcTestCase(APITransactionTestCase):
         self.assertGreater(response.json()[0]["size"], 10000000)
         self.assertLess(response.json()[0]["size"], 11000000)
 
+    def test_purge_old_versions_command(self):
+        """This tests manual purging of old versions with the management command"""
+
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
+
+        def count_versions():
+            """counts the versions in first file of project1"""
+            file = list(self.project1.files)[0]
+            return len(file.versions)
+
+        def read_version(n):
+            """returns the content of version in first file of project1"""
+            file = list(self.project1.files)[0]
+            return file.versions[n]._data.get()["Body"].read().decode()
+
+        # Create 20 versions (direct upload to s3)
+        bucket = utils.get_s3_bucket()
+        key = f"projects/{self.project1.id}/files/file.txt/"
+        for i in range(20):
+            test_file = io.BytesIO(f"v{i}".encode())
+            bucket.upload_fileobj(test_file, key)
+
+        # Ensure it worked
+        self.assertEqual(count_versions(), 20)
+        self.assertEqual(read_version(0), "v19")
+        self.assertEqual(read_version(19), "v0")
+
+        # Run management command on other project should have no effect
+        other = Project.objects.create(name="other", owner=self.user1)
+        call_command("purge_old_file_versions", "--force", "--projects", other.pk)
+        self.assertEqual(count_versions(), 20)
+
+        # Run management command should leave 3
+        call_command("purge_old_file_versions", "--force")
+        self.assertEqual(count_versions(), 3)
+        self.assertEqual(read_version(0), "v19")
+        self.assertEqual(read_version(2), "v17")
+
+        # Run management command is idempotent
+        call_command("purge_old_file_versions", "--force")
+        self.assertEqual(count_versions(), 3)
+        self.assertEqual(read_version(0), "v19")
+        self.assertEqual(read_version(2), "v17")
+
     def test_purge_old_versions(self):
-        """This tests manual purging of old versions"""
+        """This tests automated purging of old versions when uploading files"""
 
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
 
@@ -582,39 +626,34 @@ class QfcTestCase(APITransactionTestCase):
             file = list(self.project1.files)[0]
             return file.versions[n]._data.get()["Body"].read().decode()
 
-        # Create 20 versions
+        # As PRO account, 10 version should be kept out of 20
+        self.user1.useraccount.account_type = UserAccount.TYPE_PRO
+        self.user1.useraccount.save()
         for i in range(20):
             test_file = io.StringIO(f"v{i}")
             self.client.post(apipath, {"file": test_file}, format="multipart")
-
-        # Ensure it worked
-        self.assertEqual(count_versions(), 20)
-        self.assertEqual(read_version(0), "v19")
-        self.assertEqual(read_version(19), "v0")
-
-        # Purge another project has no effect
-        other = Project.objects.create(name="other", owner=self.user1)
-        call_command("purge_old_file_versions", "--force", "--projects", other.pk)
-        self.assertEqual(count_versions(), 20)
-
-        # Purge pro account keeps 10 versions
-        self.user1.useraccount.account_type = UserAccount.TYPE_PRO
-        self.user1.useraccount.save()
-        call_command("purge_old_file_versions", "--force")
         self.assertEqual(count_versions(), 10)
         self.assertEqual(read_version(0), "v19")
         self.assertEqual(read_version(9), "v10")
 
-        # Purge community account keeps 3 versions
+        # As COMMUNITY account, 3 version should be kept
         self.user1.useraccount.account_type = UserAccount.TYPE_COMMUNITY
         self.user1.useraccount.save()
-        call_command("purge_old_file_versions", "--force")
-        self.assertEqual(count_versions(), 3)
-        self.assertEqual(read_version(0), "v19")
-        self.assertEqual(read_version(2), "v17")
 
-        # Purge is idempotent
-        call_command("purge_old_file_versions", "--force")
-        self.assertEqual(count_versions(), 3)
+        # But first we check that uploading to another project doesn't affect a projct
+        otherproj = Project.objects.create(name="other", owner=self.user1)
+        otherpath = f"/api/v1/files/{otherproj.id}/file.txt/"
+        self.client.post(otherpath, {"file": io.StringIO("v1")}, format="multipart")
+        self.assertEqual(count_versions(), 10)
         self.assertEqual(read_version(0), "v19")
-        self.assertEqual(read_version(2), "v17")
+        self.assertEqual(read_version(9), "v10")
+
+        # As COMMUNITY account, 3 version should be kept out of 20 new ones
+        self.user1.useraccount.account_type = UserAccount.TYPE_COMMUNITY
+        self.user1.useraccount.save()
+        for i in range(20, 40):
+            test_file = io.StringIO(f"v{i}")
+            self.client.post(apipath, {"file": test_file}, format="multipart")
+        self.assertEqual(count_versions(), 3)
+        self.assertEqual(read_version(0), "v39")
+        self.assertEqual(read_version(2), "v37")

--- a/docker-app/qfieldcloud/core/utils2/storage.py
+++ b/docker-app/qfieldcloud/core/utils2/storage.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import logging
 from typing import IO
 
 import qfieldcloud.core.utils
+from qfieldcloud.core.models import UserAccount
+
+logger = logging.getLogger(__name__)
 
 
 def upload_user_avatar(user: "User", file: IO, mimetype: str) -> str:  # noqa: F821
@@ -96,3 +100,54 @@ def remove_project_thumbail(project: "Project") -> None:  # noqa: F821
     bucket = qfieldcloud.core.utils.get_s3_bucket()
     key = project.thumbnail_uri
     bucket.object_versions.filter(Prefix=key).delete()
+
+
+def purge_old_file_versions(project: "Project") -> None:  # noqa: F821
+    """
+    Deletes old versions of all files in the given project. Will keep __3__
+    versions for COMMUNITY user accounts, and __10__ versions for PRO user
+    accounts
+    """
+
+    logger.info(f"Cleaning up old files for {project}")
+
+    # Determine account type
+    account_type = project.owner.useraccount.account_type
+    if account_type == UserAccount.TYPE_COMMUNITY:
+        keep_count = 3
+    elif account_type == UserAccount.TYPE_PRO:
+        keep_count = 10
+    else:
+        raise NotImplementedError(f"Unknown account type {account_type}")
+
+    logger.debug(f"Keeping {keep_count} versions")
+
+    # Process file by file
+    for file in qfieldcloud.core.utils.get_project_files_with_versions(project.pk):
+
+        filename = file.latest.name
+        old_versions = file.versions
+
+        # Sort by date (newest first)
+        old_versions.sort(key=lambda i: i.last_modified, reverse=True)
+
+        # Skip the newest N
+        old_versions_to_purge = old_versions[keep_count:]
+
+        # Debug print
+        all_count = len(old_versions)
+        topurge_count = len(old_versions_to_purge)
+        logger.debug(
+            f'Purging {topurge_count} out of {all_count} old versions for "{filename}"...'
+        )
+
+        # Remove the N oldest
+        for old_version in old_versions_to_purge:
+            if old_version.is_latest:
+                # This is not supposed to happen, as versions were sorted above,
+                # but leaving it here as a security measure in case version
+                # ordering changes for some reason.
+                raise Exception("Trying to delete latest version")
+            # TODO: any way to batch those ? will probaby get slow on production
+            old_version._data.delete()
+            # TODO: audit ? take implementation from files_views.py:211

--- a/docker-app/qfieldcloud/core/utils2/storage.py
+++ b/docker-app/qfieldcloud/core/utils2/storage.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import logging
 from typing import IO
 
+import qfieldcloud.core.models
 import qfieldcloud.core.utils
-from qfieldcloud.core.models import UserAccount
 
 logger = logging.getLogger(__name__)
 
@@ -113,9 +113,9 @@ def purge_old_file_versions(project: "Project") -> None:  # noqa: F821
 
     # Determine account type
     account_type = project.owner.useraccount.account_type
-    if account_type == UserAccount.TYPE_COMMUNITY:
+    if account_type == qfieldcloud.core.models.UserAccount.TYPE_COMMUNITY:
         keep_count = 3
-    elif account_type == UserAccount.TYPE_PRO:
+    elif account_type == qfieldcloud.core.models.UserAccount.TYPE_PRO:
         keep_count = 10
     else:
         raise NotImplementedError(f"Unknown account type {account_type}")

--- a/docker-app/qfieldcloud/core/utils2/storage.py
+++ b/docker-app/qfieldcloud/core/utils2/storage.py
@@ -125,20 +125,14 @@ def purge_old_file_versions(project: "Project") -> None:  # noqa: F821
     # Process file by file
     for file in qfieldcloud.core.utils.get_project_files_with_versions(project.pk):
 
-        filename = file.latest.name
-        old_versions = file.versions
-
-        # Sort by date (newest first)
-        old_versions.sort(key=lambda i: i.last_modified, reverse=True)
-
         # Skip the newest N
-        old_versions_to_purge = old_versions[keep_count:]
+        old_versions_to_purge = sorted(
+            file.versions, key=lambda v: v.last_modified, reverse=True
+        )[keep_count:]
 
         # Debug print
-        all_count = len(old_versions)
-        topurge_count = len(old_versions_to_purge)
         logger.debug(
-            f'Purging {topurge_count} out of {all_count} old versions for "{filename}"...'
+            f'Purging {len(old_versions_to_purge)} out of {len(file.versions)} old versions for "{file.latest.name}"...'
         )
 
         # Remove the N oldest

--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -192,7 +192,7 @@ class DownloadPushDeleteFileView(views.APIView):
                 changes={filename: [None, new_object.latest.e_tag]},
             )
 
-        # Delete the old versions if the files
+        # Delete the old file versions
         purge_old_file_versions(project)
 
         return Response(status=status.HTTP_201_CREATED)

--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -6,6 +6,7 @@ from qfieldcloud.core import exceptions, permissions_utils, utils
 from qfieldcloud.core.models import ProcessProjectfileJob, Project
 from qfieldcloud.core.utils import get_project_file_with_versions
 from qfieldcloud.core.utils2.audit import LogEntry, audit
+from qfieldcloud.core.utils2.storage import purge_old_file_versions
 from rest_framework import permissions, status, views
 from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
@@ -190,6 +191,9 @@ class DownloadPushDeleteFileView(views.APIView):
                 LogEntry.Action.CREATE,
                 changes={filename: [None, new_object.latest.e_tag]},
             )
+
+        # Delete the old versions if the files
+        purge_old_file_versions(project)
 
         return Response(status=status.HTTP_201_CREATED)
 


### PR DESCRIPTION
This adds:
- a management command to purge old versions of files (`purge_old_file_versions`)
- a cronjob running this command once a day

It currently hardcodes the number of versions to keep (3 for COMMUNITY accounts, 10 for PRO accounts).

Some questions / things to consider:
- Using a number of versions to keep instead of a time span means that quickly pushing many changes is less safe than rarely pushing, which IMO is not nice for the user
- The command runs on all projects at once. Hard to predict how slow this will be in real life. We probably need to batch the queries somehow ? Do we have a way to test this without affecting actual data ?
- Unsure if a management command is the right place for this ? Other such tasks are directly implement in cron.py, maybe that's enough ?
- Do we want to audit these operations ?
- Do we want to add some kind of "model" layer to manage these files, to avoid duplicating code (e.g. how prefixes are built, or if/how these are audited)

@suricactus Let me know if it matches what is needed.

