### PR TITLE
Prevent login with organizations or teams

### DIFF
--- a/docker-app/qfieldcloud/authentication/auth_backends.py
+++ b/docker-app/qfieldcloud/authentication/auth_backends.py
@@ -1,0 +1,26 @@
+from allauth.account.auth_backends import (
+    AuthenticationBackend as AllAuthAuthenticationBackend,
+)
+
+
+class AuthenticationBackend(AllAuthAuthenticationBackend):
+    """Extend the original `allauth` authentication backend to limit user types who can sign in.
+
+    Sign in via team or organization should be forbidden.
+    """
+
+    def _authenticate_by_username(self, **credentials):
+        user = super()._authenticate_by_username(**credentials)
+
+        if user and user.is_user:
+            return user
+
+        return None
+
+    def _authenticate_by_email(self, **credentials):
+        user = super()._authenticate_by_email(**credentials)
+
+        if user and user.is_user:
+            return user
+
+        return None

--- a/docker-app/qfieldcloud/authentication/tests/test_authentication.py
+++ b/docker-app/qfieldcloud/authentication/tests/test_authentication.py
@@ -2,7 +2,7 @@ import logging
 
 from django.utils.timezone import datetime, now
 from qfieldcloud.authentication.models import AuthToken
-from qfieldcloud.core.models import User
+from qfieldcloud.core.models import Organization, Team, User
 from qfieldcloud.core.tests.utils import setup_subscription_plans
 from rest_framework.test import APITransactionTestCase
 
@@ -42,7 +42,7 @@ class QfcTestCase(APITransactionTestCase):
             )
         )
 
-    def login(self, username, password, user_agent=""):
+    def login(self, username, password, user_agent="", success=True):
         response = self.client.post(
             "/api/v1/auth/login/",
             {
@@ -52,7 +52,8 @@ class QfcTestCase(APITransactionTestCase):
             HTTP_USER_AGENT=user_agent,
         )
 
-        self.assertEqual(response.status_code, 200)
+        if success:
+            self.assertEqual(response.status_code, 200)
 
         return response
 
@@ -205,3 +206,43 @@ class QfcTestCase(APITransactionTestCase):
 
         self.assertEquals(len(tokens), 1)
         self.assertLess(first_used_at, second_used_at)
+
+    def test_login_users_only(self):
+        u1 = User.objects.create_user(username="u1", password="abc123")
+        o1 = Organization.objects.create_user(
+            username="o1", password="abc123", organization_owner=u1
+        )
+        t1 = Team.objects.create_user(
+            username="@o1/t1", password="abc123", team_organization=o1
+        )
+
+        # regular users can login
+        response = self.login("u1", "abc123", success=True)
+
+        tokens = u1.auth_tokens.order_by("-created_at").all()
+
+        self.assertEquals(len(tokens), 1)
+        self.assertEquals(o1.auth_tokens.order_by("-created_at").count(), 0)
+        self.assertEquals(t1.auth_tokens.order_by("-created_at").count(), 0)
+        self.assertTokenMatch(tokens[0], response.json())
+        self.assertIsNone(tokens[0].last_used_at)
+
+        # organizations cannot login
+        response = self.login("o1", "abc123", success=False)
+
+        self.assertEquals(u1.auth_tokens.order_by("-created_at").count(), 1)
+        self.assertEquals(o1.auth_tokens.order_by("-created_at").count(), 0)
+        self.assertEquals(t1.auth_tokens.order_by("-created_at").count(), 0)
+        self.assertEquals(
+            response.json(), {"code": "api_error", "message": "API Error"}
+        )
+
+        # teams cannot login
+        response = self.login("t1", "abc123", success=False)
+
+        self.assertEquals(u1.auth_tokens.order_by("-created_at").count(), 1)
+        self.assertEquals(o1.auth_tokens.order_by("-created_at").count(), 0)
+        self.assertEquals(t1.auth_tokens.order_by("-created_at").count(), 0)
+        self.assertEquals(
+            response.json(), {"code": "api_error", "message": "API Error"}
+        )

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -48,10 +48,9 @@ ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS").split(" ")
 
 AUTHENTICATION_BACKENDS = [
     "axes.backends.AxesBackend",
-    # Needed to login by username in Django admin, regardless of `allauth`
-    "django.contrib.auth.backends.ModelBackend",
-    # `allauth` specific authentication methods, such as login by email
-    "allauth.account.auth_backends.AuthenticationBackend",
+    # custom QFC backend that extends the `allauth` specific authentication methods
+    # such as login by email, but restricting who can login to only regular users
+    "qfieldcloud.authentication.auth_backends.AuthenticationBackend",
 ]
 
 


### PR DESCRIPTION
Fix https://github.com/opengisch/QField/issues/3195

Quite interesting we didn't find it until now. A follow up would be to prevent resetting a password of an organization.