### PR TITLE
When a file is uploaded to a project, start a new process_projectfile job

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -4,7 +4,7 @@ import string
 import uuid
 from datetime import timedelta
 from enum import Enum
-from typing import Any, Iterable, Type
+from typing import Any, Iterable, List, Type
 
 import qfieldcloud.core.utils2.storage
 from auditlog.registry import auditlog
@@ -913,7 +913,30 @@ class Project(models.Model):
         return utils.get_s3_project_size(self.id)
 
     @property
-    def private(self):
+    def staticfile_dirs(self) -> List[str]:
+        """Returns a list of configured staticfile dirs for the project.
+
+        Staticfile dir is a special directory in the QField infrastructure that holds static files
+        such as images, pdf etc. By default "DCIM" is considered a staticfile directory.
+
+        TODO this function expects whether `staticfile_dirs` key in project_details. However,
+        neither the extraction from the projectfile, nor the configuration in QFieldSync are implemented.
+
+        Returns:
+            List[str]: A list configured staticfile dirs for the project.
+        """
+        staticfile_dirs = []
+
+        if self.project_details and self.project_details.get("staticfile_dirs"):
+            staticfile_dirs = self.project_details.get("staticfile_dirs", [])
+
+        if not staticfile_dirs:
+            staticfile_dirs = ["DCIM"]
+
+        return staticfile_dirs
+
+    @property
+    def private(self) -> bool:
         # still used in the project serializer
         return not self.is_public
 

--- a/docker-app/qfieldcloud/core/utils2/storage.py
+++ b/docker-app/qfieldcloud/core/utils2/storage.py
@@ -9,6 +9,23 @@ import qfieldcloud.core.utils
 logger = logging.getLogger(__name__)
 
 
+def staticfile_prefix(project: "Project", filename: str) -> str:  # noqa: F821
+    """Returns the staticfile dir where the file belongs to or empty string if it does not.
+
+    Args:
+        project (Project): project to check
+        filename (str): filename to check
+
+    Returns:
+        str: the staticfile dir or empty string if no match found
+    """
+    for staticfile_dir in project.staticfile_dirs:
+        if filename.startswith(staticfile_dir):
+            return staticfile_dir
+
+    return ""
+
+
 def upload_user_avatar(user: "User", file: IO, mimetype: str) -> str:  # noqa: F821
     """Uploads a picture as a user avatar.
 

--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -6,7 +6,7 @@ from qfieldcloud.core import exceptions, permissions_utils, utils
 from qfieldcloud.core.models import ProcessProjectfileJob, Project
 from qfieldcloud.core.utils import S3ObjectVersion, get_project_file_with_versions
 from qfieldcloud.core.utils2.audit import LogEntry, audit
-from qfieldcloud.core.utils2.storage import purge_old_file_versions
+from qfieldcloud.core.utils2.storage import purge_old_file_versions, staticfile_prefix
 from rest_framework import permissions, status, views
 from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
@@ -171,8 +171,12 @@ class DownloadPushDeleteFileView(views.APIView):
 
         assert new_object
 
-        if is_qgis_project_file:
-            project.project_filename = filename
+        if staticfile_prefix(project, filename) == "" and (
+            is_qgis_project_file or project.project_filename is not None
+        ):
+            if is_qgis_project_file:
+                project.project_filename = filename
+
             ProcessProjectfileJob.objects.create(
                 project=project, created_by=self.request.user
             )


### PR DESCRIPTION
This way the order in which files are uploaded is not that important anymore.
To save extra unnecessary process jobs, DCIM dir is ignored, since it
consists of staticfiles only.