### PR TITLE
Prevent worker wrapper exception when Project.project_details was already NULL

### DIFF
--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -508,5 +508,7 @@ class ProcessProjectfileJobRun(JobRun):
 
     def after_docker_exception(self) -> None:
         project = self.job.project
-        project.project_details = None
-        project.save(update_fields=("project_details",))
+
+        if project.project_details is not None:
+            project.project_details = None
+            project.save(update_fields=("project_details",))


### PR DESCRIPTION
When using `update_fields` and there are no modified rows, django will throw an error.