### PR TITLE
Print QGIS version withing the worker and set XDG_RUNTIME_DIR 

### DIFF
--- a/docker-qgis/Dockerfile
+++ b/docker-qgis/Dockerfile
@@ -28,4 +28,6 @@ ENV LIBC_FATAL_STDERR_=1
 ENV LANG=C.UTF-8
 ENV PYTHONPATH="/usr/src/app/lib:${PYTHONPATH}"
 
+ENV XDG_RUNTIME_DIR="/run/user/0"
+
 ENTRYPOINT ["/bin/sh", "-c", "/usr/bin/xvfb-run -a \"$@\"", ""]

--- a/docker-qgis/entrypoint.py
+++ b/docker-qgis/entrypoint.py
@@ -114,8 +114,9 @@ def _download_project_directory(project_id: str, download_dir: Path = None) -> P
         absolute_filename = download_dir.joinpath(relative_filename)
         absolute_filename.parent.mkdir(parents=True, exist_ok=True)
 
+        # NOTE the E_TAG already is surrounded by double quotes
         logging.info(
-            f'Downloading file "{obj.key}", size: {obj.size} bytes, md5sum: "{obj.e_tag}" '
+            f'Downloading file "{obj.key}", size: {obj.size} bytes, md5sum: {obj.e_tag} '
         )
 
         bucket.download_file(obj.key, str(absolute_filename))

--- a/docker-qgis/utils.py
+++ b/docker-qgis/utils.py
@@ -123,9 +123,7 @@ def start_app():
         QGISAPP = QgsApplication(argvb, gui_flag)
 
         QtCore.qInstallMessageHandler(_qt_message_handler)
-        os.environ["QGIS_CUSTOM_CONFIG_PATH"] = tempfile.mkdtemp(
-            "", "QGIS-PythonTestConfigPath"
-        )
+        os.environ["QGIS_CUSTOM_CONFIG_PATH"] = tempfile.mkdtemp("", "QGIS_CONFIG")
         QGISAPP.initQgis()
 
         QtCore.qInstallMessageHandler(_qt_message_handler)

--- a/docker-qgis/utils.py
+++ b/docker-qgis/utils.py
@@ -112,7 +112,9 @@ def start_app():
     global QGISAPP
 
     if QGISAPP is None:
-        qgs_stderr_logger.info("Starting QGIS app...")
+        qgs_stderr_logger.info(
+            f"Starting QGIS app version {Qgis.versionInt()} ({Qgis.devVersion()})..."
+        )
         argvb = []
 
         # Note: QGIS_PREFIX_PATH is evaluated in QgsApplication -
@@ -148,6 +150,7 @@ def stop_app():
         return
 
     if QGISAPP is not None:
+        qgs_stderr_logger.info("Stopping QGIS app...")
         QGISAPP.exitQgis()
         del QGISAPP
 


### PR DESCRIPTION
While neither `/run/user/0` nor `/var/run/user/0` really exist, this prevents certain types of failure, such as:

- core dumped, as it happens when it is set to a custom dir within the
tmpdir with 700 perms
- error from the dev server:
`WARNING:QGIS_STDERR:QStandardPaths: wrong ownership on runtime directory /tmp/runtime-root, -2 instead of 0`
which causes the internet providers to fail miserably