### PR TITLE
Workaround vector layer type rename in QGIS 3.30

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1119,9 +1119,11 @@ class Project(models.Model):
         has_online_vector_layers = False
 
         for layer_data in layers_by_id.values():
-            if layer_data.get("type_name") == "VectorLayer" and not layer_data.get(
-                "filename", ""
-            ):
+            # NOTE QGIS 3.30.x returns "Vector", while previous versions return "VectorLayer"
+            if layer_data.get("type_name") in (
+                "VectorLayer",
+                "Vector",
+            ) and not layer_data.get("filename", ""):
                 has_online_vector_layers = True
                 break
 


### PR DESCRIPTION
Calling `QgsVectorLayer().type().name` QGIS 3.30.x returns "Vector", while previous versions return "VectorLayer"

Related issue: https://github.com/qgis/QGIS/issues/53023

Fixes regression introduced in #637 .