### PR TITLE
Qf 2134 fix sentry logging

### DIFF
--- a/docker-app/qfieldcloud/core/exceptions.py
+++ b/docker-app/qfieldcloud/core/exceptions.py
@@ -49,6 +49,14 @@ class NotAuthenticatedError(QFieldCloudException):
     status_code = status.HTTP_401_UNAUTHORIZED
 
 
+class PermissionDeniedError(QFieldCloudException):
+    """Raised when the user has not the required permission for an action."""
+
+    code = "permission_denied"
+    message = "Permission denied"
+    status_code = status.HTTP_403_FORBIDDEN
+
+
 class EmptyContentError(QFieldCloudException):
     """Raised when a request doesn't contain an expected content
     (e.g. a file)"""

--- a/docker-app/qfieldcloud/core/rest_utils.py
+++ b/docker-app/qfieldcloud/core/rest_utils.py
@@ -11,11 +11,15 @@ logger = logging.getLogger(__name__)
 
 def exception_handler(exc, context):
 
+    log_exception = True
+
     if isinstance(exc, qfieldcloud_exceptions.QFieldCloudException):
         pass
     elif isinstance(exc, rest_exceptions.AuthenticationFailed):
+        log_exception = False
         exc = qfieldcloud_exceptions.AuthenticationFailedError()
     elif isinstance(exc, rest_exceptions.NotAuthenticated):
+        log_exception = False
         exc = qfieldcloud_exceptions.NotAuthenticatedError()
     elif isinstance(exc, rest_exceptions.APIException):
         exc = qfieldcloud_exceptions.APIError(
@@ -24,6 +28,7 @@ def exception_handler(exc, context):
     elif isinstance(exc, exceptions.ObjectDoesNotExist):
         exc = qfieldcloud_exceptions.ObjectNotFoundError(detail=str(exc))
     elif isinstance(exc, exceptions.ValidationError):
+        log_exception = False
         exc = qfieldcloud_exceptions.ValidationError(detail=str(exc))
     else:
         # When running tests, we rethrow the exception, so we get a full trace to
@@ -47,7 +52,10 @@ def exception_handler(exc, context):
             "detail": exc.detail,
         }
 
-    logging.exception(exc)
+    if log_exception:
+        logging.exception(exc)
+    else:
+        logging.info(str(exc))
 
     return Response(
         body,

--- a/docker-app/qfieldcloud/core/rest_utils.py
+++ b/docker-app/qfieldcloud/core/rest_utils.py
@@ -29,6 +29,7 @@ def exception_handler(exc, context):
             status_code=exc.status_code, detail=exc.detail
         )
     elif isinstance(exc, exceptions.ObjectDoesNotExist):
+        log_exception = False
         exc = qfieldcloud_exceptions.ObjectNotFoundError(detail=str(exc))
     elif isinstance(exc, exceptions.ValidationError):
         log_exception = False

--- a/docker-app/qfieldcloud/core/rest_utils.py
+++ b/docker-app/qfieldcloud/core/rest_utils.py
@@ -21,6 +21,9 @@ def exception_handler(exc, context):
     elif isinstance(exc, rest_exceptions.NotAuthenticated):
         log_exception = False
         exc = qfieldcloud_exceptions.NotAuthenticatedError()
