### PR TITLE
Update Port where django is running

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To build development images and run the containers:
     docker-compose up -d --build
 
 It will read the `docker-compose*.yml` files specified in the `COMPOSE_FILE`
-variable and start a django built-in server at `http://localhost:8000`.
+variable and start a django built-in server at `http://localhost:8111`.
 
 Run the django database migrations.
 


### PR DESCRIPTION
Related to 866c5032d1f2bfebec369db939c1f371d58f2217 the django port changed to 8111 from 8000. This needs to be changed in the README.md