### PR TITLE
Fix dangling QGIS containers eating host's disk space

### DIFF
--- a/docker-app/requirements_worker_wrapper.txt
+++ b/docker-app/requirements_worker_wrapper.txt
@@ -1,1 +1,2 @@
 docker==4.2.2
+tenacity==8.1.0

--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -29,9 +29,16 @@ from qfieldcloud.core.models import (
 )
 from qfieldcloud.core.utils import get_qgis_project_file
 from qfieldcloud.core.utils2 import storage
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_random_exponential,
+)
 
 logger = logging.getLogger(__name__)
 
+RETRY_COUNT = 5
 TIMEOUT_ERROR_EXIT_CODE = -1
 QGIS_CONTAINER_NAME = os.environ.get("QGIS_CONTAINER_NAME", None)
 QFIELDCLOUD_HOST = os.environ.get("QFIELDCLOUD_HOST", None)
@@ -256,14 +263,34 @@ class JobRun:
         response = {"StatusCode": TIMEOUT_ERROR_EXIT_CODE}
 
         try:
-            # will throw an ConnectionError, but the container is still alive
+            # will throw an `requests.exceptions.ConnectionError`, but the container is still alive
             response = container.wait(timeout=self.container_timeout_secs)
         except Exception as err:
             logger.exception("Timeout error.", exc_info=err)
 
-        logs = container.logs()
-        container.stop()
-        container.remove()
+        logs = b""
+        # Retry reading the logs, as it may fail
+        # NOTE when reading the logs of a finished container, it might timeout with an ``.
+        # This leads to exception and prevents the container to be removed few lines below.
+        # Therefore try reading the logs, as they are important, and if it fails, just use a
+        # generic "failed to read logs" message.
+        # Similar issue here: https://github.com/docker/docker-py/issues/2266
+
+        retriable = retry(
+            wait=wait_random_exponential(max=10),
+            stop=stop_after_attempt(RETRY_COUNT),
+            retry=retry_if_exception_type(requests.exceptions.ConnectionError),
+            reraise=True,
+        )
+
+        try:
+            logs = retriable(lambda: container.logs())()
+        except requests.exceptions.ConnectionError:
+            logs = b"[QFC/Worker/1001] Failed to read logs."
+
+        retriable(lambda: container.stop())()
+        retriable(lambda: container.remove())()
+
         logger.info(
             f"Finished execution with code {response['StatusCode']}, logs:\n{logs}"
         )


### PR DESCRIPTION
If `container.logs()` call fails, the container remains dangling since it is never deleted with the python API.

Adding a automatic retry should solve this.


