### PR TITLE
Forbid usage of match/case in the codebase

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,4 @@ repos:
     rev: "3.9.0"
     hooks:
       - id: flake8
+        additional_dependencies: [flake8-match==1.0.0]


### PR DESCRIPTION
While useful in a subset of situations, it brings additional cognitive pressure to evaluate if it is used properly.

It's behavior is not intuitive for people coming from other languages and may lead to critical bugs we can just avoid.

The good old if/else served the python users for 30 years, I believe we can keep until we see real limitations.