### PR TITLE
Setup sentry environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
       SECRET_KEY: ${SECRET_KEY}
       DEBUG: ${DEBUG}
       ENVIRONMENT: ${ENVIRONMENT}
+      # actually I never made it work with sentry_sdk.init(environment=ENVIRONMENT)
+      SENTRY_ENVIRONMENT: ${ENVIRONMENT}
       SQL_DATABASE: ${POSTGRES_DB}
       SQL_DATABASE_TEST: test_${POSTGRES_DB}
       SQL_USER: ${POSTGRES_USER}


### PR DESCRIPTION
Tried to set it up with:

```
ENVIRONMENT = os.environ.get("ENVIRONMENT")
sentry_sdk.init(environment=ENVIRONMENT)
```

but then:

```
sentry_sdk.client_get_options()
```

didn't return the correct environment. Dunno why, but this seems to work.