### PR TITLE
Fix storage size calculation to include old versions

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -909,6 +909,7 @@ class Project(models.Model):
         return self.name + " (" + str(self.id) + ")" + " owner: " + self.owner.username
 
     def storage_size(self):
+        """Retrieves the storage size from S3"""
         return utils.get_s3_project_size(self.id)
 
     @property

--- a/docker-app/qfieldcloud/core/utils.py
+++ b/docker-app/qfieldcloud/core/utils.py
@@ -248,7 +248,7 @@ def get_deltafile_schema_validator() -> jsonschema.Draft7Validator:
 
 
 def get_s3_project_size(project_id: str) -> int:
-    """Return the size in MiB of the project on the storage, included the
+    """Return the size in MiB of the project on the storage, including the
     exported files and their versions"""
 
     bucket = get_s3_bucket()

--- a/docker-app/qfieldcloud/core/utils.py
+++ b/docker-app/qfieldcloud/core/utils.py
@@ -249,15 +249,15 @@ def get_deltafile_schema_validator() -> jsonschema.Draft7Validator:
 
 def get_s3_project_size(project_id: str) -> int:
     """Return the size in MiB of the project on the storage, included the
-    exported files"""
+    exported files and their versions"""
 
     bucket = get_s3_bucket()
 
-    prefix = "projects/{}/".format(project_id)
-    total_size = 0
+    prefix = f"projects/{project_id}/"
 
-    for obj in bucket.objects.filter(Prefix=prefix):
-        total_size += obj.size
+    total_size = 0
+    for version in bucket.object_versions.filter(Prefix=prefix):
+        total_size += version.size
 
     return round(total_size / (1024 * 1024), 3)
 


### PR DESCRIPTION
I don't think this exactly matches what's used on disk (probably only stores changed chunks ?), because it just sums the size of all versions. I didn't find actual data usage exposed. 

Seems AWS has an API to calculate actual size per prefix (see https://stackoverflow.com/a/35095500/13690651), but didn't find anything like that with boto3...

Still, I think it makes sense to simply sum the versions, as it's easier to understand for users anyway.

Some questions:
- Currently, `Project.storage_size()` will result on API calls each time it is invoked, meaning that it's not really usable for anything else than displaying one at a time in the admin (which is the only usage of it currently as far as I can see). I guess we need to persist that in the database. But then when exactly do we update it ? In a cronjob ? Or rightaway after uploads ? Depends a bit how exactly we want to deal with quotas.