### PR TITLE
Fix configuration of Sentry by converting the envvar SENTRY_SAMPLE_RATE to a float

### DIFF
--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -259,7 +259,7 @@ LOGIN_URL = "account_login"
 # Sentry configuration
 SENTRY_DSN = os.environ.get("SENTRY_DSN", "")
 if SENTRY_DSN:
-    SENTRY_SAMPLE_RATE = os.environ.get("SENTRY_SAMPLE_RATE", 1)
+    SENTRY_SAMPLE_RATE = float(os.environ.get("SENTRY_SAMPLE_RATE", 1))
 
     def before_send(event, hint):
         from qfieldcloud.core.exceptions import ProjectAlreadyExistsError


### PR DESCRIPTION
Sentry does not validate it's initialization function, but when there is an error, instead of proper error page in DEBUG mode, it just shows "A server error occurred.  Please contact the administrator.".


The problem was introduced with #491 