### PR TITLE
Reject job and project creation for unsufficient useraccount

### DIFF
--- a/docker-app/qfieldcloud/core/exceptions.py
+++ b/docker-app/qfieldcloud/core/exceptions.py
@@ -177,12 +177,11 @@ class ReachedMaxOrganizationMembersError(QFieldCloudException):
     status_code = status.HTTP_403_FORBIDDEN
 
 
-class PermissionDeniedInactiveError(QFieldCloudException):
+class AccountInactiveError(QFieldCloudException):
     """
-    Raised when the user has not the required permission for an action,
-    because the useraccount is inactive.
+    Raised when an action is denied because the useraccount is inactive.
     """
 
     code = "permission_denied_inactive"
     message = "Permission denied because the useraccount is inactive"
-    status_code = status.HTTP_402_PAYMENT_REQUIRED
+    status_code = status.HTTP_403_FORBIDDEN

--- a/docker-app/qfieldcloud/core/exceptions.py
+++ b/docker-app/qfieldcloud/core/exceptions.py
@@ -176,6 +176,7 @@ class ReachedMaxOrganizationMembersError(QFieldCloudException):
     message = "Cannot add new organization members, account limit has been reached."
     status_code = status.HTTP_403_FORBIDDEN
 
+
 class PermissionDeniedInactiveError(QFieldCloudException):
     """
     Raised when the user has not the required permission for an action,
@@ -185,4 +186,3 @@ class PermissionDeniedInactiveError(QFieldCloudException):
     code = "permission_denied_inactive"
     message = "Permission denied because the useraccount is inactive"
     status_code = status.HTTP_403_FORBIDDEN
-

--- a/docker-app/qfieldcloud/core/exceptions.py
+++ b/docker-app/qfieldcloud/core/exceptions.py
@@ -178,6 +178,7 @@ class ReachedMaxOrganizationMembersError(QFieldCloudException):
 
 
 class SubscriptionInactiveError(QFieldCloudException):
+    # TODO use PermissionDeniedError instead?
     """Raised when a subscription is inactive"""
 
     code = "subscription_inactive"

--- a/docker-app/qfieldcloud/core/exceptions.py
+++ b/docker-app/qfieldcloud/core/exceptions.py
@@ -177,13 +177,13 @@ class ReachedMaxOrganizationMembersError(QFieldCloudException):
     status_code = status.HTTP_403_FORBIDDEN
 
 
-class AccountInactiveError(QFieldCloudException):
+class InactiveSubscriptionError(QFieldCloudException):
     """
-    Raised when a permission (action) is denied because the useraccount is inactive.
+    Raised when a permission (action) is denied because the useraccount subrscription is inactive.
     """
 
-    code = "permission_denied_inactive"
-    message = "Permission denied because the useraccount is inactive"
+    code = "inactive_subscription"
+    message = "Permission denied because the subscription is inactive"
     status_code = status.HTTP_403_FORBIDDEN
 
 

--- a/docker-app/qfieldcloud/core/exceptions.py
+++ b/docker-app/qfieldcloud/core/exceptions.py
@@ -175,3 +175,14 @@ class ReachedMaxOrganizationMembersError(QFieldCloudException):
     code = "organization_has_max_number_of_members"
     message = "Cannot add new organization members, account limit has been reached."
     status_code = status.HTTP_403_FORBIDDEN
+
+class PermissionDeniedInactiveError(QFieldCloudException):
+    """
+    Raised when the user has not the required permission for an action,
+    because the useraccount is inactive.
+    """
+
+    code = "permission_denied_inactive"
+    message = "Permission denied because the useraccount is inactive"
+    status_code = status.HTTP_403_FORBIDDEN
+

--- a/docker-app/qfieldcloud/core/exceptions.py
+++ b/docker-app/qfieldcloud/core/exceptions.py
@@ -175,12 +175,3 @@ class ReachedMaxOrganizationMembersError(QFieldCloudException):
     code = "organization_has_max_number_of_members"
     message = "Cannot add new organization members, account limit has been reached."
     status_code = status.HTTP_403_FORBIDDEN
-
-
-class SubscriptionInactiveError(QFieldCloudException):
-    # TODO use PermissionDeniedError instead?
-    """Raised when a subscription is inactive"""
-
-    code = "subscription_inactive"
-    message = "Cannot start any work (i.e job) for user with inactive subscription."
-    status_code = status.HTTP_403_FORBIDDEN

--- a/docker-app/qfieldcloud/core/exceptions.py
+++ b/docker-app/qfieldcloud/core/exceptions.py
@@ -175,3 +175,11 @@ class ReachedMaxOrganizationMembersError(QFieldCloudException):
     code = "organization_has_max_number_of_members"
     message = "Cannot add new organization members, account limit has been reached."
     status_code = status.HTTP_403_FORBIDDEN
+
+
+class SubscriptionInactiveError(QFieldCloudException):
+    """Raised when a subscription is inactive"""
+
+    code = "subscription_inactive"
+    message = "Cannot start any work (i.e job) for user with inactive subscription."
+    status_code = status.HTTP_403_FORBIDDEN

--- a/docker-app/qfieldcloud/core/exceptions.py
+++ b/docker-app/qfieldcloud/core/exceptions.py
@@ -179,9 +179,19 @@ class ReachedMaxOrganizationMembersError(QFieldCloudException):
 
 class AccountInactiveError(QFieldCloudException):
     """
