### PR TITLE
Infrastructure for selenium tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ ENVIRONMENT=test
 
 QFIELDCLOUD_HOST=localhost
 DJANGO_SETTINGS_MODULE=qfieldcloud.settings
-DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 0.0.0.0 app
+DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 0.0.0.0 app nginx
 
 SECRET_KEY=change_me
 

--- a/conf/nginx/templates/default.conf.template
+++ b/conf/nginx/templates/default.conf.template
@@ -33,7 +33,7 @@ server {
   ssl_certificate     certs/${QFIELDCLOUD_HOST}.pem;
   ssl_certificate_key certs/${QFIELDCLOUD_HOST}-key.pem;
 
-  server_name ${QFIELDCLOUD_HOST};
+  server_name ${QFIELDCLOUD_HOST} nginx;
   client_max_body_size 10G;
   keepalive_timeout 5;
 

--- a/docker-app/requirements_test.txt
+++ b/docker-app/requirements_test.txt
@@ -1,2 +1,4 @@
 click==8.1.3
 fiona==1.8.22
+imageio==2.22.4
+selenium==4.6.0


### PR DESCRIPTION
(not ready for review yet)

Groundwork for selenium testing:
- allow `nginx` as a hostname (so the selenium browser can access the app using the proxy instead of django, hence testing the full stack)
- include python-selenium dependency

TODO before merge
- [x] reenable preventiong of access by IP
- [x] consider using nginx as QFIELDCLOUD_HOST in the settings instead of hardcoding all that
- [x] see how to only install python-selenium on test setups (we don't need it on prod)