### PR TITLE
Improve how the API handles exceptions

### DIFF
--- a/docker-app/qfieldcloud/core/rest_utils.py
+++ b/docker-app/qfieldcloud/core/rest_utils.py
@@ -48,7 +48,7 @@ def exception_handler(exc, context):
             "detail": exc.detail,
         }
 
-    logging.exception(exc)
+    logging.info(exc)
 
     return Response(
         body,

--- a/docker-app/qfieldcloud/core/rest_utils.py
+++ b/docker-app/qfieldcloud/core/rest_utils.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 
+from django.conf import settings
 from django.core import exceptions
 from qfieldcloud.core import exceptions as qfieldcloud_exceptions
 from rest_framework import exceptions as rest_exceptions
@@ -36,14 +37,16 @@ def exception_handler(exc, context):
     body = {
         "code": exc.code,
         "message": exc.message,
-        "debug": {
+    }
+
+    if settings.DEBUG:
+        body["debug"] = {
             "view": str(context["view"]),
             "args": context["args"],
             "kwargs": context["kwargs"],
             "request": str(context["request"]),
             "detail": exc.detail,
-        },
-    }
+        }
 
     logging.exception(exc)
 

--- a/docker-app/qfieldcloud/core/rest_utils.py
+++ b/docker-app/qfieldcloud/core/rest_utils.py
@@ -31,7 +31,7 @@ def exception_handler(exc, context):
         # help with debugging
         if IN_TEST_SUITE:
             raise exc
-        logging.log(exc, level="exception")
+        logging.exception(exc)
         exc = qfieldcloud_exceptions.QFieldCloudException(detail=str(exc))
 
     body = {

--- a/docker-app/qfieldcloud/core/rest_utils.py
+++ b/docker-app/qfieldcloud/core/rest_utils.py
@@ -1,9 +1,9 @@
 import logging
-import sys
 
 from django.conf import settings
 from django.core import exceptions
 from qfieldcloud.core import exceptions as qfieldcloud_exceptions
+from qfieldcloud.testing import IN_TEST_SUITE
 from rest_framework import exceptions as rest_exceptions
 from rest_framework.response import Response
 
@@ -29,7 +29,7 @@ def exception_handler(exc, context):
     else:
         # When running tests, we rethrow the exception, so we get a full trace to
         # help with debugging
-        if sys.argv[1] == "test":
+        if IN_TEST_SUITE:
             raise exc
         logging.log(exc, level="exception")
         exc = qfieldcloud_exceptions.QFieldCloudException(detail=str(exc))

--- a/docker-app/qfieldcloud/core/rest_utils.py
+++ b/docker-app/qfieldcloud/core/rest_utils.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 from django.core import exceptions
 from qfieldcloud.core import exceptions as qfieldcloud_exceptions
@@ -9,6 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 def exception_handler(exc, context):
+
     if isinstance(exc, qfieldcloud_exceptions.QFieldCloudException):
         pass
     elif isinstance(exc, rest_exceptions.AuthenticationFailed):
@@ -24,6 +26,11 @@ def exception_handler(exc, context):
     elif isinstance(exc, exceptions.ValidationError):
         exc = qfieldcloud_exceptions.ValidationError(detail=str(exc))
     else:
+        # When running tests, we rethrow the exception, so we get a full trace to
+        # help with debugging
+        if sys.argv[1] == "test":
+            raise exc
+        logging.log(exc, level="exception")
         exc = qfieldcloud_exceptions.QFieldCloudException(detail=str(exc))
 
     body = {

--- a/docker-app/qfieldcloud/core/tests/test_user.py
+++ b/docker-app/qfieldcloud/core/tests/test_user.py
@@ -72,6 +72,7 @@ class QfcTestCase(APITestCase):
         self.client.credentials()
 
     def test_login(self):
+
         response = self.client.post(
             "/api/v1/auth/login/", {"username": "user1", "password": "abc123"}
         )

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -281,6 +281,8 @@ INVITATIONS_INVITATION_ONLY = True
 INVITATIONS_ACCEPT_INVITE_AFTER_SIGNUP = True
 INVITATIONS_GONE_ON_ACCEPT_ERROR = False
 
+TEST_RUNNER = "qfieldcloud.testing.QfcTestSuiteRunner"
+
 LOGLEVEL = os.environ.get("LOGLEVEL", "DEBUG").upper()
 LOGGING = {
     "version": 1,

--- a/docker-app/qfieldcloud/testing.py
+++ b/docker-app/qfieldcloud/testing.py
@@ -1,0 +1,11 @@
+from django.test.runner import DiscoverRunner
+
+# Whether we are currently running tests
+IN_TEST_SUITE = False
+
+
+class QfcTestSuiteRunner(DiscoverRunner):
+    def __init__(self, *args, **kwargs):
+        global IN_TEST_SUITE
+        IN_TEST_SUITE = True
+        super().__init__(*args, **kwargs)


### PR DESCRIPTION
Improve DRF exception handler:

- rethrow unexpected exceptions in tests (so we get the actual trace to the console instead of uninformative error 500)
- don't expose debug details when DEBUG=false
- only log unexpected errors with logger.exception (the other are logged with logger.info, as they are not errors - also we now log the original exception instead of the constructed QFieldCloudException)

(extracted from #254)