### PR TITLE
Prepare the list of deltas to be applied on the time of creating the job

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1114,6 +1114,11 @@ class Delta(models.Model):
     old_geom = models.GeometryField(null=True, srid=4326, dim=4)
     new_geom = models.GeometryField(null=True, srid=4326, dim=4)
 
+    jobs_to_apply = models.ManyToManyField(
+        to="ApplyJob",
+        through="ApplyJobDelta",
+    )
+
     def __str__(self):
         return str(self.id) + ", project: " + str(self.project.id)
 

--- a/docker-app/qfieldcloud/core/tests/test_delta.py
+++ b/docker-app/qfieldcloud/core/tests/test_delta.py
@@ -40,6 +40,14 @@ class QfcTestCase(APITransactionTestCase):
         )
         self.project1.save()
 
+        self.project2 = Project.objects.create(
+            id="2f221069-59f6-40d2-b7d6-0f454380c2ed",
+            name="project2",
+            is_public=False,
+            owner=self.user2,
+        )
+        self.project1.save()
+
         ProjectCollaborator.objects.create(
             project=self.project1,
             collaborator=self.user2,
@@ -458,6 +466,53 @@ class QfcTestCase(APITransactionTestCase):
                 ]
             ],
             token=self.token1.key,
+        )
+
+    def test_delta_pushed_after_job_triggered_two_projects(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
+        project1 = self.upload_project_files(self.project1)
+
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token2.key)
+        project2 = self.upload_project_files(self.project2)
+
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
+
+        # Push a deltafile
+        deltafile1_name = "singlelayer_singledelta.json"
+        self.assertTrue(self.upload_deltas(project1, deltafile1_name))
+        with open(testdata_path(f"delta/deltas/{deltafile1_name}")) as f:
+            deltafile1_id = json.load(f)["id"]
+
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token2.key)
+        deltafile2_name = "singlelayer_singledelta_project2.json"
+        self.assertTrue(self.upload_deltas(project2, deltafile2_name))
+        with open(testdata_path(f"delta/deltas/{deltafile2_name}")) as f:
+            deltafile2_id = json.load(f)["id"]
+
+        self.check_deltas_by_file_id(
+            project1,
+            deltafile1_id,
+            final_values=[
+                [
+                    "9311eb96-bff8-4d5b-ab36-c314a007cfcd",
+                    "STATUS_APPLIED",
+                    self.user1.username,
+                ]
+            ],
+            token=self.token1.key,
+        )
+
+        self.check_deltas_by_file_id(
+            project2,
+            deltafile2_id,
+            final_values=[
+                [
+                    "f2af4942-e4ab-446e-bd97-5aab17e7ccc1",
+                    "STATUS_APPLIED",
+                    self.user2.username,
+                ]
+            ],
+            token=self.token2.key,
         )
 
     def test_change_and_delete_pushed_only_features(self):

--- a/docker-app/qfieldcloud/core/tests/test_delta.py
+++ b/docker-app/qfieldcloud/core/tests/test_delta.py
@@ -699,8 +699,6 @@ class QfcTestCase(APITransactionTestCase):
     ):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
 
-        uri = f"/api/v1/deltas/{project.id}/"
-
         if delta_filename is not None:
             # Push a deltafile
             self.assertTrue(self.upload_deltas(project, delta_filename))
@@ -710,9 +708,6 @@ class QfcTestCase(APITransactionTestCase):
             if not deltafile_id:
                 with open(delta_file) as f:
                     deltafile_id = json.load(f)["id"]
-
-        if deltafile_id:
-            uri = f"{uri}{deltafile_id}/"
 
         self.check_deltas_by_file_id(
             project,
@@ -736,7 +731,9 @@ class QfcTestCase(APITransactionTestCase):
     ):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
 
-        uri = f"/api/v1/deltas/{project.id}/{deltafile_id}/"
+        uri = f"/api/v1/deltas/{project.id}/"
+        if deltafile_id:
+            uri = f"{uri}{deltafile_id}/"
 
         response = self.client.get(uri)
         self.assertTrue(rest_framework.status.is_success(response.status_code))

