### PR TITLE
Fix the Delta.Method enums to inherit str, so the string comparison works

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1067,7 +1067,7 @@ class ProjectCollaborator(models.Model):
 
 
 class Delta(models.Model):
-    class Method(Enum):
+    class Method(str, Enum):
         Create = "create"
         Delete = "delete"
         Patch = "patch"


### PR DESCRIPTION
This fix directly affects the permissions check for role reporter, which were failing before, as `delta.method == Delta.Method.Create` was returning false.