Prevents errors like:
```
Traceback (most recent call last):
  File \"/usr/local/lib/python3.8/site-packages/urllib3/response.py\", line 438, in _error_catcher
    yield
  File \"/usr/local/lib/python3.8/site-packages/urllib3/response.py\", line 764, in read_chunked
    self._update_chunk_length()
  File \"/usr/local/lib/python3.8/site-packages/urllib3/response.py\", line 694, in _update_chunk_length
    line = self._fp.fp.readline()
  File \"/usr/local/lib/python3.8/socket.py\", line 669, in readinto
    return self._sock.recv_into(b)
socket.timeout: timed out

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File \"/usr/local/lib/python3.8/site-packages/requests/models.py\", line 758, in generate
    for chunk in self.raw.stream(chunk_size, decode_content=True):
  File \"/usr/local/lib/python3.8/site-packages/urllib3/response.py\", line 572, in stream
    for line in self.read_chunked(amt, decode_content=decode_content):
  File \"/usr/local/lib/python3.8/site-packages/urllib3/response.py\", line 793, in read_chunked
    self._original_response.close()
  File \"/usr/local/lib/python3.8/contextlib.py\", line 131, in __exit__
    self.gen.throw(type, value, traceback)
  File \"/usr/local/lib/python3.8/site-packages/urllib3/response.py\", line 443, in _error_catcher
    raise ReadTimeoutError(self._pool, None, \"Read timed out.\")
  urllib3.exceptions.ReadTimeoutError: UnixHTTPConnectionPool(host='localhost', port=None): Read timed out.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File \"/usr/src/app/worker_wrapper/wrapper.py\", line 113, in run
    exit_code, output = self._run_docker(
      File \"/usr/src/app/worker_wrapper/wrapper.py\", line 264, in _run_docker
    logs = container.logs()
  File \"/usr/local/lib/python3.8/site-packages/docker/models/containers.py\", line 302, in logs
    return self.client.api.logs(self.id, **kwargs)
  File \"/usr/local/lib/python3.8/site-packages/docker/utils/decorators.py\", line 19, in wrapped
    return f(self, resource_id, *args, **kwargs)
  File \"/usr/local/lib/python3.8/site-packages/docker/api/container.py\", line 854, in logs
    res = self._get(url, params=params, stream=stream)
  File \"/usr/local/lib/python3.8/site-packages/docker/utils/decorators.py\", line 46, in inner
    return f(self, *args, **kwargs)
  File \"/usr/local/lib/python3.8/site-packages/docker/api/client.py\", line 230, in _get
    return self.get(url, **self._set_request_timeout(kwargs))
  File \"/usr/local/lib/python3.8/site-packages/requests/sessions.py\", line 555, in get
    return self.request('GET', url, **kwargs)
  File \"/usr/local/lib/python3.8/site-packages/requests/sessions.py\", line 542, in request
    resp = self.send(prep, **send_kwargs)
  File \"/usr/local/lib/python3.8/site-packages/requests/sessions.py\", line 697, in send
    r.content
  File \"/usr/local/lib/python3.8/site-packages/requests/models.py\", line 836, in content
    self._content = b''.join(self.iter_content(CONTENT_CHUNK_SIZE)) or b''
  File \"/usr/local/lib/python3.8/site-packages/requests/models.py\", line 765, in generate
    raise ConnectionError(e)
requests.exceptions.ConnectionError: UnixHTTPConnectionPool(host='localhost', port=None): Read timed out.", "message": "Failed job run:
{\"error\": \"UnixHTTPConnectionPool(host='localhost', port=None): Read timed out.\", \"error_origin\": \"worker_wrapper\", \"error_stack\": [\"  File \\\"/usr/src/app/worker_wrapper/wrapper.py\\\", line 113, in run\
        exit_code, output = self._run_docker(\
    \", \"  File \\\"/usr/src/app/worker_wrapper/wrapper.py\\\", line 264, in _run_docker\
        logs = container.logs()\
    \", \"  File \\\"/usr/local/lib/python3.8/site-packages/docker/models/containers.py\\\", line 302, in logs\
        return self.client.api.logs(self.id, **kwargs)\
    \", \"  File \\\"/usr/local/lib/python3.8/site-packages/docker/utils/decorators.py\\\", line 19, in wrapped\
        return f(self, resource_id, *args, **kwargs)\
    \", \"  File \\\"/usr/local/lib/python3.8/site-packages/docker/api/container.py\\\", line 854, in logs\
        res = self._get(url, params=params, stream=stream)\
    \", \"  File \\\"/usr/local/lib/python3.8/site-packages/docker/utils/decorators.py\\\", line 46, in inner\
        return f(self, *args, **kwargs)\
    \", \"  File \\\"/usr/local/lib/python3.8/site-packages/docker/api/client.py\\\", line 230, in _get\
        return self.get(url, **self._set_request_timeout(kwargs))\
    \", \"  File \\\"/usr/local/lib/python3.8/site-packages/requests/sessions.py\\\", line 555, in get\
        return self.request('GET', url, **kwargs)\
    \", \"  File \\\"/usr/local/lib/python3.8/site-packages/requests/sessions.py\\\", line 542, in request\
        resp = self.send(prep, **send_kwargs)\
    \", \"  File \\\"/usr/local/lib/python3.8/site-packages/requests/sessions.py\\\", line 697, in send\
        r.content\
    \", \"  File \\\"/usr/local/lib/python3.8/site-packages/requests/models.py\\\", line 836, in content\
        self._content = b''.join(self.iter_content(CONTENT_CHUNK_SIZE)) or b''\
    \", \"  File \\\"/usr/local/lib/python3.8/site-packages/requests/models.py\\\", line 765, in generate\
        raise ConnectionError(e)\
    \"]}", "time": "2022-11-27T13:30:44.622699"}
```