### PR TITLE
Speed up QFieldCloud admin by referencing user with autocomplete view

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -500,6 +500,9 @@ class UserAccount(models.Model):
 
         return False
 
+    def __str__(self) -> str:
+        return f"{self.user.username_with_full_name} ({self.__class__.__name__})"
+
 
 class Geodb(models.Model):
     def random_string():


### PR DESCRIPTION
By default django is rendering all possible values in a select field, which
is no longer scalable with 60k users. Therefore an autocomplete field is
rendered.

Also make UserAccount representation nicer from "Useraccount 1" to "suricactus (UserAccount)".