### PR TITLE
Bump django-audit dependency to the latest 2.2.2

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -8,7 +8,6 @@ from typing import List, Optional
 
 import django_cryptography.fields
 import qfieldcloud.core.utils2.storage
-from auditlog.context import disable_auditlog
 from deprecated import deprecated
 from django.contrib.auth.models import AbstractUser
 from django.contrib.auth.models import UserManager as DjangoUserManager
@@ -312,8 +311,7 @@ class User(AbstractUser):
         if self.type != User.Type.TEAM:
             qfieldcloud.core.utils2.storage.delete_user_avatar(self)
 
-        with disable_auditlog():
-            super().delete(*args, **kwargs)
+        super().delete(*args, **kwargs)
 
     class Meta:
         base_manager_name = "objects"

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1,4 +1,3 @@
-import contextlib
 import os
 import secrets
 import string
@@ -9,7 +8,7 @@ from typing import List, Optional
 
 import django_cryptography.fields
 import qfieldcloud.core.utils2.storage
-from auditlog.registry import auditlog
+from auditlog.context import disable_auditlog
 from deprecated import deprecated
 from django.contrib.auth.models import AbstractUser
 from django.contrib.auth.models import UserManager as DjangoUserManager
@@ -313,7 +312,7 @@ class User(AbstractUser):
         if self.type != User.Type.TEAM:
             qfieldcloud.core.utils2.storage.delete_user_avatar(self)
 
-        with no_audits([User, UserAccount, Project]):
+        with disable_auditlog():
             super().delete(*args, **kwargs)
 
     class Meta:
@@ -1581,66 +1580,3 @@ class Secret(models.Model):
                 fields=["project", "name"], name="secret_project_name_uniq"
             )
         ]
-
-
-audited_models = [
-    (User, {"exclude_fields": ["last_login", "updated_at"]}),
-    (UserAccount, {}),
-    (Organization, {}),
-    (OrganizationMember, {}),
-    (Team, {}),
-    (TeamMember, {}),
-    (
-        Project,
-        {
-            "include_fields": [
-                "id",
-                "name",
-                "description",
-                "owner",
-                "is_public",
-                "owner",
-                "created_at",
-            ],
-        },
-    ),
-    (ProjectCollaborator, {}),
-    (
-        Delta,
-        {
-            "include_fields": [
-                "id",
-                "deltafile_id",
-                "project",
-                "content",
-                "last_status",
-                "created_by",
-            ],
-        },
-    ),
-    (Secret, {"exclude_fields": ["value"]}),
-]
-
-
-def register_model_audits(subset: List[models.Model] = []) -> None:
-    for model, kwargs in audited_models:
-        if subset and model not in subset:
-            continue
-        auditlog.register(model, **kwargs)
-
-
-def deregister_model_audits(subset: List[models.Model] = []) -> None:
-    for model, _kwargs in audited_models:
-        if subset and model not in subset:
-            continue
-
-        auditlog.unregister(model)
-
-
-@contextlib.contextmanager
-def no_audits(subset: List[models.Model] = []):
-    try:
-        deregister_model_audits(subset)
-        yield
-    finally:
-        register_model_audits(subset)

--- a/docker-app/qfieldcloud/core/tests/test_admin.py
+++ b/docker-app/qfieldcloud/core/tests/test_admin.py
@@ -70,6 +70,7 @@ class QfcTestCase(TransactionTestCase):
             "/admin/axes/accessattempt/add/",
             "/admin/axes/accessfailurelog/add/",
             "/admin/axes/accesslog/add/",
+            "/admin/auditlog/logentry/add/",
         )
         # TODO make tests pass for these sortable URLs
         skip_sort_urls = ("/admin/django_cron/cronjoblog/?o=4",)

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -431,3 +431,80 @@ CONSTANCE_CONFIG_FIELDSETS = {
     ),
     "Subscription": ("TRIAL_PERIOD_DAYS",),
 }
