### PR TITLE
Deleting stored package should delete the files and all it's versions

### DIFF
--- a/docker-app/qfieldcloud/core/management/commands/listfiles.py
+++ b/docker-app/qfieldcloud/core/management/commands/listfiles.py
@@ -1,0 +1,65 @@
+from django.core.management.base import BaseCommand
+from qfieldcloud.core.utils import get_s3_bucket
+
+
+class Command(BaseCommand):
+    """
+    List object storage (S3) files and versions
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument("prefix", type=str)
+        parser.add_argument(
+            "--level",
+            type=str,
+            default="version",
+            help='Level of detail, one of: "version", "file", "summary".  Default is "version".',
+        )
+
+    def handle(self, *args, **options):
+        prefix = options.get("prefix")
+        level = options.get("level")
+
+        assert level in (
+            "version",
+            "file",
+            "summary",
+        ), "Level of detail not recognized."
+
+        bucket = get_s3_bucket()
+
+        files_b = 0
+        files_count = 0
+        files_and_versions_b = 0
+        files_and_versions_count = 0
+        last_files_count = 0
+        for version in bucket.object_versions.filter(Prefix=prefix):
+            files_and_versions_count += 1
+            files_and_versions_b += version.size or 0
+
+            last_files_count = files_count
+            if version.is_latest:
+                files_count += 1
+                files_b += version.size or 0
+
+            if level in ("version", "file"):
+                if level == "version" or version.is_latest:
+                    is_latest = "T" if version.is_latest else "F"
+                    print(
+                        version.id,
+                        str(version.last_modified),
+                        is_latest,
+                        version.e_tag,
+                        version.size,
+                        version.key,
+                        sep="\t",
+                    )
+            elif level in ("summary",):
+                if last_files_count != files_count and files_count % 10000 == 0:
+                    print(
+                        f"Intermediate results. {files_count} files, {files_b / 1000 / 1000:.2f} MB; {files_and_versions_count} versions, {files_and_versions_b / 1000 / 1000:.5f} MB"
+                    )
+
+        print(
+            f"Final results. {files_count} files, {files_b / 1000 / 1000:.2f} MB; {files_and_versions_count} versions, {files_and_versions_b / 1000 / 1000:.5f} MB"
+        )

--- a/docker-app/qfieldcloud/core/utils2/storage.py
+++ b/docker-app/qfieldcloud/core/utils2/storage.py
@@ -269,7 +269,7 @@ def upload_project_file(
 def delete_project_files(project_id: str) -> None:
     bucket = qfieldcloud.core.utils.get_s3_bucket()
     prefix = f"projects/{project_id}/"
-    bucket.objects.filter(Prefix=prefix).delete()
+    bucket.object_versions.filter(Prefix=prefix).delete()
 
 
 def delete_file(project: "Project", filename: str):  # noqa: F821
@@ -379,4 +379,4 @@ def delete_stored_package(project_id: str, package_id: str) -> None:
     bucket = qfieldcloud.core.utils.get_s3_bucket()
     prefix = f"projects/{project_id}/packages/{package_id}/"
 
-    bucket.objects.filter(Prefix=prefix).delete()
+    bucket.object_versions.filter(Prefix=prefix).delete()

--- a/docker-app/qfieldcloud/core/views/projects_views.py
+++ b/docker-app/qfieldcloud/core/views/projects_views.py
@@ -3,9 +3,10 @@ from django.db import transaction
 from django.utils.decorators import method_decorator
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
-from qfieldcloud.core import exceptions, permissions_utils, utils
+from qfieldcloud.core import exceptions, permissions_utils
 from qfieldcloud.core.models import Project, ProjectQueryset
 from qfieldcloud.core.serializers import ProjectSerializer
+from qfieldcloud.core.utils2 import storage
 from rest_framework import generics, permissions, viewsets
 
 User = get_user_model()
@@ -149,9 +150,7 @@ class ProjectViewSet(viewsets.ModelViewSet):
 
     def destroy(self, request, projectid):
         # Delete files from storage
-        bucket = utils.get_s3_bucket()
-        prefix = utils.safe_join("projects/{}/".format(projectid))
-        bucket.objects.filter(Prefix=prefix).delete()
+        storage.delete_project_files(projectid)
 
         return super().destroy(request, projectid)
 


### PR DESCRIPTION
If you use:
```
bucket.objects.filter(...).delete()
```
it deletes only adds a new version with empty size and etag and makes it latest. This means we collect all the file history.

But:
```
bucket.object_versions.filter(...).delete()
```
deletes the file and all it's versions like it never existed.