### PR TITLE
Bump `django-axes` dependency to the latest 5.40.1

### DIFF
--- a/docker-app/qfieldcloud/core/tests/test_admin.py
+++ b/docker-app/qfieldcloud/core/tests/test_admin.py
@@ -68,6 +68,7 @@ class QfcTestCase(TransactionTestCase):
             "/admin/core/delta/add/",
             "/admin/core/job/add/",
             "/admin/axes/accessattempt/add/",
+            "/admin/axes/accessfailurelog/add/",
             "/admin/axes/accesslog/add/",
         )
         # TODO make tests pass for these sortable URLs

--- a/docker-app/requirements.txt
+++ b/docker-app/requirements.txt
@@ -17,7 +17,7 @@ Django==3.2.17
 django-allauth==0.44.0
 django-appconf==1.0.5
 django-auditlog==1.0a1
-django-axes==5.28.0
+django-axes==5.40.1
 django-bootstrap4==3.0.1
 django-classy-tags==3.0.1
 django-common-helpers==0.9.2


### PR DESCRIPTION
DB migrations:
- https://github.com/jazzband/django-axes/blob/master/axes/migrations/0008_accessfailurelog.py - Added a new model, no python execution, no scary DB locks expected.

Changelog:
https://github.com/jazzband/django-axes/releases/tag/5.40.1

Changes:
https://github.com/jazzband/django-axes/compare/5.28.0...5.40.1