### PR TITLE
Users getting error 500 when trying to register with username taken by an Organization

### DIFF
--- a/docker-app/qfieldcloud/core/adapters.py
+++ b/docker-app/qfieldcloud/core/adapters.py
@@ -1,4 +1,6 @@
+from allauth.account import app_settings
 from allauth.account.adapter import DefaultAccountAdapter
+from django.core.exceptions import ValidationError
 from invitations.adapters import BaseInvitationsAdapter
 from qfieldcloud.core.models import Person
 
@@ -17,3 +19,35 @@ class AccountAdapter(DefaultAccountAdapter, BaseInvitationsAdapter):
         """
         user = Person()
         return user
+
+    def clean_username(self, username, shallow=False):
+        result = super().clean_username(username, shallow)
+
+        # NOTE `allauth` depends on the `PRESERVE_USERNAME_CASING` to make `iexact` lookups.
+        # When set to `False` as it is now, all `Person` usernames are stored as lowercase.
+        # However, usernames for `Organization` or `Team` are not stored lowercase and then `allauth` does not check for them.
+
+        # TODO check what are the consequences if we don't add all of these and change the `PRESERVE_USERNAME_CASING` to `True`.
+        if not app_settings.PRESERVE_USERNAME_CASING:
+            username_field = app_settings.USER_MODEL_USERNAME_FIELD
+
+            if Person.objects.filter(
+                **{f"{username_field}__iexact": username},
+            ).exists():
+
+                error_message = Person._meta.get_field(
+                    username_field
+                ).error_messages.get("unique")
+
+                if not error_message:
+                    error_message = self.error_messages["username_taken"]
+
+                raise ValidationError(
+                    error_message,
+                    params={
+                        "model_name": Person.__name__,
+                        "field_label": username_field,
+                    },
+                )
+
+        return result


### PR DESCRIPTION
NOTE `allauth` depends on the `PRESERVE_USERNAME_CASING` to make `iexact` lookups. When set to `False` as it is now, all `Person` usernames are stored as lowercase. However, usernames for `Organization` or `Team` are not stored lowercase and then `allauth` does not check for them.

TODO check what are the consequences if we don't add all of these and change the `PRESERVE_USERNAME_CASING` to `True`.