### PR TITLE
Fix backwards compatibility when `QFIELDCLOUD_DEFAULT_TIME_ZONE` is not set

### DIFF
--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -202,7 +202,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = os.environ.get("QFIELDCLOUD_DEFAULT_TIME_ZONE", "Europe/Zurich")
+TIME_ZONE = os.environ.get("QFIELDCLOUD_DEFAULT_TIME_ZONE") or "Europe/Zurich"
 
 USE_I18N = False
 


### PR DESCRIPTION
In theory, we should mark all docker-compose envvars mandatory. But it's not the right moment for that right now, already in the backlog.

Fixes a bug introduced by #587 .