### PR TITLE
Fix replacing null bytes with utf8 conversion but reading the whole file

### DIFF
--- a/docker-app/qfieldcloud/core/utils.py
+++ b/docker-app/qfieldcloud/core/utils.py
@@ -214,7 +214,7 @@ def _strip_json_null_bytes_memory_file(file: IO) -> IO:
     BLOCKSIZE = 65536
 
     for chunk in file.chunks(BLOCKSIZE):
-        result.write(chunk.decode().replace(r"\u0000", "").encode())
+        result.write(chunk.replace(b"\0", b""))
     file.seek(0)
     result.seek(0)
 
@@ -227,7 +227,7 @@ def _strip_json_null_bytes_file(file: IO) -> IO:
 
     buf = file.read(BLOCKSIZE)
     while len(buf) > 0:
-        result.write(buf.decode().replace(r"\u0000", "").encode())
+        result.write(buf.replace(b"\0", b""))
         buf = file.read(BLOCKSIZE)
     file.seek(0)
     result.seek(0)

--- a/docker-app/qfieldcloud/core/utils.py
+++ b/docker-app/qfieldcloud/core/utils.py
@@ -203,32 +203,8 @@ def _get_md5sum_file(file: IO) -> str:
 
 def strip_json_null_bytes(file: IO) -> IO:
     """Return JSON string stream without NULL chars."""
-    if type(file) is InMemoryUploadedFile or type(file) is TemporaryUploadedFile:
-        return _strip_json_null_bytes_memory_file(file)
-    else:
-        return _strip_json_null_bytes_file(file)
-
-
-def _strip_json_null_bytes_memory_file(file: IO) -> IO:
     result = io.BytesIO()
-    BLOCKSIZE = 65536
-
-    for chunk in file.chunks(BLOCKSIZE):
-        result.write(chunk.replace(b"\0", b""))
-    file.seek(0)
-    result.seek(0)
-
-    return result
-
-
-def _strip_json_null_bytes_file(file: IO) -> IO:
-    result = io.BytesIO()
-    BLOCKSIZE = 65536
-
-    buf = file.read(BLOCKSIZE)
-    while len(buf) > 0:
-        result.write(buf.replace(b"\0", b""))
-        buf = file.read(BLOCKSIZE)
+    result.write(file.read().decode().replace(r"\u0000", "").encode())
     file.seek(0)
     result.seek(0)
 


### PR DESCRIPTION
Reading the whole file is not too much of a concern, as the delta files
should not grow indefinitely.

If we decode to utf8, we might get a chunk splitting the utf8 char in two,
therefore creating invalid utf8 character.

Tried to work with bytes directly, but failed. In theory we can safely
remove the null bytes without worrying too much, as null bytes appear
only for null characters in utf8.
Or at least according to this: https://stackoverflow.com/a/6907327/1226137