-    Raised when an action is denied because the useraccount is inactive.
+    Raised when a permission (action) is denied because the useraccount is inactive.
     """
 
     code = "permission_denied_inactive"
     message = "Permission denied because the useraccount is inactive"
+    status_code = status.HTTP_403_FORBIDDEN
+
+
+class PlanInsufficientError(QFieldCloudException):
+    """
+    Raised when a permission (action) is denied because the useraccount plan is insufficient.
+    """
+
+    code = "permission_denied_plan_insufficient"
+    message = "Permission denied because the useraccount's plan is insufficient"
     status_code = status.HTTP_403_FORBIDDEN

--- a/docker-app/qfieldcloud/core/exceptions.py
+++ b/docker-app/qfieldcloud/core/exceptions.py
@@ -185,4 +185,4 @@ class PermissionDeniedInactiveError(QFieldCloudException):
 
     code = "permission_denied_inactive"
     message = "Permission denied because the useraccount is inactive"
-    status_code = status.HTTP_403_FORBIDDEN
+    status_code = status.HTTP_402_PAYMENT_REQUIRED

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1215,7 +1215,6 @@ class Project(models.Model):
             storage.delete_project_thumbnail(self)
         super().delete(*args, **kwargs)
 
-
     # FIXME merge (mixin?) with Job
     def clean(self) -> None:
         """
@@ -1231,11 +1230,10 @@ class Project(models.Model):
 
         if useraccount.storage_free_bytes < 0:
             raise QuotaError
-        
+
         # FIXME also check/permit online vector data
 
         return super().clean()
-
 
     def save(self, recompute_storage=False, *args, **kwargs):
         self.clean()
@@ -1244,7 +1242,6 @@ class Project(models.Model):
         if recompute_storage:
             self.file_storage_bytes = storage.get_project_file_storage_in_bytes(self.id)
         super().save(*args, **kwargs)
-
 
 
 class ProjectCollaboratorQueryset(models.QuerySet):

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -26,7 +26,7 @@ from django.utils.translation import gettext as _
 from model_utils.managers import InheritanceManager, InheritanceManagerMixin
 from qfieldcloud.core import geodb_utils, utils, validators
 from qfieldcloud.core.exceptions import (
-    PermissionDeniedError,
+    PermissionDeniedInactiveError,
     QuotaError,
     ReachedMaxOrganizationMembersError,
 )
@@ -1225,7 +1225,7 @@ class Project(models.Model):
         current_subscription = useraccount.current_subscription
 
         if not current_subscription.is_active:
