### PR TITLE
Remove filter from user autocompletion

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -1151,11 +1151,7 @@ class UserAdmin(QFieldCloudModelAdmin):
     search_fields = ("username__icontains",)
 
     def get_queryset(self, request: HttpRequest):
-        return (
-            super()
-            .get_queryset(request)
-            .filter(type__in=(User.Type.PERSON, User.Type.ORGANIZATION))
-        )
+        return super().get_queryset(request)
 
     def has_module_permission(self, request: HttpRequest) -> bool:
         # hide this module from Django admin, it is accessible via "Person" and "Organization" as inline edit


### PR DESCRIPTION
closes 592

This filter creates the SQL WHERE Clause, that causes the autocompletion filters to fail. (see [here](https://github.com/opengisch/qfieldcloud/issues/592#issuecomment-1500889942))

Usually, the users are filtered depending on the requirement of the field. 

I checked, the other autocompletion fields. They are still filtering as intended. 

I don't think that there are other side effects, because the class is only used by autocompletion. 