### PR TITLE
Remove the pipenv dependency for envvar validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-
-      - name: Install pipenv
-        run: pip install pipenv
-
       - name: Check code formatting
         uses: pre-commit/action@v2.0.3
 

--- a/scripts/check_envvars.sh
+++ b/scripts/check_envvars.sh
@@ -1,4 +1,3 @@
 #!/bin/bash -e
 
-pipenv run pip install pyyaml
-pipenv run python scripts/check_envvars.py .env.example --docker-compose-dir . --ignored-varnames CONFIG_PATH
+python3 scripts/check_envvars.py .env.example --docker-compose-dir . --ignored-varnames CONFIG_PATH


### PR DESCRIPTION
@why-not-try-calmer seems the split of the CI in two broke the `pipenv` dependency in the latter part. No idea why I overlooked that https://github.com/opengisch/qfieldcloud/pull/520 is failing...