### PR TITLE
Replace deprecated scale with deploy.replicas

### DIFF
--- a/docker-compose.override.local.yml
+++ b/docker-compose.override.local.yml
@@ -20,7 +20,8 @@ services:
       - redis
 
   worker_wrapper:
-    scale: ${QFIELDCLOUD_WORKER_REPLICAS}
+    deploy:
+      replicas: ${QFIELDCLOUD_WORKER_REPLICAS}
     build:
       args:
         - DEBUG_BUILD=1

--- a/docker-compose.override.test.yml
+++ b/docker-compose.override.test.yml
@@ -24,7 +24,8 @@ services:
     command: python3 -m debugpy --listen 0.0.0.0:5681 manage.py dequeue
     ports:
       - 5681:5681
-    scale: ${QFIELDCLOUD_WORKER_REPLICAS}
+    deploy:
+      replicas: ${QFIELDCLOUD_WORKER_REPLICAS}
 
   db:
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,7 +166,8 @@ services:
       - ${LOG_DIRECTORY}:/log
       - ${TMP_DIRECTORY}:/tmp
     logging: *default-logging
-    scale: ${QFIELDCLOUD_WORKER_REPLICAS}
+    deploy:
+      replicas: ${QFIELDCLOUD_WORKER_REPLICAS}
 
   ofelia:
     image: mcuadros/ofelia:v0.3.4


### PR DESCRIPTION
In the docker compose files `scale:` is used, which is deprecated:
```
WARN[0000] `scale` is deprecated. Use the `deploy.replicas` element 
```
This PR replaces it with deploy.replicas.

Since docker 1.18 Variables of the wrong type (what is the case here) [are casted](https://github.com/docker/compose/pull/5291).