### PR TITLE
Remove `prefetch_related` for 1:n that caused memory leak and super slow responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,15 +82,15 @@ If using the provided docker-compose overrides for developement, `debugpy` is in
 You can debug interactively by adding this snipped anywhere in the code.
 ```python
 import debugpy
-debugpy.listen(("0.0.0.0", 5678))
+debugpy.listen(("0.0.0.0", 5680))
 print("debugpy waiting for debugger... 🐛")
 debugpy.wait_for_client()  # optional
 ```
 
-Or alternativley, prefix your commands with `python -m debugpy --listen 0.0.0.0:5678 --wait-for-client`.
+Or alternativley, prefix your commands with `python -m debugpy --listen 0.0.0.0:5680 --wait-for-client`.
 ```shell
-docker-compose run app -p 5678:5678 python -m debugpy --listen 0.0.0.0:5678 --wait-for-client manage.py test
-docker-compose run worker_wrapper -p 5679:5679 python -m debugpy --listen 0.0.0.0:5679 --wait-for-client manage.py test
+docker-compose run app -p 5680:5680 python -m debugpy --listen 0.0.0.0:5680 --wait-for-client manage.py test
+docker-compose run worker_wrapper -p 5681:5681 python -m debugpy --listen 0.0.0.0:5681 --wait-for-client manage.py test
 ```
 
 Then, configure your IDE to connect (example given for VSCode's `.vscode/launch.json`, triggered with `F5`):
@@ -103,7 +103,7 @@ Then, configure your IDE to connect (example given for VSCode's `.vscode/launch.
             "type": "python",
             "request": "attach",
             "justMyCode": false,
-            "connect": {"host": "localhost", "port": 5678},
+            "connect": {"host": "localhost", "port": 5680},
             "pathMappings": [{
                 "localRoot": "${workspaceFolder}/docker-app/qfieldcloud",
                 "remoteRoot": "/usr/src/app/qfieldcloud"
@@ -114,7 +114,7 @@ Then, configure your IDE to connect (example given for VSCode's `.vscode/launch.
             "type": "python",
             "request": "attach",
             "justMyCode": false,
-            "connect": {"host": "localhost", "port": 5679},
+            "connect": {"host": "localhost", "port": 5681},
             "pathMappings": [{
                 "localRoot": "${workspaceFolder}/docker-app/qfieldcloud",
                 "remoteRoot": "/usr/src/app/qfieldcloud"
@@ -123,6 +123,8 @@ Then, configure your IDE to connect (example given for VSCode's `.vscode/launch.
     ]
 }
 ```
+
+Note if you run tests using the `docker-compose.test.yml` configuration, the `app` and `worker-wrapper` containers expose ports `5680` and `5681` respectively.
 
 
 ## Add root certificate

--- a/docker-app/qfieldcloud/core/exceptions.py
+++ b/docker-app/qfieldcloud/core/exceptions.py
@@ -4,8 +4,8 @@ from rest_framework import status
 class QFieldCloudException(Exception):
     """Generic QFieldCloud Exception"""
 
-    code = ("unknown_error",)
-    message = ("QFieldcloud Unknown Error",)
+    code = "unknown_error"
+    message = "QFieldcloud Unknown Error"
     status_code = None
 
     def __init__(self, detail="", status_code=None):

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -54,8 +54,7 @@ class UserQueryset(models.QuerySet):
 
     def for_project(self, project: "Project"):
         qs = (
-            self.prefetch_related("project_roles")
-            .defer("project_roles__project_id", "project_roles__project_id")
+            self.defer("project_roles__project_id", "project_roles__project_id")
             .filter(
                 user_type=User.TYPE_USER,
                 project_roles__project=project,
@@ -71,8 +70,7 @@ class UserQueryset(models.QuerySet):
 
     def for_organization(self, organization: "Organization"):
         qs = (
-            self.prefetch_related("organization_roles")
-            .defer(
+            self.defer(
                 "organization_roles__user_id",
                 "organization_roles__organization_id",
             )
@@ -469,8 +467,7 @@ class OrganizationQueryset(models.QuerySet):
 
     def of_user(self, user):
         qs = (
-            self.prefetch_related("membership_roles")
-            .defer("membership_roles__user_id", "membership_roles__organization_id")
+            self.defer("membership_roles__user_id", "membership_roles__organization_id")
             .filter(
                 membership_roles__user=user,
             )
@@ -747,8 +744,7 @@ class ProjectQueryset(models.QuerySet):
 
     def for_user(self, user):
         qs = (
-            self.prefetch_related("user_roles")
-            .defer("user_roles__user_id", "user_roles__project_id")
+            self.defer("user_roles__user_id", "user_roles__project_id")
             .filter(
                 user_roles__user=user,
                 user_roles__is_valid=True,

--- a/docker-app/qfieldcloud/core/tests/test_project.py
+++ b/docker-app/qfieldcloud/core/tests/test_project.py
@@ -75,11 +75,23 @@ class QfcTestCase(APITestCase):
         )
 
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
-        response = self.client.get("/api/v1/projects/?include-public=true")
+
+        # 1) do not list the public projects by default
+        response = self.client.get("/api/v1/projects/")
+        self.assertTrue(status.is_success(response.status_code))
+        self.assertEqual(len(response.data), 0)
+
+        # 1) list the public projects on request
+        response = self.client.get("/api/v1/projects/?include-public=1")
         self.assertTrue(status.is_success(response.status_code))
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["name"], "project1")
         self.assertEqual(response.data[0]["owner"], "user2")
+
+        # 1) do not list the public projects for any other value than 1
+        response = self.client.get("/api/v1/projects/?include-public=true")
+        self.assertTrue(status.is_success(response.status_code))
+        self.assertEqual(len(response.data), 0)
 
     def test_list_collaborators_of_project(self):
 

--- a/docker-app/qfieldcloud/core/views/projects_views.py
+++ b/docker-app/qfieldcloud/core/views/projects_views.py
@@ -109,10 +109,8 @@ class ProjectViewSet(viewsets.ModelViewSet):
         # included with the `include-public` query parameter.
         if self.action == "list":
             include_public = False
-            include_public_param = self.request.query_params.get(
-                "include-public", default=None
-            )
-            if include_public_param and include_public_param.lower() == "true":
+            include_public_param = self.request.query_params.get("include-public")
+            if include_public_param and include_public_param.lower() == "1":
                 include_public = True
 
             if not include_public:

--- a/docker-compose.override.test.yml
+++ b/docker-compose.override.test.yml
@@ -10,17 +10,17 @@ services:
       SQL_DATABASE: test_${POSTGRES_DB}
       SQL_DATABASE_TEST: test_${POSTGRES_DB}
     ports:
-      - 5678:5678
-    command: python3 manage.py runserver 0.0.0.0:8000
+      - 5680:5680
+    command: python3 -m debugpy --listen 0.0.0.0:5680 manage.py runserver 0.0.0.0:8000
 
   worker_wrapper:
     environment:
       # we must use the same db for test and runserver
       SQL_DATABASE: test_${POSTGRES_DB}
       SQL_DATABASE_TEST: test_${POSTGRES_DB}
-    command: python -m debugpy --listen 0.0.0.0:5679 manage.py dequeue
+    command: python3 -m debugpy --listen 0.0.0.0:5681 manage.py dequeue
     ports:
-      - 5679:5679
+      - 5681:5681
 
   db:
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,7 @@ services:
         max-file: "5"
     labels:
       ofelia.enabled: "true"
+      ofelia.job-exec.runcrons.no-overlap: "true"
       ofelia.job-exec.runcrons.schedule: '@every 1m'
       ofelia.job-exec.runcrons.command: python manage.py runcrons
 


### PR DESCRIPTION
Note to myself:
Django does separate select for each of the N relationships, which makes everything incredibly slow.