### PR TITLE
If object storage (s3) returns non-ok status, show 404

### DIFF
--- a/conf/nginx/pages/404.html
+++ b/conf/nginx/pages/404.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>404 Not Found</title>
+</head>
+<body bgcolor="white">
+    <center><h1>404 Not Found</h1></center>
+</body>
+</html>

--- a/conf/nginx/templates/default.conf.template
+++ b/conf/nginx/templates/default.conf.template
@@ -35,6 +35,8 @@ server {
   # path for static files (only needed for serving local staticfiles)
   root /var/www/html/;
 
+  error_page 497 https://$host:${WEB_HTTPS_PORT}$request_uri;
+
   # checks for static file, if not found proxy to app
   location / {
     try_files $uri @proxy_to_app;

--- a/conf/nginx/templates/default.conf.template
+++ b/conf/nginx/templates/default.conf.template
@@ -102,7 +102,11 @@ server {
     proxy_hide_header X-Amz-Storage-Class;
     proxy_hide_header X-Amz-Version-Id;
 
+    proxy_intercept_errors on;
+
     proxy_pass $redirect_uri;
+
+    error_page 401 402 403 404 405 406 407 408 409 410 411 412 413 414 415 416 417 500 501 502 503 504 505 =404 /pages/404.html;
   }
 
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,7 @@ services:
     volumes:
       - static_volume:/var/www/html/staticfiles/
       - media_volume:/var/www/html/mediafiles/
+      - ./conf/nginx/pages/:/var/www/html/pages/
       - ./conf/nginx/templates/:/etc/nginx/templates/
       - ./conf/nginx/certs/:/etc/nginx/certs/:ro
       - ./conf/nginx/options-ssl-nginx.conf:/etc/nginx/options-ssl-nginx.conf


### PR DESCRIPTION
I just don't feel ok we show the XML from the storage API.