+
+
+# `django-auditlog` configurations, read more on https://django-auditlog.readthedocs.io/en/latest/usage.html
+AUDITLOG_INCLUDE_TRACKING_MODELS = [
+    # NOTE `Delta` and `Job` models are not being automatically audited, because their data changes very often and timestamps are available in their models.
+    {
+        "model": "account.emailaddress",
+    },
+    # NOTE Constance model cannot be audited. If enabled, an `IndexError list index out of range` is raised.
+    # {
+    #     "model": "constance.config",
+    # },
+    {
+        "model": "core.geodb",
+    },
+    {
+        "model": "core.organization",
+    },
+    # TODO check if we can use `Organization.members` m2m when next version is released as described in "Many-to-many fields" here https://django-auditlog.readthedocs.io/en/latest/usage.html#automatically-logging-changes
+    {
+        "model": "core.organizationmember",
+    },
+    {
+        "model": "core.person",
+        "exclude_fields": ["last_login", "updated_at"],
+    },
+    {
+        "model": "core.project",
+        # these fields are updated by scripts and will produce a lot of audit noise
+        "exclude_fields": [
+            "updated_at",
+            "data_last_updated_at",
+            "data_last_packaged_at",
+            "last_package_job",
+            "storage_size_mb",
+        ],
+    },
+    # TODO check if we can use `Project.collaborators` m2m when next version is released as described in "Many-to-many fields" here https://django-auditlog.readthedocs.io/en/latest/usage.html#automatically-logging-changes
+    {
+        "model": "core.projectcollaborator",
+    },
+    {
+        "model": "core.secret",
+        "mask_fields": [
+            "value",
+        ],
+    },
+    # TODO check if we can use `Team.members` m2m when next version is released as described in "Many-to-many fields" here https://django-auditlog.readthedocs.io/en/latest/usage.html#automatically-logging-changes
+    {
+        "model": "core.team",
+    },
+    {
+        "model": "core.teammember",
+    },
+    {
+        "model": "core.user",
+        "exclude_fields": ["last_login", "updated_at"],
+    },
+    {
+        "model": "core.useraccount",
+    },
+    {
+        "model": "invitations.invitation",
+    },
+    {
+        "model": "subscription.package",
+    },
+    {
+        "model": "subscription.packagetype",
+    },
+    {
+        "model": "subscription.plan",
+    },
+    {
+        "model": "subscription.subscription",
+    },
+]

--- a/docker-app/requirements.txt
+++ b/docker-app/requirements.txt
@@ -16,7 +16,7 @@ Deprecated==1.2.13
 Django==3.2.17
 django-allauth==0.44.0
 django-appconf==1.0.5
-django-auditlog==1.0a1
+django-auditlog==2.2.2
 django-axes==5.40.1
 django-bootstrap4==3.0.1
 django-classy-tags==3.0.1


### PR DESCRIPTION
DB migrations:
- https://github.com/jazzband/django-auditlog/blob/master/auditlog/migrations/0008_action_index.py - adds an index, will lock temporarily
- https://github.com/jazzband/django-auditlog/blob/master/auditlog/migrations/0009_alter_logentry_additional_data.py - adds a nullable JSON field, should be fast
- https://github.com/jazzband/django-auditlog/blob/master/auditlog/migrations/0010_alter_logentry_timestamp.py - adds a non-nullable timestamp field with default value, will be slow but not terrible
- https://github.com/jazzband/django-auditlog/blob/master/auditlog/migrations/0011_logentry_serialized_data.py - adds a nullable JSON field, should be fast
- https://github.com/jazzband/django-auditlog/blob/master/auditlog/migrations/0012_add_logentry_action_access.py - no DB changes, changing the choices of an integer field

Changelog:
https://github.com/jazzband/django-auditlog/blob/master/CHANGELOG.md#221-2022-11-28
NOTE: v2.2.2 is missing from the changelog, but fixes an issue with deleting an audit from the admin, see jazzband/django-auditlog#496

Changes:
jazzband/django-auditlog@v1.0a1...v2.2.2


Also enable audits when deleting a user.

With older versions of auditlog module, deleting a user that owns a project was causing an error, which seems to be fixed with 2.2.2 (see https://github.com/opengisch/qfieldcloud/pull/344).