### PR TITLE
Fix storage calculation when deleting multiple files at once

### DIFF
--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -240,8 +240,9 @@ class DownloadPushDeleteFileView(views.APIView):
 
         return Response(status=status.HTTP_201_CREATED)
 
+    @transaction.atomic()
     def delete(self, request, projectid, filename):
-        project = Project.objects.get(id=projectid)
+        project = Project.objects.select_for_update().get(id=projectid)
         version_id = request.META.get("HTTP_X_FILE_VERSION")
 
         if version_id:


### PR DESCRIPTION
With parallel requests, the ORM bit me again by caching the old value. I am pretty sure there must be a smarter way of incrementing and decrementing data in the DB, but what I have though so far is not super Django-ish:

This is plain ugly:
```
Project.objects.filter(pk=project.pk).update(file_storage_bytes=F('file_storage_bytes')+file.size)
```