### PR TITLE
Add a utility CLI that creates missing useraccounts if a user/org is missing one

### DIFF
--- a/docker-app/qfieldcloud/core/management/commands/createuseraccounts.py
+++ b/docker-app/qfieldcloud/core/management/commands/createuseraccounts.py
@@ -1,0 +1,18 @@
+from django.core.management.base import BaseCommand
+from qfieldcloud.core.models import User, UserAccount
+
+
+class Command(BaseCommand):
+    """
+    Creates user accounts for all users that are missing a user account.
+    """
+
+    def handle(self, *args, **options):
+        for user in User.objects.filter(
+            useraccount=None, type__in=[User.TYPE_USER, User.TYPE_ORGANIZATION]
+        ):
+            print(
+                f'Creating user account for user "{user.username}" email "{user.email}"...'
+            )
+
+            UserAccount.objects.create(user)


### PR DESCRIPTION
Why they are missing I am not sure, but it happened twice.