### PR TITLE
Added delete_file_version function to deletes a specific file version

### DIFF
--- a/docker-app/qfieldcloud/core/utils.py
+++ b/docker-app/qfieldcloud/core/utils.py
@@ -63,6 +63,10 @@ class S3ObjectVersion:
     def is_latest(self) -> bool:
         return self._data.is_latest
 
+    @property
+    def display(self) -> str:
+        return self.last_modified.strftime("v%Y%m%d%H%M%S")
+
 
 class S3ObjectWithVersions(NamedTuple):
     latest: S3ObjectVersion

--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -4,7 +4,7 @@ from django.http.response import HttpResponse, HttpResponseRedirect
 from django.utils import timezone
 from qfieldcloud.core import exceptions, permissions_utils, utils
 from qfieldcloud.core.models import ProcessProjectfileJob, Project
-from qfieldcloud.core.utils import get_project_file_with_versions
+from qfieldcloud.core.utils import S3ObjectVersion, get_project_file_with_versions
 from qfieldcloud.core.utils2.audit import LogEntry, audit
 from qfieldcloud.core.utils2.storage import purge_old_file_versions
 from rest_framework import permissions, status, views
@@ -69,6 +69,7 @@ class ListFilesView(views.APIView):
                     "version_id": version.version_id,
                     "last_modified": last_modified,
                     "is_latest": version.is_latest,
+                    "display": S3ObjectVersion(version.key, version).display,
                 }
             )
 


### PR DESCRIPTION
I have used the name "delete" as it is more straigh forward for me what it means. I guess the function you have recently added should be renamed too.

Ideally `purge_old_file_versions` should start using `delete_file_version`.