+    elif isinstance(exc, rest_exceptions.PermissionDenied):
+        log_exception = False
+        exc = qfieldcloud_exceptions.PermissionDeniedError()
     elif isinstance(exc, rest_exceptions.APIException):
         exc = qfieldcloud_exceptions.APIError(
             status_code=exc.status_code, detail=exc.detail

--- a/docker-app/qfieldcloud/core/rest_utils.py
+++ b/docker-app/qfieldcloud/core/rest_utils.py
@@ -11,40 +11,41 @@ logger = logging.getLogger(__name__)
 
 def exception_handler(exc, context):
 
-    log_exception = True
-
-    if isinstance(exc, qfieldcloud_exceptions.QFieldCloudException):
-        pass
-    elif isinstance(exc, rest_exceptions.AuthenticationFailed):
-        log_exception = False
-        exc = qfieldcloud_exceptions.AuthenticationFailedError()
+    # Map exceptions to qfc exceptions
+    is_error = False
+    if isinstance(exc, rest_exceptions.AuthenticationFailed):
+        qfc_exc = qfieldcloud_exceptions.AuthenticationFailedError()
     elif isinstance(exc, rest_exceptions.NotAuthenticated):
-        log_exception = False
-        exc = qfieldcloud_exceptions.NotAuthenticatedError()
+        qfc_exc = qfieldcloud_exceptions.NotAuthenticatedError()
     elif isinstance(exc, rest_exceptions.PermissionDenied):
-        log_exception = False
-        exc = qfieldcloud_exceptions.PermissionDeniedError()
-    elif isinstance(exc, rest_exceptions.APIException):
-        exc = qfieldcloud_exceptions.APIError(
-            status_code=exc.status_code, detail=exc.detail
-        )
+        qfc_exc = qfieldcloud_exceptions.PermissionDeniedError()
     elif isinstance(exc, exceptions.ObjectDoesNotExist):
-        log_exception = False
-        exc = qfieldcloud_exceptions.ObjectNotFoundError(detail=str(exc))
+        qfc_exc = qfieldcloud_exceptions.ObjectNotFoundError(detail=str(exc))
     elif isinstance(exc, exceptions.ValidationError):
-        log_exception = False
-        exc = qfieldcloud_exceptions.ValidationError(detail=str(exc))
+        qfc_exc = qfieldcloud_exceptions.ValidationError(detail=str(exc))
+    elif isinstance(exc, qfieldcloud_exceptions.QFieldCloudException):
+        is_error = True
+        qfc_exc = exc
+    elif isinstance(exc, rest_exceptions.APIException):
+        is_error = True
+        qfc_exc = qfieldcloud_exceptions.APIError(exc.detail, exc.status_code)
     else:
-        # When running tests, we rethrow the exception, so we get a full trace to
-        # help with debugging
+        # Unexpected ! We rethrow original exception to make debugging tests easier
         if settings.IN_TEST_SUITE:
             raise exc
+        is_error = True
+        qfc_exc = qfieldcloud_exceptions.QFieldCloudException(detail=str(exc))
+
+    if is_error:
+        # log the original exception
         logging.exception(exc)
-        exc = qfieldcloud_exceptions.QFieldCloudException(detail=str(exc))
+    else:
+        # log as info as repeated errors could still indicate an actual issue
+        logging.info(str(exc))
 
     body = {
-        "code": exc.code,
-        "message": exc.message,
+        "code": qfc_exc.code,
+        "message": qfc_exc.message,
     }
 
     if settings.DEBUG:
@@ -53,15 +54,10 @@ def exception_handler(exc, context):
             "args": context["args"],
             "kwargs": context["kwargs"],
             "request": str(context["request"]),
-            "detail": exc.detail,
+            "detail": qfc_exc.detail,
         }
-
-    if log_exception:
-        logging.exception(exc)
-    else:
-        logging.info(str(exc))
 
     return Response(
         body,
-        status=exc.status_code,
+        status=qfc_exc.status_code,
     )

--- a/docker-app/qfieldcloud/core/tests/test_project.py
+++ b/docker-app/qfieldcloud/core/tests/test_project.py
@@ -298,7 +298,7 @@ class QfcTestCase(APITestCase):
         response = self.client.get("/api/v1/projects/{}/".format(project1.id))
 
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json()["code"], "api_error")
+        self.assertEqual(response.json()["code"], "permission_denied")
 
         # Get an unexisting project id
         response = self.client.get(


### PR DESCRIPTION
Fixes for errors logged to sentry. To better review, look at the individual commits (referring to the sentry issue), since the last one refactors the error handler.

I'm not 100% sure doing this all in the exception handler is the right place, because stuff like `ObjectDoesNotExist` may be an user error (e.g. user entering a wrong URL) but also due to bugs in the code... IMO it would be cleaner to only take care about how exceptions are returned to the user in the handler, but otherwise catch/manage them in the code where we expect them to happen.