### PR TITLE
remove useless tearDown methods followup

### DIFF
--- a/docker-app/qfieldcloud/core/tests/test_packages.py
+++ b/docker-app/qfieldcloud/core/tests/test_packages.py
@@ -52,6 +52,9 @@ class QfcTestCase(APITransactionTestCase):
             port=5432,
         )
 
+    def tearDown(self):
+        self.conn.close()
+
     def upload_files(
         self,
         token: str,

--- a/docker-app/qfieldcloud/core/tests/test_qfield_file.py
+++ b/docker-app/qfieldcloud/core/tests/test_qfield_file.py
@@ -52,6 +52,9 @@ class QfcTestCase(APITransactionTestCase):
             port=5432,
         )
 
+    def tearDown(self):
+        self.conn.close()
+
     def fail(self, msg: str, job: Job = None):
         if job:
             msg += f"\n\nOutput:\n================\n{job.output}\n================"


### PR DESCRIPTION
restored some parts of tearDown logic whose removal is probably linked to test failures such as https://github.com/opengisch/qfieldcloud/runs/5225583774?check_suite_focus=true