### PR TITLE
Skip downloading attachments in workers

### DIFF
--- a/docker-app/qfieldcloud/core/utils.py
+++ b/docker-app/qfieldcloud/core/utils.py
@@ -314,6 +314,22 @@ def get_s3_project_size(project_id: str) -> int:
     return round(total_size / (1024 * 1024), 3)
 
 
+def get_project_files(project_id: str, path: str = "") -> Iterable[S3Object]:
+    """Returns a list of files and their versions.
+
+    Args:
+        project_id (str): the project id
+        path (str): additional filter prefix
+
+    Returns:
+        Iterable[S3ObjectWithVersions]: the list of files
+    """
+    bucket = get_s3_bucket()
+    prefix = f"projects/{project_id}/files/{path}"
+
+    return list_files(bucket, prefix, strip_prefix=True)
+
+
 def get_project_files_with_versions(project_id: str) -> Iterable[S3ObjectWithVersions]:
     """Returns a list of files and their versions.
 

--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -35,7 +35,7 @@ class ListFilesView(views.APIView):
 
     def get(self, request, projectid):
 
-        Project.objects.get(id=projectid)
+        project = Project.objects.get(id=projectid)
 
         bucket = utils.get_s3_bucket()
 
@@ -61,11 +61,14 @@ class ListFilesView(views.APIView):
                 sha256sum = metadata["Sha256sum"]
 
             if version.is_latest:
+                is_attachment = get_attachment_dir_prefix(project, filename) != ""
+
                 files[version.key]["name"] = filename
                 files[version.key]["size"] = version.size
                 files[version.key]["sha256"] = sha256sum
                 files[version.key]["md5sum"] = version.e_tag.replace('"', "")
                 files[version.key]["last_modified"] = last_modified
+                files[version.key]["is_attachment"] = is_attachment
 
             files[version.key]["versions"].append(
                 {

--- a/docker-compose.override.test.yml
+++ b/docker-compose.override.test.yml
@@ -18,6 +18,9 @@ services:
       # we must use the same db for test and runserver
       SQL_DATABASE: test_${POSTGRES_DB}
       SQL_DATABASE_TEST: test_${POSTGRES_DB}
+    command: python -m debugpy --listen 0.0.0.0:5679 manage.py dequeue
+    ports:
+      - 5679:5679
 
   db:
     environment:

--- a/docker-qgis/entrypoint.py
+++ b/docker-qgis/entrypoint.py
@@ -152,6 +152,7 @@ def cmd_package_project(args):
                 arguments={
                     "project_id": args.projectid,
                     "destination": WorkDirPath(mkdir=True),
+                    "skip_attachments": True,
                 },
                 method=qfieldcloud.qgis.utils.download_project,
                 return_names=["tmp_project_dir"],
@@ -228,6 +229,7 @@ def cmd_apply_deltas(args):
                 arguments={
                     "project_id": args.projectid,
                     "destination": WorkDirPath(mkdir=True),
+                    "skip_attachments": True,
                 },
                 method=qfieldcloud.qgis.utils.download_project,
                 return_names=["tmp_project_dir"],
@@ -285,6 +287,7 @@ def cmd_process_projectfile(args):
                 arguments={
                     "project_id": args.projectid,
                     "destination": WorkDirPath(mkdir=True),
+                    "skip_attachments": True,
                 },
                 method=qfieldcloud.qgis.utils.download_project,
                 return_names=["tmp_project_dir"],

--- a/docker-qgis/utils.py
+++ b/docker-qgis/utils.py
@@ -159,7 +159,9 @@ def stop_app():
         del QGISAPP
 
 
-def download_project(project_id: str, destination: Path = None) -> Path:
+def download_project(
+    project_id: str, destination: Path = None, skip_attachments: bool = True
+) -> Path:
     """Download the files in the project "working" directory from the S3
     Storage into a temporary directory. Returns the directory path"""
     if not destination:
@@ -172,6 +174,10 @@ def download_project(project_id: str, destination: Path = None) -> Path:
 
     client = sdk.Client()
     files = client.list_remote_files(project_id)
+
+    if skip_attachments:
+        files = [file for file in files if not file["is_attachment"]]
+
     client.download_files(
         files,
         project_id,


### PR DESCRIPTION
Attachments are unimportant files such as photos, video, documents etc
that do not affect the work of the geospatial project.

- Add `is_attachment` flag to the files/package response to indicate
whether the file is considered an attachment.
- Do not download files within the worker that are flagged as `is_attachment`
- List files from the package and add the files from the original project
files in the attachment directories.
- When a file is requested from the package files endpoint and has an
attachment prefix, first check if the file is available in the package
and if not, try to download it from the original project files.