### PR TITLE
Download file improvements, hiding the s3 urls; No more redirecting fallback

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -23,7 +23,6 @@ from django.urls import reverse_lazy
 from django.utils.translation import gettext as _
 from model_utils.managers import InheritanceManager
 from qfieldcloud.core import geodb_utils, utils, validators
-from qfieldcloud.core.utils import get_s3_object_url
 from timezone_field import TimeZoneField
 
 # http://springmeblog.com/2018/how-to-implement-multiple-user-types-with-django/
@@ -420,7 +419,10 @@ class UserAccount(models.Model):
     @property
     def avatar_url(self):
         if self.avatar_uri:
-            return get_s3_object_url(self.avatar_uri)
+            return reverse_lazy(
+                "public_files",
+                kwargs={"filename": self.avatar_uri},
+            )
         else:
             return None
 
@@ -895,7 +897,10 @@ class Project(models.Model):
     @property
     def thumbnail_url(self):
         if self.thumbnail_uri:
-            return get_s3_object_url(self.thumbnail_uri)
+            return reverse_lazy(
+                "project_metafiles",
+                kwargs={"projectid": self.id, "filename": self.thumbnail_uri[51:]},
+            )
         else:
             return None
 

--- a/docker-app/qfieldcloud/core/rest_utils.py
+++ b/docker-app/qfieldcloud/core/rest_utils.py
@@ -3,7 +3,6 @@ import logging
 from django.conf import settings
 from django.core import exceptions
 from qfieldcloud.core import exceptions as qfieldcloud_exceptions
-from qfieldcloud.testing import IN_TEST_SUITE
 from rest_framework import exceptions as rest_exceptions
 from rest_framework.response import Response
 
@@ -29,7 +28,7 @@ def exception_handler(exc, context):
     else:
         # When running tests, we rethrow the exception, so we get a full trace to
         # help with debugging
-        if IN_TEST_SUITE:
+        if settings.IN_TEST_SUITE:
             raise exc
         logging.exception(exc)
         exc = qfieldcloud_exceptions.QFieldCloudException(detail=str(exc))

--- a/docker-app/qfieldcloud/core/tests/test_delta.py
+++ b/docker-app/qfieldcloud/core/tests/test_delta.py
@@ -4,9 +4,8 @@ import logging
 import time
 
 import fiona
-import requests
 import rest_framework
-from django.http.response import HttpResponse, HttpResponseRedirect
+from django.http.response import FileResponse, HttpResponse
 from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core import utils
 from qfieldcloud.core.models import Job, Project, ProjectCollaborator, User
@@ -590,13 +589,13 @@ class QfcTestCase(APITransactionTestCase):
     def get_file_contents(self, project, filename):
         response = self.client.get(f"/api/v1/files/{project.id}/{filename}/")
 
-        if isinstance(response, HttpResponseRedirect):
-            response = requests.get(response.url)
-
         self.assertTrue(status.is_success(response.status_code))
         self.assertEqual(get_filename(response), filename)
 
-        return response.content
+        if isinstance(response, FileResponse):
+            return b"".join(response.streaming_content)
+        else:
+            return response.content
 
     def upload_deltas(self, project, delta_filename):
         delta_file = testdata_path(f"delta/deltas/{delta_filename}")

--- a/docker-app/qfieldcloud/core/urls.py
+++ b/docker-app/qfieldcloud/core/urls.py
@@ -63,6 +63,16 @@ urlpatterns = [
         name="project_file_download",
     ),
     path(
+        "files/meta/<uuid:projectid>/<path:filename>",
+        files_views.ProjectMetafilesView.as_view(),
+        name="project_metafiles",
+    ),
+    path(
+        "files/public/<path:filename>",
+        files_views.PublicFilesView.as_view(),
+        name="public_files",
+    ),
+    path(
         "packages/<uuid:project_id>/latest/",
         package_views.LatestPackageView.as_view(),
     ),

--- a/docker-app/qfieldcloud/core/utils2/__init__.py
+++ b/docker-app/qfieldcloud/core/utils2/__init__.py
@@ -1,0 +1,6 @@
+import qfieldcloud.core.utils2.audit as audit
+import qfieldcloud.core.utils2.db as db
+import qfieldcloud.core.utils2.jobs as jobs
+import qfieldcloud.core.utils2.storage as storage
+
+__all__ = ["audit", "db", "jobs", "storage"]

