### PR TITLE
Debug improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ debugpy.wait_for_client()  # optional
 
 Or alternativley, prefix your commands with `python -m debugpy --listen 0.0.0.0:5678`.
 ```shell
-docker-compose run app python -m debugpy --listen 0.0.0.0:5678 manage.py test
+docker-compose run app -p 5678:5678 python -m debugpy --listen 0.0.0.0:5678 manage.py test
 ```
 
 Then, configure your IDE to connect (example given for VSCode's `.vscode/launch.json`, triggered with `F5`):

--- a/README.md
+++ b/README.md
@@ -103,10 +103,22 @@ Then, configure your IDE to connect (example given for VSCode's `.vscode/launch.
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "QFieldCloud - Remote attach",
+            "name": "QFC debug app",
             "type": "python",
             "request": "attach",
+            "justMyCode": false,
             "connect": {"host": "localhost", "port": 5678},
+            "pathMappings": [{
+                "localRoot": "${workspaceFolder}/docker-app/qfieldcloud",
+                "remoteRoot": "/usr/src/app/qfieldcloud"
+            }]
+        },
+        {
+            "name": "QFC debug worker_wrapper",
+            "type": "python",
+            "request": "attach",
+            "justMyCode": false,
+            "connect": {"host": "localhost", "port": 5679},
             "pathMappings": [{
                 "localRoot": "${workspaceFolder}/docker-app/qfieldcloud",
                 "remoteRoot": "/usr/src/app/qfieldcloud"

--- a/README.md
+++ b/README.md
@@ -92,9 +92,10 @@ print("debugpy waiting for debugger... 🐛")
 debugpy.wait_for_client()  # optional
 ```
 
-Or alternativley, prefix your commands with `python -m debugpy --listen 0.0.0.0:5678`.
+Or alternativley, prefix your commands with `python -m debugpy --listen 0.0.0.0:5678 --wait-for-client`.
 ```shell
-docker-compose run app -p 5678:5678 python -m debugpy --listen 0.0.0.0:5678 manage.py test
+docker-compose run app -p 5678:5678 python -m debugpy --listen 0.0.0.0:5678 --wait-for-client manage.py test
+docker-compose run worker_wrapper -p 5679:5679 python -m debugpy --listen 0.0.0.0:5679 --wait-for-client manage.py test
 ```
 
 Then, configure your IDE to connect (example given for VSCode's `.vscode/launch.json`, triggered with `F5`):

--- a/docker-compose.override.dev.yml
+++ b/docker-compose.override.dev.yml
@@ -5,9 +5,6 @@ services:
   app:
     depends_on:
       - geodb
-    ports:
-      # debugpy
-      - "5678:5678"
     build:
       args:
         DEBUG_BUILD: ${DEBUG}

--- a/docker-compose.override.local.yml
+++ b/docker-compose.override.local.yml
@@ -3,6 +3,9 @@ version: '3.7'
 services:
 
   app:
+    build:
+      args:
+        - DEBUG_BUILD=1
     ports:
       # allow direct access without nginx
       - "5001:8000"
@@ -24,6 +27,9 @@ services:
       - smtp4dev
 
   worker_wrapper:
+    build:
+      args:
+        - DEBUG_BUILD=1
     ports:
       # debugpy
       - "5679:5679"

--- a/docker-compose.override.local.yml
+++ b/docker-compose.override.local.yml
@@ -9,8 +9,6 @@ services:
     ports:
       # allow direct access without nginx
       - "5001:8000"
-      # debugpy
-      - "5678:5678"
     volumes:
       # mount the source for live reload
       - ./docker-app/qfieldcloud:/usr/src/app/qfieldcloud
@@ -30,9 +28,6 @@ services:
     build:
       args:
         - DEBUG_BUILD=1
-    ports:
-      # debugpy
-      - "5679:5679"
     volumes:
       # mount the source for live reload
       - ./docker-app/qfieldcloud:/usr/src/app/qfieldcloud

--- a/docker-compose.override.local.yml
+++ b/docker-compose.override.local.yml
@@ -6,6 +6,8 @@ services:
     ports:
       # allow direct access without nginx
       - "5001:8000"
+      # debugpy
+      - "5678:5678"
     volumes:
       # mount the source for live reload
       - ./docker-app/qfieldcloud:/usr/src/app/qfieldcloud

--- a/docker-compose.override.local.yml
+++ b/docker-compose.override.local.yml
@@ -24,6 +24,9 @@ services:
       - smtp4dev
 
   worker_wrapper:
+    ports:
+      # debugpy
+      - "5679:5679"
     volumes:
       # mount the source for live reload
       - ./docker-app/qfieldcloud:/usr/src/app/qfieldcloud


### PR DESCRIPTION
Note the recommended local development docker-compose is the one with `local` suffix.

Add debugger to the worker wrapper too. It uses different port because:
- conflict with port exposure
- theoretically support parallel debuging, even though it would be clumsy with to VS code editors.