### PR TITLE
Replace null bytes in delta json in the delta to prevent pg error

### DIFF
--- a/docker-app/qfieldcloud/core/tests/test_delta.py
+++ b/docker-app/qfieldcloud/core/tests/test_delta.py
@@ -181,6 +181,28 @@ class QfcTestCase(APITransactionTestCase):
             features = list(layer)
             self.assertEqual(666, features[0]["properties"]["int"])
 
+    def test_push_apply_delta_file_with_null_char(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
+        project = self.upload_project_files(self.project1)
+
+        self.upload_and_check_deltas(
+            project=project,
+            delta_filename="singlelayer_singledelta_null.json",
+            token=self.token1.key,
+            final_values=[
+                [
+                    "9311eb96-bff8-4d5b-ab36-c314a007cfcd",
+                    "STATUS_APPLIED",
+                    self.user1.username,
+                ]
+            ],
+        )
+
+        gpkg = io.BytesIO(self.get_file_contents(project, "testdata.gpkg"))
+        with fiona.open(gpkg, layer="points") as layer:
+            features = list(layer)
+            self.assertEqual("", features[0]["properties"]["str"])
+
     def test_push_apply_delta_file_with_error(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
         project = self.upload_project_files(self.project1)

--- a/docker-app/qfieldcloud/core/tests/testdata/delta/deltas/singlelayer_singledelta_null.json
+++ b/docker-app/qfieldcloud/core/tests/testdata/delta/deltas/singlelayer_singledelta_null.json
@@ -1,0 +1,28 @@
+{
+    "deltas": [
+        {
+            "uuid": "9311eb96-bff8-4d5b-ab36-c314a007cfcd",
+            "clientId": "cd517e24-a520-4021-8850-e5af70e3a612",
+            "exportId": "f70c7286-fcec-4dbe-85b5-63d4735dac47",
+            "localPk": "1",
+            "sourcePk": "1",
+            "localLayerId": "points_897d5ed7_b810_4624_abe3_9f7c0a93d6a1",
+            "sourceLayerId": "points_897d5ed7_b810_4624_abe3_9f7c0a93d6a1",
+            "method": "patch",
+            "new": {
+                "attributes": {
+                    "str": "\u0000"
+                }
+            },
+            "old": {
+                "attributes": {
+                    "str": "str1"
+                }
+            }
+        }
+    ],
+    "files": [],
+    "id": "6f109cd3-f44c-41db-b134-5f38468b9fda",
+    "project": "e02d02cc-af1b-414c-a14c-e2ed5dfee52f",
+    "version": "1.0"
+}

--- a/docker-app/qfieldcloud/core/utils.py
+++ b/docker-app/qfieldcloud/core/utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import io
 import json
 import logging
 import os
@@ -191,12 +192,47 @@ def _get_md5sum_memory_file(
 def _get_md5sum_file(file: IO) -> str:
     BLOCKSIZE = 65536
     hasher = hashlib.md5()
+
     buf = file.read(BLOCKSIZE)
     while len(buf) > 0:
         hasher.update(buf)
         buf = file.read(BLOCKSIZE)
     file.seek(0)
     return hasher.hexdigest()
+
+
+def strip_json_null_bytes(file: IO) -> IO:
+    """Return JSON string stream without NULL chars."""
+    if type(file) is InMemoryUploadedFile or type(file) is TemporaryUploadedFile:
+        return _strip_json_null_bytes_memory_file(file)
+    else:
+        return _strip_json_null_bytes_file(file)
+
+
+def _strip_json_null_bytes_memory_file(file: IO) -> IO:
+    result = io.BytesIO()
+    BLOCKSIZE = 65536
+
+    for chunk in file.chunks(BLOCKSIZE):
+        result.write(chunk.decode().replace(r"\u0000", "").encode())
+    file.seek(0)
+    result.seek(0)
+
+    return result
+
+
+def _strip_json_null_bytes_file(file: IO) -> IO:
+    result = io.BytesIO()
+    BLOCKSIZE = 65536
+
+    buf = file.read(BLOCKSIZE)
+    while len(buf) > 0:
+        result.write(buf.decode().replace(r"\u0000", "").encode())
+        buf = file.read(BLOCKSIZE)
+    file.seek(0)
+    result.seek(0)
+
+    return result
 
 
 def safe_join(base: str, *paths: str) -> str:

--- a/docker-app/qfieldcloud/core/views/deltas_views.py
+++ b/docker-app/qfieldcloud/core/views/deltas_views.py
@@ -59,7 +59,7 @@ class ListCreateDeltasView(generics.ListCreateAPIView):
         if "file" not in request.data:
             raise exceptions.EmptyContentError()
 
-        request_file = request.data["file"]
+        request_file = utils.strip_json_null_bytes(request.data["file"])
         created_deltas = []
 
         try:


### PR DESCRIPTION
```
unsupported Unicode escape sequence
LINE 1: ...id, '2c6f40b1-7d2a-4225-be8d-8190d7a691f9'::uuid, '{"clientI...
                                                             ^
DETAIL:  \u0000 cannot be converted to text.
```
no more