### PR TITLE
Don't throw if project deleted after job instantiation

### DIFF
--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -167,7 +167,7 @@ class JobRun:
                 self.job.project.refresh_from_db()
             except Project.DoesNotExist:
                 logger.info(
-                    f"Running Job and Project were deleted on db after job instantiation"
+                    "Running Job and Project were deleted on db after job instantiation"
                 )
                 self.after_docker_run()
                 return

--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -166,7 +166,7 @@ class JobRun:
             try:
                 self.job.project.refresh_from_db()
             except Project.DoesNotExist:
-                # if the project was deleted on db in the meantime the was also deleted (cascade)
+                # the project and job were deleted on the db in the meantime
                 self.after_docker_run()
                 return
 

--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -166,7 +166,7 @@ class JobRun:
             try:
                 self.job.project.refresh_from_db()
             except Project.DoesNotExist:
-                # the project and job were deleted on the db in the meantime
+                logger.info(f"Running Job and Project were deleted on db after job instantiation")
                 self.after_docker_run()
                 return
 

--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -166,7 +166,9 @@ class JobRun:
             try:
                 self.job.project.refresh_from_db()
             except Project.DoesNotExist:
-                logger.info(f"Running Job and Project were deleted on db after job instantiation")
+                logger.info(
+                    f"Running Job and Project were deleted on db after job instantiation"
+                )
                 self.after_docker_run()
                 return
 

--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -165,12 +165,13 @@ class JobRun:
             # make sure we have reloaded the project, since someone might have changed it already
             try:
                 self.job.project.refresh_from_db()
-                self.job.status = Job.Status.FINISHED
-                self.job.save()
             except Project.DoesNotExist:
-                # if the project was deleted in the meantime, also delete this job
-                self.job.delete()
+                # if the project was deleted on db in the meantime the was also deleted (cascade)
+                self.after_docker_run()
+                return
 
+            self.job.status = Job.Status.FINISHED
+            self.job.save()
             self.after_docker_run()
 
         except Exception as err:


### PR DESCRIPTION
Could reproduce and test locally and works. IMO we don't need to report when user does this.
`logger.info` is not reported to sentry, right?

Maybe we could even cancel the whole process somwhere earlier if project is deleted, but as it is a rare case not worth the effort?