--- a/docker-app/qfieldcloud/core/tests/testdata/delta/deltas/singlelayer_singledelta_project2.json
+++ b/docker-app/qfieldcloud/core/tests/testdata/delta/deltas/singlelayer_singledelta_project2.json
@@ -1,0 +1,28 @@
+{
+    "deltas": [
+        {
+            "uuid": "f2af4942-e4ab-446e-bd97-5aab17e7ccc1",
+            "clientId": "e6bafe63-7d79-4970-b49b-5d4f13e6344b",
+            "exportId": "d2706728-bf75-4220-b76e-e1f36aea31f5",
+            "localPk": "1",
+            "sourcePk": "1",
+            "localLayerId": "points_897d5ed7_b810_4624_abe3_9f7c0a93d6a1",
+            "sourceLayerId": "points_897d5ed7_b810_4624_abe3_9f7c0a93d6a1",
+            "method": "patch",
+            "new": {
+                "attributes": {
+                    "int": 666
+                }
+            },
+            "old": {
+                "attributes": {
+                    "int": 1
+                }
+            }
+        }
+    ],
+    "files": [],
+    "id": "dcfd00b1-e156-4a25-aa1c-a72584636e28",
+    "project": "2f221069-59f6-40d2-b7d6-0f454380c2ed",
+    "version": "1.0"
+}

--- a/docker-app/qfieldcloud/core/utils2/jobs.py
+++ b/docker-app/qfieldcloud/core/utils2/jobs.py
@@ -2,18 +2,20 @@ import logging
 from typing import List, Optional
 
 import qfieldcloud.core.models as models
+from django.db import transaction
 from django.db.models import Q
 from qfieldcloud.core import exceptions
 
 logger = logging.getLogger(__name__)
 
 
+@transaction.atomic
 def apply_deltas(
     project: "models.Project",
     user: "models.User",
     project_file: str,
     overwrite_conflicts: bool,
-    delta_ids: List[str] = None,
+    delta_ids: List[str] = [],
 ) -> Optional["models.ApplyJob"]:
     """Apply a deltas"""
 
@@ -21,6 +23,25 @@ def apply_deltas(
         f"Requested apply_deltas on {project} with {project_file}; overwrite_conflicts: {overwrite_conflicts}; delta_ids: {delta_ids}"
     )
 
+    # 1. Check if there are any pending deltas.
+    # We need to call .select_for_update() to make sure there would not be a concurrent
+    # request that will try to apply these deltas.
+    pending_deltas = models.Delta.objects.select_for_update().filter(
+        project=project,
+        last_status=models.Delta.Status.PENDING,
+    )
+
+    # 1.1. Filter only the deltas of interest.
+    if len(delta_ids) > 0:
+        pending_deltas.filter(pk__in=delta_ids)
+
+    # 2. If there are no pending deltas, do not create a new job and return.
+    if pending_deltas.count() == 0:
+        return None
+
+    # 3. Find all the pending or queued jobs in the queue.
+    # If an "apply_delta" job is in a "started" status, we don't know how far the execution reached
+    # so we better assume the deltas will reach a non-"pending" status.
     apply_jobs = models.ApplyJob.objects.filter(
         project=project,
         status=[
@@ -29,26 +50,32 @@ def apply_deltas(
         ],
     )
 
-    if len(apply_jobs) > 0:
-        return apply_jobs[0]
+    # 4. Check whether there are jobs found in the queue and exclude all deltas that are part of any pending job.
+    if apply_jobs.count() > 0:
+        pending_deltas = pending_deltas.exclude(jobs_to_apply__in=apply_jobs)
 
-    pending_deltas = models.Delta.objects.filter(
-        project=project,
-        last_status=models.Delta.Status.PENDING,
-    )
-
-    if delta_ids is not None:
-        pending_deltas = pending_deltas.filter(pk__in=delta_ids)
-
-    if len(pending_deltas) == 0:
+    # 5. If there are no pending deltas, do not create a new job and return.
+    if pending_deltas.count() == 0:
         return None
 
+    # 6. There are pending deltas that are not part of any pending job. So we create one.
     apply_job = models.ApplyJob.objects.create(
         project=project,
         created_by=user,
         overwrite_conflicts=overwrite_conflicts,
     )
 
+    models.ApplyJobDelta.objects.bulk_create(
+        [
+            models.ApplyJobDelta(
+                apply_job=apply_job,
+                delta=delta,
+            )
+            for delta in pending_deltas
+        ]
+    )
+
+    # 7. return the created job
     return apply_job
 
 


### PR DESCRIPTION
This PR aims to simplify the execution of delta apply jobs within the worker, by always using a predefined list of deltas. This list is created on the time of creation of new delta apply job.

The code should follow the coditions explained here https://docs.qfield.org/reference/qfieldcloud/jobs/#delta-apply-delta_apply-job 

The highlight of this PR is that the M:N `ApplyJobDelta` is populated only within the Django app and the worker-wrapper is just reading from that list.