-            raise PermissionDeniedError(
+            raise PermissionDeniedInactiveError(
                 _("Cannot create job for user with inactive subscription.")
             )
 
@@ -1588,7 +1588,7 @@ class Job(models.Model):
         current_subscription = useraccount.current_subscription
 
         if not current_subscription.is_active:
-            raise PermissionDeniedError(
+            raise PermissionDeniedInactiveError(
                 _("Cannot create job for user with inactive subscription.")
             )
 
@@ -1599,7 +1599,7 @@ class Job(models.Model):
             self.project.has_online_vector_data
             and not current_subscription.plan.is_external_db_supported
         ):
-            raise PermissionDeniedError(
+            raise PermissionDeniedInactiveError(
                 _(
                     "Cannot create job on project with online vector data and unsupported subscription plan."
                 )

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1557,7 +1557,7 @@ class Job(models.Model):
         or the project has online vector layers (postgis) and his account does not support it
         """
         useraccount = self.created_by.useraccount
-        current_subscription = useraccount.active_subscription
+        current_subscription = useraccount.current_subscription
 
         if not current_subscription.is_active:
             raise ValidationError(

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1604,7 +1604,12 @@ class Job(models.Model):
 
 
 class PackageJob(Job):
+    def clean(self):
+        self.raise_insufficient_subscription()
+        return super().clean()
+
     def save(self, *args, **kwargs):
+        self.clean()
         self.type = self.Type.PACKAGE
         return super().save(*args, **kwargs)
 
@@ -1612,36 +1617,20 @@ class PackageJob(Job):
         verbose_name = "Job: package"
         verbose_name_plural = "Jobs: package"
 
+
+class ProcessProjectfileJob(Job):
     def clean(self):
         self.raise_insufficient_subscription()
         return super().clean()
 
-
     def save(self, *args, **kwargs):
         self.clean()
-        return super().save(*args, **kwargs)
-
-
-
-class ProcessProjectfileJob(Job):
-    def save(self, *args, **kwargs):
         self.type = self.Type.PROCESS_PROJECTFILE
         return super().save(*args, **kwargs)
 
     class Meta:
         verbose_name = "Job: process QGIS project file"
         verbose_name_plural = "Jobs: process QGIS project file"
-
-
-    def clean(self):
-        self.raise_insufficient_subscription()
-        return super().clean()
-
-
-    def save(self, *args, **kwargs):
-        self.clean()
-        return super().save(*args, **kwargs)
-
 
 
 class ApplyJob(Job):

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1560,7 +1560,9 @@ class Job(models.Model):
         current_subscription = useraccount.active_subscription
 
         if not current_subscription.is_active:
-            raise ValidationError(_("Cannot create job for user with inactive subscription."))
+            raise ValidationError(
+                _("Cannot create job for user with inactive subscription.")
+            )
 
         if useraccount.storage_free_bytes < 0:
             raise QuotaError

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -27,6 +27,7 @@ from model_utils.managers import InheritanceManager, InheritanceManagerMixin
 from qfieldcloud.core import geodb_utils, utils, validators
 from qfieldcloud.core.exceptions import (
     AccountInactiveError,
+    PlanInsufficientError,
     QuotaError,
     ReachedMaxOrganizationMembersError,
 )
@@ -1596,7 +1597,7 @@ class Job(models.Model):
             self.project.has_online_vector_data
             and not current_subscription.plan.is_external_db_supported
         ):
-            raise AccountInactiveError(
+            raise PlanInsufficientError(
                 _(
                     "Cannot create job on project with online vector data and unsupported subscription plan."
                 )

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1216,7 +1216,6 @@ class Project(models.Model):
             storage.delete_project_thumbnail(self)
         super().delete(*args, **kwargs)
 
-    # FIXME merge (mixin?) with Job
     def clean(self) -> None:
         """
         Prevent creating new projects if the user is inactive or over quota
@@ -1231,8 +1230,6 @@ class Project(models.Model):
 
         if useraccount.storage_free_bytes < 0:
             raise QuotaError
-
-        # FIXME also check/permit online vector data
 
         return super().clean()
 

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -26,7 +26,7 @@ from django.utils.translation import gettext as _
 from model_utils.managers import InheritanceManager, InheritanceManagerMixin
 from qfieldcloud.core import geodb_utils, utils, validators
 from qfieldcloud.core.exceptions import (
-    AccountInactiveError,
+    InactiveSubscriptionError,
     PlanInsufficientError,
     QuotaError,
     ReachedMaxOrganizationMembersError,
@@ -1224,7 +1224,7 @@ class Project(models.Model):
         current_subscription = useraccount.current_subscription
 
         if not current_subscription.is_active:
-            raise AccountInactiveError(
+            raise InactiveSubscriptionError(
                 _("Cannot create job for user with inactive subscription.")
             )
 
@@ -1583,7 +1583,7 @@ class Job(models.Model):
         current_subscription = useraccount.current_subscription
 
         if not current_subscription.is_active:
-            raise AccountInactiveError(
+            raise InactiveSubscriptionError(
                 _("Cannot create job for user with inactive subscription.")
             )
 

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -26,7 +26,7 @@ from django.utils.translation import gettext as _
 from model_utils.managers import InheritanceManager, InheritanceManagerMixin
 from qfieldcloud.core import geodb_utils, utils, validators
 from qfieldcloud.core.exceptions import (
-    PermissionError,
+    PermissionDeniedError,
     QuotaError,
     ReachedMaxOrganizationMembersError,
 )
@@ -1564,7 +1564,7 @@ class Job(models.Model):
         current_subscription = useraccount.current_subscription
 
         if not current_subscription.is_active:
-            raise PermissionError(
+            raise PermissionDeniedError(
                 _("Cannot create job for user with inactive subscription.")
             )
 
@@ -1575,7 +1575,7 @@ class Job(models.Model):
             self.project.has_online_vector_data
             and not current_subscription.plan.is_external_db_supported
         ):
-            raise PermissionError(
+            raise PermissionDeniedError(
                 _(
                     "Cannot create job on project with online vector data and unsupported subscription plan."
                 )

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -25,7 +25,11 @@ from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
 from model_utils.managers import InheritanceManager, InheritanceManagerMixin
 from qfieldcloud.core import geodb_utils, utils, validators
-from qfieldcloud.core.exceptions import QuotaError, ReachedMaxOrganizationMembersError
+from qfieldcloud.core.exceptions import (
+    PermissionError,
+    QuotaError,
+    ReachedMaxOrganizationMembersError,
+)
 from qfieldcloud.core.utils2 import storage
 from timezone_field import TimeZoneField
 
@@ -1560,7 +1564,7 @@ class Job(models.Model):
         current_subscription = useraccount.current_subscription
 
         if not current_subscription.is_active:
-            raise ValidationError(
+            raise PermissionError(
                 _("Cannot create job for user with inactive subscription.")
             )
 
@@ -1571,7 +1575,7 @@ class Job(models.Model):
             self.project.has_online_vector_data
             and not current_subscription.plan.is_external_db_supported
         ):
-            raise ValidationError(
+            raise PermissionError(
                 _(
                     "Cannot create job on project with online vector data and unsupported subscription plan."
                 )

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1560,7 +1560,7 @@ class Job(models.Model):
         current_subscription = useraccount.active_subscription
 
         if not current_subscription.is_active:
-            raise ValidationError(_("Cannot create job for inactive user."))
+            raise ValidationError(_("Cannot create job for user with inactive subscription."))
 
         if useraccount.storage_free_bytes < 0:
             raise QuotaError

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1576,7 +1576,7 @@ class Job(models.Model):
                 "The job ended in unknown state. Please verify the project is configured properly, try again and contact QFieldCloud support for more information."
             )
 
-    def clean(self) -> None:
+    def raise_insufficient_subscription(self) -> None:
         """
         Prevent creating new jobs if the user is inactive, over quota
         or the project has online vector layers (postgis) and his account does not support it
@@ -1602,12 +1602,6 @@ class Job(models.Model):
                 )
             )
 
-        return super().clean()
-
-    def save(self, *args, **kwargs):
-        self.clean()
-        return super().save(*args, **kwargs)
-
 
 class PackageJob(Job):
     def save(self, *args, **kwargs):
@@ -1618,6 +1612,16 @@ class PackageJob(Job):
         verbose_name = "Job: package"
         verbose_name_plural = "Jobs: package"
 
+    def clean(self):
+        self.raise_insufficient_subscription()
+        return super().clean()
+
+
+    def save(self, *args, **kwargs):
+        self.clean()
+        return super().save(*args, **kwargs)
+
+
 
 class ProcessProjectfileJob(Job):
     def save(self, *args, **kwargs):
@@ -1627,6 +1631,17 @@ class ProcessProjectfileJob(Job):
     class Meta:
         verbose_name = "Job: process QGIS project file"
         verbose_name_plural = "Jobs: process QGIS project file"
+
+
+    def clean(self):
+        self.raise_insufficient_subscription()
+        return super().clean()
+
+
+    def save(self, *args, **kwargs):
+        self.clean()
+        return super().save(*args, **kwargs)
+
 
 
 class ApplyJob(Job):

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -26,7 +26,7 @@ from django.utils.translation import gettext as _
 from model_utils.managers import InheritanceManager, InheritanceManagerMixin
 from qfieldcloud.core import geodb_utils, utils, validators
 from qfieldcloud.core.exceptions import (
-    PermissionDeniedInactiveError,
+    AccountInactiveError,
     QuotaError,
     ReachedMaxOrganizationMembersError,
 )
@@ -1224,7 +1224,7 @@ class Project(models.Model):
         current_subscription = useraccount.current_subscription
 
         if not current_subscription.is_active:
-            raise PermissionDeniedInactiveError(
+            raise AccountInactiveError(
                 _("Cannot create job for user with inactive subscription.")
             )
 
@@ -1585,7 +1585,7 @@ class Job(models.Model):
         current_subscription = useraccount.current_subscription
 
         if not current_subscription.is_active:
-            raise PermissionDeniedInactiveError(
+            raise AccountInactiveError(
                 _("Cannot create job for user with inactive subscription.")
             )
 
@@ -1596,7 +1596,7 @@ class Job(models.Model):
             self.project.has_online_vector_data
             and not current_subscription.plan.is_external_db_supported
         ):
-            raise PermissionDeniedInactiveError(
+            raise AccountInactiveError(
                 _(
                     "Cannot create job on project with online vector data and unsupported subscription plan."
                 )

--- a/docker-app/qfieldcloud/core/tests/test_job.py
+++ b/docker-app/qfieldcloud/core/tests/test_job.py
@@ -1,0 +1,85 @@
+import logging
+from unittest import mock
+
+from django.forms.models import ValidationError
+from qfieldcloud.authentication.models import AuthToken
+from qfieldcloud.core.models import Job, Person, Project
+from qfieldcloud.subscription.models import Subscription
+from rest_framework.test import APITestCase
+
+from .utils import setup_subscription_plans
+
+logging.disable(logging.CRITICAL)
+
+
+class QfcTestCase(APITestCase):
+    def setUp(self):
+        setup_subscription_plans()
+
+        # Create a user
+        self.user1 = Person.objects.create_user(username="user1", password="abc123")
+        self.token1 = AuthToken.objects.get_or_create(user=self.user1)[0]
+
+        # Create a project
+        self.project1 = Project.objects.create(
+            name="project1", owner=self.user1, description="desc", is_public=False
+        )
+
+    def test_create_job_succesfully(self):
+        job = Job.objects.create(
+            type=Job.Type.PACKAGE, project=self.project1, created_by=self.user1
+        )
+
+        self.assertEqual(job.status, Job.Status.PENDING)
+
+    def test_create_job_by_inactive_user(self):
+        subscription = self.user1.useraccount.active_subscription
+        subscription.status = Subscription.Status.INACTIVE_DRAFT
+        subscription.save()
+
+        # Make sure the user is inactive
+        self.assertFalse(subscription.is_active)
+
+        # Cannot create job if user's subscription is inactive
+        with self.assertRaises(ValidationError):
+            Job.objects.create(
+                type=Job.Type.PACKAGE, project=self.project1, created_by=self.user1
+            )
+
+    def test_create_job_if_user_is_over_quota(self):
+        plan = self.user1.useraccount.active_subscription.plan
+
+        # Create a project that uses all the storage
+        more_bytes_than_plan = (plan.storage_mb * 1000 * 1000) + 1
+        Project.objects.create(
+            name="p1",
+            owner=self.user1,
+            file_storage_bytes=more_bytes_than_plan,
+        )
+
+        # Cannot create job if the user's plan is over quota
+        with self.assertRaises(ValidationError):
+            Job.objects.create(
+                type=Job.Type.PACKAGE, project=self.project1, created_by=self.user1
+            )
+
+    def test_create_job_on_project_with_online_vector_data_for_unsupported_user_plan(
+        self,
+    ):
+        # The actual property is tested in qfieldcloud.core.tests.test_packages.QfcTestCase.test_has_no_online_vector_data
+        with mock.patch.object(
+            Project, "has_online_vector_data", new_callable=mock.PropertyMock
+        ) as mock_has_online_vector_data:
+            mock_has_online_vector_data.return_value = True
+            self.assertTrue(self.project1.has_online_vector_data)
+
+            # Make sure the user's plan does not allow online vector data
+            self.assertFalse(
+                self.user1.useraccount.active_subscription.plan.is_external_db_supported
+            )
+
+            # Cannot create job with a project that has online vector data
+            with self.assertRaises(ValidationError):
+                Job.objects.create(
+                    type=Job.Type.PACKAGE, project=self.project1, created_by=self.user1
+                )

--- a/docker-app/qfieldcloud/core/tests/test_job.py
+++ b/docker-app/qfieldcloud/core/tests/test_job.py
@@ -42,7 +42,7 @@ class QfcTestCase(APITestCase):
         self.assertFalse(subscription.is_active)
 
         # Cannot create job if user's subscription is inactive
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(PermissionError):
             Job.objects.create(
                 type=Job.Type.PACKAGE, project=self.project1, created_by=self.user1
             )
@@ -80,7 +80,7 @@ class QfcTestCase(APITestCase):
             )
 
             # Cannot create job with a project that has online vector data
-            with self.assertRaises(ValidationError):
+            with self.assertRaises(PermissionError):
                 Job.objects.create(
                     type=Job.Type.PACKAGE, project=self.project1, created_by=self.user1
                 )

--- a/docker-app/qfieldcloud/core/tests/test_job.py
+++ b/docker-app/qfieldcloud/core/tests/test_job.py
@@ -34,7 +34,7 @@ class QfcTestCase(APITestCase):
         self.assertEqual(job.status, Job.Status.PENDING)
 
     def test_create_job_by_inactive_user(self):
-        subscription = self.user1.useraccount.active_subscription
+        subscription = self.user1.useraccount.current_subscription
         subscription.status = Subscription.Status.INACTIVE_DRAFT
         subscription.save()
 
@@ -48,7 +48,7 @@ class QfcTestCase(APITestCase):
             )
 
     def test_create_job_if_user_is_over_quota(self):
-        plan = self.user1.useraccount.active_subscription.plan
+        plan = self.user1.useraccount.current_subscription.plan
 
         # Create a project that uses all the storage
         more_bytes_than_plan = (plan.storage_mb * 1000 * 1000) + 1
@@ -76,7 +76,7 @@ class QfcTestCase(APITestCase):
 
             # Make sure the user's plan does not allow online vector data
             self.assertFalse(
-                self.user1.useraccount.active_subscription.plan.is_external_db_supported
+                self.user1.useraccount.current_subscription.plan.is_external_db_supported
             )
 
             # Cannot create job with a project that has online vector data

--- a/docker-app/qfieldcloud/core/tests/test_job.py
+++ b/docker-app/qfieldcloud/core/tests/test_job.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 from django.forms.models import ValidationError
 from qfieldcloud.authentication.models import AuthToken
-from qfieldcloud.core.exceptions import QuotaError, PermissionDeniedError
+from qfieldcloud.core.exceptions import QuotaError, PermissionDeniedInactiveError
 from qfieldcloud.core.models import Job, Person, Project
 from qfieldcloud.subscription.models import Subscription
 from rest_framework.test import APITestCase
@@ -42,7 +42,7 @@ class QfcTestCase(APITestCase):
         self.assertFalse(subscription.is_active)
 
         # Cannot create job if user's subscription is inactive
-        with self.assertRaises(PermissionDeniedError):
+        with self.assertRaises(PermissionDeniedInactiveError):
             Job.objects.create(
                 type=Job.Type.PACKAGE, project=self.project1, created_by=self.user1
             )
@@ -80,7 +80,7 @@ class QfcTestCase(APITestCase):
             )
 
             # Cannot create job with a project that has online vector data
-            with self.assertRaises(PermissionDeniedError):
+            with self.assertRaises(PermissionDeniedInactiveError):
                 Job.objects.create(
                     type=Job.Type.PACKAGE, project=self.project1, created_by=self.user1
                 )

--- a/docker-app/qfieldcloud/core/tests/test_job.py
+++ b/docker-app/qfieldcloud/core/tests/test_job.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 from django.forms.models import ValidationError
 from qfieldcloud.authentication.models import AuthToken
-from qfieldcloud.core.exceptions import QuotaError
+from qfieldcloud.core.exceptions import QuotaError, PermissionDeniedError
 from qfieldcloud.core.models import Job, Person, Project
 from qfieldcloud.subscription.models import Subscription
 from rest_framework.test import APITestCase
@@ -42,7 +42,7 @@ class QfcTestCase(APITestCase):
         self.assertFalse(subscription.is_active)
 
         # Cannot create job if user's subscription is inactive
-        with self.assertRaises(PermissionError):
+        with self.assertRaises(PermissionDeniedError):
             Job.objects.create(
                 type=Job.Type.PACKAGE, project=self.project1, created_by=self.user1
             )
@@ -80,7 +80,7 @@ class QfcTestCase(APITestCase):
             )
 
             # Cannot create job with a project that has online vector data
-            with self.assertRaises(PermissionError):
+            with self.assertRaises(PermissionDeniedError):
                 Job.objects.create(
                     type=Job.Type.PACKAGE, project=self.project1, created_by=self.user1
                 )

--- a/docker-app/qfieldcloud/core/tests/test_job.py
+++ b/docker-app/qfieldcloud/core/tests/test_job.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 from django.forms.models import ValidationError
 from qfieldcloud.authentication.models import AuthToken
+from qfieldcloud.core.exceptions import QuotaError
 from qfieldcloud.core.models import Job, Person, Project
 from qfieldcloud.subscription.models import Subscription
 from rest_framework.test import APITestCase
@@ -58,7 +59,7 @@ class QfcTestCase(APITestCase):
         )
 
         # Cannot create job if the user's plan is over quota
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(QuotaError):
             Job.objects.create(
                 type=Job.Type.PACKAGE, project=self.project1, created_by=self.user1
             )

--- a/docker-app/qfieldcloud/core/tests/test_job.py
+++ b/docker-app/qfieldcloud/core/tests/test_job.py
@@ -2,7 +2,11 @@ import logging
 from unittest import mock
 
 from qfieldcloud.authentication.models import AuthToken
-from qfieldcloud.core.exceptions import AccountInactiveError, QuotaError
+from qfieldcloud.core.exceptions import (
+    AccountInactiveError,
+    PlanInsufficientError,
+    QuotaError,
+)
 from qfieldcloud.core.models import Job, Person, Project
 from qfieldcloud.subscription.models import Subscription
 from rest_framework.test import APITestCase
@@ -79,7 +83,7 @@ class QfcTestCase(APITestCase):
             )
 
             # Cannot create job with a project that has online vector data
-            with self.assertRaises(AccountInactiveError):
+            with self.assertRaises(PlanInsufficientError):
                 Job.objects.create(
                     type=Job.Type.PACKAGE, project=self.project1, created_by=self.user1
                 )

--- a/docker-app/qfieldcloud/core/tests/test_job.py
+++ b/docker-app/qfieldcloud/core/tests/test_job.py
@@ -2,7 +2,7 @@ import logging
 from unittest import mock
 
 from qfieldcloud.authentication.models import AuthToken
-from qfieldcloud.core.exceptions import PermissionDeniedInactiveError, QuotaError
+from qfieldcloud.core.exceptions import AccountInactiveError, QuotaError
 from qfieldcloud.core.models import Job, Person, Project
 from qfieldcloud.subscription.models import Subscription
 from rest_framework.test import APITestCase
@@ -41,7 +41,7 @@ class QfcTestCase(APITestCase):
         self.assertFalse(subscription.is_active)
 
         # Cannot create job if user's subscription is inactive
-        with self.assertRaises(PermissionDeniedInactiveError):
+        with self.assertRaises(AccountInactiveError):
             Job.objects.create(
                 type=Job.Type.PACKAGE, project=self.project1, created_by=self.user1
             )
@@ -79,7 +79,7 @@ class QfcTestCase(APITestCase):
             )
 
             # Cannot create job with a project that has online vector data
-            with self.assertRaises(PermissionDeniedInactiveError):
+            with self.assertRaises(AccountInactiveError):
                 Job.objects.create(
                     type=Job.Type.PACKAGE, project=self.project1, created_by=self.user1
                 )

--- a/docker-app/qfieldcloud/core/tests/test_job.py
+++ b/docker-app/qfieldcloud/core/tests/test_job.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core.exceptions import (
-    AccountInactiveError,
+    InactiveSubscriptionError,
     PlanInsufficientError,
     QuotaError,
 )
@@ -72,13 +72,13 @@ class QfcTestCase(APITestCase):
         self.assertFalse(subscription.is_active)
 
         # Cannot create package job if user's subscription is inactive
-        with self.assertRaises(AccountInactiveError):
+        with self.assertRaises(InactiveSubscriptionError):
             PackageJob.objects.create(
                 project=self.project1, created_by=self.user1, type=Job.Type.PACKAGE
             )
 
         # Cannot create processprojectfile job if user's subscription is inactive
-        with self.assertRaises(AccountInactiveError):
+        with self.assertRaises(InactiveSubscriptionError):
             ProcessProjectfileJob.objects.create(
                 type=Job.Type.PROCESS_PROJECTFILE,
                 project=self.project1,

--- a/docker-app/qfieldcloud/core/tests/test_job.py
+++ b/docker-app/qfieldcloud/core/tests/test_job.py
@@ -1,9 +1,8 @@
 import logging
 from unittest import mock
 
-from django.forms.models import ValidationError
 from qfieldcloud.authentication.models import AuthToken
-from qfieldcloud.core.exceptions import QuotaError, PermissionDeniedInactiveError
+from qfieldcloud.core.exceptions import PermissionDeniedInactiveError, QuotaError
 from qfieldcloud.core.models import Job, Person, Project
 from qfieldcloud.subscription.models import Subscription
 from rest_framework.test import APITestCase

--- a/docker-app/qfieldcloud/core/tests/test_project.py
+++ b/docker-app/qfieldcloud/core/tests/test_project.py
@@ -1,9 +1,8 @@
 import logging
 
 from django.core.exceptions import ValidationError
-from qfieldcloud.subscription.models import Subscription
-from qfieldcloud.core.exceptions import QuotaError, PermissionDeniedInactiveError
 from qfieldcloud.authentication.models import AuthToken
+from qfieldcloud.core.exceptions import PermissionDeniedInactiveError, QuotaError
 from qfieldcloud.core.models import (
     Organization,
     OrganizationMember,
@@ -13,6 +12,7 @@ from qfieldcloud.core.models import (
     Team,
     TeamMember,
 )
+from qfieldcloud.subscription.models import Subscription
 from rest_framework import status
 from rest_framework.test import APITransactionTestCase
 

--- a/docker-app/qfieldcloud/core/tests/test_project.py
+++ b/docker-app/qfieldcloud/core/tests/test_project.py
@@ -496,10 +496,11 @@ class QfcTestCase(APITransactionTestCase):
         # Cannot create project if user's subscription is inactive
         with self.assertRaises(AccountInactiveError):
             Project.objects.create(
-                type=Project.Type.PACKAGE, project=self.project1, created_by=self.user1
+                name="p1",
+                owner=self.user1,
             )
 
-    def test_create_job_if_user_is_over_quota(self):
+    def test_create_project_if_user_is_over_quota(self):
         plan = self.user1.useraccount.current_subscription.plan
 
         # Create a project that uses all the storage
@@ -510,8 +511,9 @@ class QfcTestCase(APITransactionTestCase):
             file_storage_bytes=more_bytes_than_plan,
         )
 
-        # Cannot create job if the user's plan is over quota
+        # Cannot create another project if the user's plan is over quota
         with self.assertRaises(QuotaError):
             Project.objects.create(
-                type=Project.Type.PACKAGE, project=self.project1, created_by=self.user1
+                name="p1",
+                owner=self.user1,
             )

--- a/docker-app/qfieldcloud/core/tests/test_project.py
+++ b/docker-app/qfieldcloud/core/tests/test_project.py
@@ -2,7 +2,7 @@ import logging
 
 from django.core.exceptions import ValidationError
 from qfieldcloud.authentication.models import AuthToken
-from qfieldcloud.core.exceptions import PermissionDeniedInactiveError, QuotaError
+from qfieldcloud.core.exceptions import AccountInactiveError, QuotaError
 from qfieldcloud.core.models import (
     Organization,
     OrganizationMember,
@@ -494,7 +494,7 @@ class QfcTestCase(APITransactionTestCase):
         self.assertFalse(subscription.is_active)
 
         # Cannot create project if user's subscription is inactive
-        with self.assertRaises(PermissionDeniedInactiveError):
+        with self.assertRaises(AccountInactiveError):
             Project.objects.create(
                 type=Project.Type.PACKAGE, project=self.project1, created_by=self.user1
             )

--- a/docker-app/qfieldcloud/core/tests/test_project.py
+++ b/docker-app/qfieldcloud/core/tests/test_project.py
@@ -2,7 +2,7 @@ import logging
 
 from django.core.exceptions import ValidationError
 from qfieldcloud.authentication.models import AuthToken
-from qfieldcloud.core.exceptions import AccountInactiveError, QuotaError
+from qfieldcloud.core.exceptions import InactiveSubscriptionError, QuotaError
 from qfieldcloud.core.models import (
     Organization,
     OrganizationMember,
@@ -494,7 +494,7 @@ class QfcTestCase(APITransactionTestCase):
         self.assertFalse(subscription.is_active)
 
         # Cannot create project if user's subscription is inactive
-        with self.assertRaises(AccountInactiveError):
+        with self.assertRaises(InactiveSubscriptionError):
             Project.objects.create(
                 name="p1",
                 owner=self.user1,

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -275,7 +275,7 @@ if SENTRY_DSN:
 
     def before_send(event, hint):
         from qfieldcloud.core.exceptions import (
-            AccountInactiveError,
+            InactiveSubscriptionError,
             PlanInsufficientError,
             ProjectAlreadyExistsError,
             QuotaError,
@@ -287,7 +287,7 @@ if SENTRY_DSN:
             ProjectAlreadyExistsError,
             QuotaError,
             PlanInsufficientError,
-            AccountInactiveError,
+            InactiveSubscriptionError,
         )
 
         if "exc_info" in hint:

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -275,14 +275,14 @@ if SENTRY_DSN:
     SENTRY_SAMPLE_RATE = float(os.environ.get("SENTRY_SAMPLE_RATE", 1))
 
     def before_send(event, hint):
-        from qfieldcloud.core.exceptions import ProjectAlreadyExistsError, QuotaError, PermissionDeniedError
+        from qfieldcloud.core.exceptions import ProjectAlreadyExistsError, QuotaError, PermissionDeniedInactiveError
         from rest_framework.exceptions import ValidationError
 
         ignored_exceptions = (
             ValidationError,
             ProjectAlreadyExistsError,
             QuotaError,
-            PermissionDeniedError # TODO discuss need new Exception?
+            PermissionDeniedInactiveError
         )
 
         if "exc_info" in hint:

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -13,7 +13,6 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 import os
 from datetime import timedelta
 
-
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
@@ -275,14 +274,18 @@ if SENTRY_DSN:
     SENTRY_SAMPLE_RATE = float(os.environ.get("SENTRY_SAMPLE_RATE", 1))
 
     def before_send(event, hint):
-        from qfieldcloud.core.exceptions import ProjectAlreadyExistsError, QuotaError, PermissionDeniedInactiveError
+        from qfieldcloud.core.exceptions import (
+            PermissionDeniedInactiveError,
+            ProjectAlreadyExistsError,
+            QuotaError,
+        )
         from rest_framework.exceptions import ValidationError
 
         ignored_exceptions = (
             ValidationError,
             ProjectAlreadyExistsError,
             QuotaError,
-            PermissionDeniedInactiveError
+            PermissionDeniedInactiveError,
         )
 
         if "exc_info" in hint:

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -276,6 +276,7 @@ if SENTRY_DSN:
     def before_send(event, hint):
         from qfieldcloud.core.exceptions import (
             AccountInactiveError,
+            PlanInsufficientError,
             ProjectAlreadyExistsError,
             QuotaError,
         )
@@ -285,6 +286,7 @@ if SENTRY_DSN:
             ValidationError,
             ProjectAlreadyExistsError,
             QuotaError,
+            PlanInsufficientError,
             AccountInactiveError,
         )
 

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -275,7 +275,7 @@ if SENTRY_DSN:
 
     def before_send(event, hint):
         from qfieldcloud.core.exceptions import (
-            PermissionDeniedInactiveError,
+            AccountInactiveError,
             ProjectAlreadyExistsError,
             QuotaError,
         )
@@ -285,7 +285,7 @@ if SENTRY_DSN:
             ValidationError,
             ProjectAlreadyExistsError,
             QuotaError,
-            PermissionDeniedInactiveError,
+            AccountInactiveError,
         )
 
         if "exc_info" in hint:

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 import os
 from datetime import timedelta
 
+
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
@@ -274,13 +275,14 @@ if SENTRY_DSN:
     SENTRY_SAMPLE_RATE = float(os.environ.get("SENTRY_SAMPLE_RATE", 1))
 
     def before_send(event, hint):
-        from qfieldcloud.core.exceptions import ProjectAlreadyExistsError, QuotaError
+        from qfieldcloud.core.exceptions import ProjectAlreadyExistsError, QuotaError, PermissionDeniedError
         from rest_framework.exceptions import ValidationError
 
         ignored_exceptions = (
             ValidationError,
             ProjectAlreadyExistsError,
             QuotaError,
+            PermissionDeniedError # TODO discuss need new Exception?
         )
 
         if "exc_info" in hint:

--- a/docker-app/qfieldcloud/subscription/exceptions.py
+++ b/docker-app/qfieldcloud/subscription/exceptions.py
@@ -1,6 +1,21 @@
+from rest_framework import status
+from core.exceptions import QFieldCloudException
+
 class SubscriptionException(Exception):
     ...
 
 
-class NotPremiumPlanException(SubscriptionException):
-    ...
+class NotPremiumPlanException(QFieldCloudException):
+    """Raised when TODO ..."""
+
+    # TODO code = ""
+    # message = ""
+    status_code = status.HTTP_403_FORBIDDEN
+
+
+# TODO Rather put here? (from core.exceptions)
+# class SubscriptionInactiveError(QFieldCloudException):
+# 
+# class ReachedMaxOrganizationMembersError(QFieldCloudException):
+# 
+# class QuotaError(QFieldCloudException):

--- a/docker-app/qfieldcloud/subscription/exceptions.py
+++ b/docker-app/qfieldcloud/subscription/exceptions.py
@@ -1,21 +1,6 @@
-from rest_framework import status
-from core.exceptions import QFieldCloudException
-
 class SubscriptionException(Exception):
     ...
 
 
-class NotPremiumPlanException(QFieldCloudException):
-    """Raised when TODO ..."""
-
-    # TODO code = ""
-    # message = ""
-    status_code = status.HTTP_403_FORBIDDEN
-
-
-# TODO Rather put here? (from core.exceptions)
-# class SubscriptionInactiveError(QFieldCloudException):
-# 
-# class ReachedMaxOrganizationMembersError(QFieldCloudException):
-# 
-# class QuotaError(QFieldCloudException):
+class NotPremiumPlanException(SubscriptionException):
+    ...


### PR DESCRIPTION
Summary:
Synchronization is not possible if user account unsufficient (inactive, over qouta, no online layers) -> PackageJob NOT created. Pushes are always possible -> ApplyJob created. Poject creation is rejected from WebUI and QFsync -> ProcessprojectfileJob NOT created, Project NOT created.

Further ...
- [x] prevent project creation at all? (currently an invalid project is created from QFieldSync)
- [x] add new meaningful errors (analog to QuotaError)
- [x] add new ticket QF-2668 (disable action buttons on webUI)
- [x] added ticket / followup PR to reorder exceptions https://github.com/opengisch/qfieldcloud/pull/639

New behaviour:
**useraccount inactive**
Qfieldsync: on create new project when  => `Permission denied .. useraccount is inactive`
-> no Job or Project is created at all.
![image](https://user-images.githubusercontent.com/21113500/236183157-686f8343-978f-412f-abd3-2d1aa6d18cf4.png)

Qfield: 
 - push: always works
 - synchronize: ` ... Permission denied because useraccount inactive ... `
 
![image](https://user-images.githubusercontent.com/21113500/236201498-3c0a270a-6eae-4047-94e5-18762252ff9b.png)

**online vector layers on account that doesn't support**

Qfield:
- push: always works
- synchronize: `... user accounts'plan is insufficient ... `
![image](https://user-images.githubusercontent.com/21113500/236218218-b2327433-43a2-4202-83ae-abbc79dae847.png)

**useraccount over quota**

Qfield:
- push: always works
- synchronize: `... Quota error ... `
![image](https://user-images.githubusercontent.com/21113500/236221875-e1991782-22ef-4c28-884b-03d5af698a09.png)


