### PR TITLE
Add some admin improvements

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -916,6 +916,7 @@ class OrganizationAdmin(admin.ModelAdmin):
         "username",
         "email",
         "organization_owner",
+        "date_joined",
     )
     list_display = (
         "username",
@@ -930,6 +931,8 @@ class OrganizationAdmin(admin.ModelAdmin):
         "email__iexact",
         "organization_owner__email__iexact",
     )
+
+    readonly_fields = ("date_joined",)
 
     list_select_related = ("organization_owner",)
 

--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -311,14 +311,10 @@ class UserAccountInline(admin.StackedInline):
     extra = 1
 
     def has_add_permission(self, request, obj):
-        if obj is None:
-            return True
-        return obj.type in (User.Type.PERSON, User.Type.ORGANIZATION)
+        return obj is None
 
     def has_delete_permission(self, request, obj):
-        if obj is None:
-            return True
-        return obj.type in (User.Type.PERSON, User.Type.ORGANIZATION)
+        return False
 
 
 class ProjectInline(admin.TabularInline):

--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -940,6 +940,7 @@ class OrganizationAdmin(admin.ModelAdmin):
 
     autocomplete_fields = ("organization_owner",)
 
+    @admin.display(description=_("Owner"))
     def organization_owner__link(self, instance):
         return model_admin_url(
             instance.organization_owner, instance.organization_owner.username

--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -398,6 +398,11 @@ class PersonAdmin(admin.ModelAdmin):
         "has_accepted_tos",
     )
 
+    readonly_fields = (
+        "date_joined",
+        "last_login",
+    )
+
     inlines = (
         UserAccountInline,
         GeodbInline,

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -758,6 +758,9 @@ class AbstractSubscription(models.Model):
 
         return trial_subscription, regular_subscription
 
+    def __str__(self):
+        return f"{self.__class__.__name__} #{self.id} user:{self.account.user.username} plan:{self.plan.code} total:{self.active_storage_total_mb}MB"
+
 
 class Subscription(AbstractSubscription):
     pass

--- a/docker-app/qfieldcloud/subscription/tests/test_package.py
+++ b/docker-app/qfieldcloud/subscription/tests/test_package.py
@@ -111,9 +111,12 @@ class QfcTestCase(APITransactionTestCase):
         self.assertEqual(user.useraccount.storage_free_mb, storage_free_mb)
 
     def test_get_storage_package_type(self):
+        PackageType.objects.all().delete()
+        PackageType.get_storage_package_type.cache_clear()
+
         package_type = PackageType.objects.create(
             unit_amount=1,
-            code="storage_package",
+            code="test_storage_package",
             type=PackageType.Type.STORAGE,
             min_quantity=0,
             max_quantity=100,

--- a/docker-app/requirements.txt
+++ b/docker-app/requirements.txt
@@ -34,6 +34,7 @@ django-ipware==4.0.2
 django-jsonfield==1.4.1
 django-migrate-sql-deux==0.4.0
 django-model-utils==4.3.1
+django-nonrelated-inlines==0.2
 django-notifications-hq==1.6.0
 django-phonenumber-field==7.0.0
 django-picklefield==3.1


### PR DESCRIPTION
- Make `date_joined` and `last_login` in `People` readonly
- Add `django-nonrelated-inlines` dependency
- Make add and delete permissions for inline UserAccount simpler
- Add better representation for subscriptions
- Show `date_joined` in `OrganizationAdmin`
- Shorten the owner column name in `OrganizationAdmin`