--- a/docker-app/qfieldcloud/core/utils2/jobs.py
+++ b/docker-app/qfieldcloud/core/utils2/jobs.py
@@ -1,36 +1,40 @@
 import logging
-from typing import Optional
+from typing import List, Optional
 
+import qfieldcloud.core.models as models
 from django.db.models import Q
 from qfieldcloud.core import exceptions
-from qfieldcloud.core.models import ApplyJob, Delta, Job, PackageJob, Project, User
 
 logger = logging.getLogger(__name__)
 
 
 def apply_deltas(
-    project, user, project_file, overwrite_conflicts, delta_ids=None
-) -> Optional[ApplyJob]:
+    project: "models.Project",
+    user: "models.User",
+    project_file: str,
+    overwrite_conflicts: bool,
+    delta_ids: List[str] = None,
+) -> Optional["models.ApplyJob"]:
     """Apply a deltas"""
 
     logger.info(
         f"Requested apply_deltas on {project} with {project_file}; overwrite_conflicts: {overwrite_conflicts}; delta_ids: {delta_ids}"
     )
 
-    apply_jobs = ApplyJob.objects.filter(
+    apply_jobs = models.ApplyJob.objects.filter(
         project=project,
         status=[
-            Job.Status.PENDING,
-            Job.Status.QUEUED,
+            models.Job.Status.PENDING,
+            models.Job.Status.QUEUED,
         ],
     )
 
     if len(apply_jobs) > 0:
         return apply_jobs[0]
 
-    pending_deltas = Delta.objects.filter(
+    pending_deltas = models.Delta.objects.filter(
         project=project,
-        last_status=Delta.Status.PENDING,
+        last_status=models.Delta.Status.PENDING,
     )
 
     if delta_ids is not None:
@@ -39,7 +43,7 @@ def apply_deltas(
     if len(pending_deltas) == 0:
         return None
 
-    apply_job = ApplyJob.objects.create(
+    apply_job = models.ApplyJob.objects.create(
         project=project,
         created_by=user,
         overwrite_conflicts=overwrite_conflicts,
@@ -48,7 +52,7 @@ def apply_deltas(
     return apply_job
 
 
-def repackage(project: Project, user: User) -> PackageJob:
+def repackage(project: "models.Project", user: "models.User") -> "models.PackageJob":
     """Returns an unfinished or freshly created package job.
 
     Checks if there is already an unfinished package job and returns it,
@@ -59,20 +63,22 @@ def repackage(project: Project, user: User) -> PackageJob:
 
     # Check if active package job already exists
     query = Q(project=project) & (
-        Q(status=PackageJob.Status.PENDING)
-        | Q(status=PackageJob.Status.QUEUED)
-        | Q(status=PackageJob.Status.STARTED)
+        Q(status=models.PackageJob.Status.PENDING)
+        | Q(status=models.PackageJob.Status.QUEUED)
+        | Q(status=models.PackageJob.Status.STARTED)
     )
 
-    if PackageJob.objects.filter(query).count():
-        return PackageJob.objects.get(query)
+    if models.PackageJob.objects.filter(query).count():
+        return models.PackageJob.objects.get(query)
 
-    package_job = PackageJob.objects.create(project=project, created_by=user)
+    package_job = models.PackageJob.objects.create(project=project, created_by=user)
 
     return package_job
 
 
-def repackage_if_needed(project: Project, user: User) -> PackageJob:
+def repackage_if_needed(
+    project: "models.Project", user: "models.User"
+) -> "models.PackageJob":
     if not project.project_filename:
         raise exceptions.NoQGISProjectError()
 
@@ -80,7 +86,9 @@ def repackage_if_needed(project: Project, user: User) -> PackageJob:
         package_job = repackage(project, user)
     else:
         package_job = (
-            PackageJob.objects.filter(project=project).order_by("started_at").get()
+            models.PackageJob.objects.filter(project=project)
+            .order_by("started_at")
+            .get()
         )
 
     return package_job

--- a/docker-app/qfieldcloud/core/utils2/storage.py
+++ b/docker-app/qfieldcloud/core/utils2/storage.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import logging
+from pathlib import PurePath
 from typing import IO, List
 
 import qfieldcloud.core.models
 import qfieldcloud.core.utils
+from django.conf import settings
+from django.core.files.base import ContentFile
+from django.http import FileResponse, HttpRequest
+from django.http.response import HttpResponse, HttpResponseBase
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +29,69 @@ def staticfile_prefix(project: "Project", filename: str) -> str:  # noqa: F821
             return staticfile_dir
 
     return ""
+
+
+def file_response(
+    request: HttpRequest,
+    key: str,
+    presigned: bool = False,
+    expires: int = 60,
+    version: str = None,
+    as_attachment: bool = False,
+) -> HttpResponseBase:
+    url = ""
+    filename = PurePath(key).name
+    extra_params = {}
+
+    if version is not None:
+        extra_params["VersionId"] = version
+
+    # check if we are in NGINX proxy
+    if request.META.get("HTTP_HOST", "").split(":")[-1] == request.META.get(
+        "WEB_HTTPS_PORT"
+    ):
+        if presigned:
+            if as_attachment:
+                extra_params["ResponseContentType"] = "application/force-download"
+                extra_params[
+                    "ResponseContentDisposition"
+                ] = f'attachment;filename="{filename}"'
+
+            url = qfieldcloud.core.utils.get_s3_client().generate_presigned_url(
+                "get_object",
+                Params={
+                    **extra_params,
+                    "Key": key,
+                    "Bucket": qfieldcloud.core.utils.get_s3_bucket().name,
+                },
+                ExpiresIn=expires,
+                HttpMethod="GET",
+            )
+        else:
+            url = qfieldcloud.core.utils.get_s3_object_url(key)
+
+        # Let's NGINX handle the redirect to the storage and streaming the file contents back to the client
+        response = HttpResponse()
+        response["X-Accel-Redirect"] = "/storage-download/"
+        response["redirect_uri"] = url
+
+        return response
+    elif settings.DEBUG:
+        return_file = ContentFile(b"")
+        qfieldcloud.core.utils.get_s3_bucket().download_fileobj(
+            key,
+            return_file,
+            extra_params,
+        )
+
+        return FileResponse(
+            return_file.open(),
+            as_attachment=as_attachment,
+            filename=filename,
+            content_type="text/html",
+        )
+
+    raise Exception("Expected to either run behind nginx proxy or in debug mode.")
 
 
 def upload_user_avatar(user: "User", file: IO, mimetype: str) -> str:  # noqa: F821

--- a/docker-app/qfieldcloud/core/utils2/storage.py
+++ b/docker-app/qfieldcloud/core/utils2/storage.py
@@ -76,7 +76,7 @@ def file_response(
         response["redirect_uri"] = url
 
         return response
-    elif settings.DEBUG:
+    elif settings.DEBUG or settings.IN_TEST_SUITE:
         return_file = ContentFile(b"")
         qfieldcloud.core.utils.get_s3_bucket().download_fileobj(
             key,
@@ -91,7 +91,9 @@ def file_response(
             content_type="text/html",
         )
 
-    raise Exception("Expected to either run behind nginx proxy or in debug mode.")
+    raise Exception(
+        "Expected to either run behind nginx proxy, debug mode or within a test suite."
+    )
 
 
 def upload_user_avatar(user: "User", file: IO, mimetype: str) -> str:  # noqa: F821

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -305,6 +305,9 @@ LOGGING = {
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
+# Whether we are currently running tests
+# NOTE automatically set when running tests, don't change manually!
+IN_TEST_SUITE = False
 
 QFIELDCLOUD_TOKEN_SERIALIZER = "qfieldcloud.core.serializers.TokenSerializer"
 QFIELDCLOUD_USER_SERIALIZER = "qfieldcloud.core.serializers.CompleteUserSerializer"

--- a/docker-app/qfieldcloud/testing.py
+++ b/docker-app/qfieldcloud/testing.py
@@ -1,11 +1,8 @@
+from django.conf import settings
 from django.test.runner import DiscoverRunner
-
-# Whether we are currently running tests
-IN_TEST_SUITE = False
 
 
 class QfcTestSuiteRunner(DiscoverRunner):
     def __init__(self, *args, **kwargs):
-        global IN_TEST_SUITE
-        IN_TEST_SUITE = True
+        settings.IN_TEST_SUITE = True
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
All files from s3 are now served either using the nginx X-Acccel redirect,
or directly served by django in DEBUG mode.

This way we got rid of the so problematic redirect that was breaking pretty
much every client.

Also, the `files/meta/<projectid>` endpoint looks a bit redundant, but
it all started with the `files/<projectid>` API being so unflexible. Too
late to change now.