### PR TITLE
Reduce the default Django list per page from 100 to 20 items

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -71,6 +71,9 @@ class ModelAdminEstimateCountMixin:
     # Display '(Show all)' instead of '(<count>)' in search bar
     show_full_result_count = False
 
+    # Overwrite the default Django configuration of 100
+    list_per_page = settings.QFIELDCLOUD_ADMIN_LIST_PER_PAGE
+
 
 class QFieldCloudModelAdmin(ModelAdminEstimateCountMixin, admin.ModelAdmin):
     pass
@@ -1010,6 +1013,7 @@ class OrganizationAdmin(QFieldCloudModelAdmin):
         "organization_owner",
         "date_joined",
     )
+    list_per_page = 10
     list_display = (
         "username",
         "email",

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -415,6 +415,9 @@ QFIELDCLOUD_TEST_SKIP_VIEW_ADMIN_URLS = (
     "/admin/account/emailaddress/admin/export_emails_to_csv/",
 )
 
+# Sets the default admin list view per page, the Django default is 100
+QFIELDCLOUD_ADMIN_LIST_PER_PAGE = 20
+
 # Use pg meta table estimate for pagination and display above n entries
 QFIELDCLOUD_ADMIN_EXACT_COUNT_LIMIT = 10000
 


### PR DESCRIPTION
Bigger lists makes the whole app slower and does not bring a lot of benefits with 100s of thousands of users.