### PR TITLE
Always accept file uploads from Qfield

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1144,9 +1144,7 @@ class Project(models.Model):
 
     @property
     def status(self) -> Status:
-        # NOTE the status is NOT stored in the db, because it might be outdated.
-        # One reason is after_docker_run() might still be running which means that
-        # e.g has_online_vector_data might be outdated for some seconds.
+        # NOTE the status is NOT stored in the db, because it might be outdated
         if (
             Job.objects.filter(
                 project=self, status__in=[Job.Status.QUEUED, Job.Status.STARTED]

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1144,9 +1144,9 @@ class Project(models.Model):
 
     @property
     def status(self) -> Status:
-        # NOTE the status is NOT stored in the db, because it might be outdated
+        # NOTE the status is NOT stored in the db, because it might be outdated.
         # One reason is after_docker_run() might still be running which means that
-        # e.g has_onlie_vector_data might be outdated for some seconds
+        # e.g has_online_vector_data might be outdated for some seconds.
         if (
             Job.objects.filter(
                 project=self, status__in=[Job.Status.QUEUED, Job.Status.STARTED]

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1574,13 +1574,12 @@ class Job(models.Model):
                 "The job ended in unknown state. Please verify the project is configured properly, try again and contact QFieldCloud support for more information."
             )
 
-    def check_can_be_created(self, ignore_online_layers=False):
-        # Check if the object is being created
+    def check_can_be_created(self):
         from qfieldcloud.core.permissions_utils import (
             check_supported_regarding_owner_account,
         )
 
-        check_supported_regarding_owner_account(self.project, ignore_online_layers)
+        check_supported_regarding_owner_account(self.project)
 
     def clean(self):
         if self._state.adding:
@@ -1605,8 +1604,10 @@ class PackageJob(Job):
 
 class ProcessProjectfileJob(Job):
     def check_can_be_created(self):
-        # exclude online layers from check to allow users to adapt project after downgrading plan
-        super().check_can_be_created(ignore_online_layers=True)
+        # Exclude from checks (for now) because else User cannot adapt after
+        # Downgrading.
+        # TODO create a more sophisticated model where job creation is prevented under certain conditions
+        pass
 
     def save(self, *args, **kwargs):
         self.type = self.Type.PROCESS_PROJECTFILE

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1145,6 +1145,8 @@ class Project(models.Model):
     @property
     def status(self) -> Status:
         # NOTE the status is NOT stored in the db, because it might be outdated
+        # One reason is after_docker_run() might still be running which means that
+        # e.g has_onlie_vector_data might be outdated for some seconds
         if (
             Job.objects.filter(
                 project=self, status__in=[Job.Status.QUEUED, Job.Status.STARTED]

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1606,9 +1606,8 @@ class PackageJob(Job):
 
 class ProcessProjectfileJob(Job):
     def check_can_be_created(self):
-        # Exclude from checks (for now) because else User cannot adapt after
-        # Downgrading.
-        # TODO create a more sophisticated model where job creation is prevented under certain conditions
+        # Alsways create jobs because they are cheap
+        # and is always good to have updated metadata
         pass
 
     def save(self, *args, **kwargs):

--- a/docker-app/qfieldcloud/core/permissions_utils.py
+++ b/docker-app/qfieldcloud/core/permissions_utils.py
@@ -872,7 +872,6 @@ def is_supported_regarding_owner_account(project: Project) -> bool:
 
 
 def can_always_upload_files(client_type) -> bool:
-    # ... not matter what
     return client_type in (
         AuthToken.ClientType.QFIELD,
         AuthToken.ClientType.WORKER,

--- a/docker-app/qfieldcloud/core/permissions_utils.py
+++ b/docker-app/qfieldcloud/core/permissions_utils.py
@@ -2,6 +2,7 @@ from typing import List, Literal, Union
 
 from deprecated import deprecated
 from django.utils.translation import gettext as _
+from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core.models import (
     Delta,
     Organization,
@@ -861,6 +862,14 @@ def check_supported_regarding_owner_account(
                 )
             )
     return True
+
+
+def can_always_upload_files(client_type) -> bool:
+    # ... not matter what
+    return client_type in (
+        AuthToken.ClientType.QFIELD,
+        AuthToken.ClientType.WORKER,
+    )
 
 
 def is_supported_regarding_owner_account(project: Project) -> bool:

--- a/docker-app/qfieldcloud/core/tests/test_file_upload_policy.py
+++ b/docker-app/qfieldcloud/core/tests/test_file_upload_policy.py
@@ -10,7 +10,12 @@ from qfieldcloud.subscription.models import SubscriptionStatus
 from rest_framework import status
 from rest_framework.test import APITransactionTestCase
 
-from .utils import setup_subscription_plans, testdata_path, wait_for_project_ok_status
+from .utils import (
+    setup_subscription_plans,
+    testdata_path,
+    wait_for_has_online_vector_data,
+    wait_for_project_ok_status,
+)
 
 logging.disable(logging.CRITICAL)
 
@@ -113,8 +118,7 @@ class QfcTestCase(APITransactionTestCase):
         self.assertTrue(status.is_success(response.status_code))
         wait_for_project_ok_status(self.project)
 
-        self.project.refresh_from_db()
-        self.assertTrue(self.project.has_online_vector_data)
+        self.assertTrue(wait_for_has_online_vector_data(self.project))
 
         # Check user has no storage left
         self.assertTrue(self.user.useraccount.storage_free_bytes < 0)
@@ -137,7 +141,6 @@ class QfcTestCase(APITransactionTestCase):
         response = self.add_qgis_project_file()
         self.assertTrue(status.is_success(response.status_code))
         wait_for_project_ok_status(self.project)
-        self.assertTrue(self.project.has_online_vector_data)
 
         # Check user has no storage left
         self.assertTrue(self.user.useraccount.storage_free_bytes < 0)

--- a/docker-app/qfieldcloud/core/tests/test_file_upload_policy.py
+++ b/docker-app/qfieldcloud/core/tests/test_file_upload_policy.py
@@ -58,6 +58,8 @@ class QfcTestCase(APITransactionTestCase):
         subscription.save()
         # Check user has inactive subscription
         self.assertFalse(account.current_subscription.is_active)
+        # Check user cannot have online vector data
+        self.assertFalse(subscription.plan.is_external_db_supported)
 
         plan = subscription.plan
         plan.storage_mb = 0

--- a/docker-app/qfieldcloud/core/tests/test_file_upload_policy.py
+++ b/docker-app/qfieldcloud/core/tests/test_file_upload_policy.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import pdb
 
 import psycopg2
 from qfieldcloud.authentication.models import AuthToken
@@ -112,10 +111,10 @@ class QfcTestCase(APITransactionTestCase):
 
         response = self.add_qgis_project_file()
         self.assertTrue(status.is_success(response.status_code))
-        #pdb.set_trace()
         wait_for_project_ok_status(self.project)
 
-        # self.assertTrue(self.project.has_online_vector_data)
+        self.project.refresh_from_db()
+        self.assertTrue(self.project.has_online_vector_data)
 
         # Check user has no storage left
         self.assertTrue(self.user.useraccount.storage_free_bytes < 0)

--- a/docker-app/qfieldcloud/core/tests/test_file_upload_policy.py
+++ b/docker-app/qfieldcloud/core/tests/test_file_upload_policy.py
@@ -11,9 +11,9 @@ from rest_framework import status
 from rest_framework.test import APITransactionTestCase
 
 from .utils import (
+    assert_eventually_project_has,
     setup_subscription_plans,
     testdata_path,
-    wait_for_has_online_vector_data,
     wait_for_project_ok_status,
 )
 
@@ -120,7 +120,11 @@ class QfcTestCase(APITransactionTestCase):
         self.assertTrue(status.is_success(response.status_code))
         wait_for_project_ok_status(self.project)
 
-        self.assertTrue(wait_for_has_online_vector_data(self.project))
+        self.assertTrue(
+            assert_eventually_project_has(
+                self.project, {"has_online_vector_data": True}
+            )
+        )
 
         # Check user has no storage left
         self.assertTrue(self.user.useraccount.storage_free_bytes < 0)

--- a/docker-app/qfieldcloud/core/tests/test_file_upload_policy.py
+++ b/docker-app/qfieldcloud/core/tests/test_file_upload_policy.py
@@ -63,6 +63,8 @@ class QfcTestCase(APITransactionTestCase):
         subscription.save()
         # Check user has inactive subscription
         self.assertFalse(account.current_subscription.is_active)
+        # Check user cannot have online vector data
+        self.assertFalse(subscription.plan.is_external_db_supported)
 
         plan = subscription.plan
         plan.storage_mb = 0

--- a/docker-app/qfieldcloud/core/tests/test_file_upload_policy.py
+++ b/docker-app/qfieldcloud/core/tests/test_file_upload_policy.py
@@ -120,11 +120,7 @@ class QfcTestCase(APITransactionTestCase):
         self.assertTrue(status.is_success(response.status_code))
         wait_for_project_ok_status(self.project)
 
-        self.assertTrue(
-            assert_eventually_project_has(
-                self.project, {"has_online_vector_data": True}
-            )
-        )
+        assert_eventually_project_has(self.project, {"has_online_vector_data": True})
 
         # Check user has no storage left
         self.assertTrue(self.user.useraccount.storage_free_bytes < 0)

--- a/docker-app/qfieldcloud/core/tests/test_file_upload_policy.py
+++ b/docker-app/qfieldcloud/core/tests/test_file_upload_policy.py
@@ -1,0 +1,132 @@
+import logging
+import os
+
+import psycopg2
+from qfieldcloud.authentication.models import AuthToken
+from qfieldcloud.core.geodb_utils import delete_db_and_role
+from qfieldcloud.core.models import ApplyJob, Geodb, Job, PackageJob, Person, Project
+from qfieldcloud.subscription.exceptions import SubscriptionException
+from qfieldcloud.subscription.models import SubscriptionStatus
+from rest_framework import status
+from rest_framework.test import APITransactionTestCase
+
+from .utils import setup_subscription_plans, testdata_path
+
+logging.disable(logging.CRITICAL)
+
+
+class QfcTestCase(APITransactionTestCase):
+    def setUp(self):
+        setup_subscription_plans()
+
+        # Create a user
+        self.user = Person.objects.create_user(username="user", password="abc123")
+
+        self.token_qfield = AuthToken.objects.get_or_create(
+            user=self.user,
+            client_type=AuthToken.ClientType.QFIELD,
+            # user_agent="qfield|dev", # FIXME TODO remove?
+        )[0]
+
+        self.token_worker = AuthToken.objects.get_or_create(
+            user=self.user,
+            client_type=AuthToken.ClientType.WORKER,
+        )[0]
+
+        # Create a project
+        self.project1 = Project.objects.create(
+            name="project1", is_public=False, owner=self.user
+        )
+
+        delete_db_and_role("test", self.user.username)
+
+        self.geodb = Geodb.objects.create(
+            user=self.user,
+            dbname="test",
+            hostname="geodb",
+            port=5432,
+        )
+
+        self.conn = psycopg2.connect(
+            dbname="test",
+            user=os.environ.get("GEODB_USER"),
+            password=os.environ.get("GEODB_PASSWORD"),
+            host="geodb",
+            port=5432,
+        )
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_push_file_to_qfield_always_allowed(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token_qfield.key)
+
+        # FIXME TODO 'worker'
+        self.assertEqual(self.token_qfield.client_type, AuthToken.ClientType.QFIELD)
+
+        # Check 'project owner' and 'client' user are same to ensure all scenarios
+        self.assertEqual(self.project1.owner.id, self.token_qfield.user.id)
+        account = self.user.useraccount
+        subscription = account.current_subscription
+        subscription.status = SubscriptionStatus.INACTIVE_DRAFT
+        subscription.save()
+
+        self.assertFalse(account.current_subscription.is_active)
+
+        plan = subscription.plan
+        plan.storage_mb = 0
+        plan.save()
+        self.assertEqual(account.storage_free_bytes, 0)
+
+        # Create a project that uses all the storage
+        # more_bytes_than_plan = (plan.storage_mb * 1000 * 1000) + 1
+        # Project.objects.create(
+        #     name="p1",
+        #     owner=self.user,
+        #     file_storage_bytes=more_bytes_than_plan,
+        # )
+
+        # A cross check that no delta apply or package jobs can be created on the project
+        with self.assertRaises(SubscriptionException):
+            PackageJob.objects.create(
+                type=Job.Type.PACKAGE, project=self.project1, created_by=self.user
+            )
+        with self.assertRaises(SubscriptionException):
+            ApplyJob.objects.create(
+                type=Job.Type.DELTA_APPLY, project=self.project1, created_by=self.user
+            )
+
+        cur = self.conn.cursor()
+
+        cur.execute(
+            """
+            CREATE TABLE point (
+                id          integer,
+                geometry   geometry(point, 2056)
+            );
+            """
+        )
+
+        self.conn.commit()
+
+        cur.execute(
+            """
+            INSERT INTO point(id, geometry)
+            VALUES(1, ST_GeomFromText('POINT(2725505 1121435)', 2056));
+            """
+        )
+        self.conn.commit()
+
+        # Add the qgis project
+        file = testdata_path("delta/project2.qgs")
+        response = self.client.post(
+            "/api/v1/files/{}/project.qgs/".format(self.project1.id),
+            {"file": open(file, "rb")},
+            format="multipart",
+        )
+        self.assertTrue(status.is_success(response.status_code))
+
+        response = self.client.post(
+            "/api/v1/qfield-files/export/{}/".format(self.project1.id)
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/docker-app/qfieldcloud/core/tests/test_file_upload_policy.py
+++ b/docker-app/qfieldcloud/core/tests/test_file_upload_policy.py
@@ -1,5 +1,7 @@
 import logging
 import os
+import pdb
+from time import sleep
 
 import psycopg2
 from qfieldcloud.authentication.models import AuthToken
@@ -16,27 +18,35 @@ logging.disable(logging.CRITICAL)
 
 
 class QfcTestCase(APITransactionTestCase):
+    """
+    The current policy is that a user can always push/upload a file to QFieldCloud
+    from the field, i.e. from Qfield. Also we already running jobs can always upload
+    files. Therefore we check for the client type in the post request.
+    """
+
     def setUp(self):
         setup_subscription_plans()
 
         # Create a user
         self.user = Person.objects.create_user(username="user", password="abc123")
 
+        # Create a project
+        self.project = Project.objects.create(
+            name="project1", is_public=False, owner=self.user
+        )
+
+        # We ensure the project owner and the post request sender are the same
+        # because (currently) we want the request to succeed no matter who sends it.
         self.token_qfield = AuthToken.objects.get_or_create(
-            user=self.user,
+            user=self.project.owner,
             client_type=AuthToken.ClientType.QFIELD,
             # user_agent="qfield|dev", # FIXME TODO remove?
         )[0]
 
         self.token_worker = AuthToken.objects.get_or_create(
-            user=self.user,
+            user=self.project.owner,
             client_type=AuthToken.ClientType.WORKER,
         )[0]
-
-        # Create a project
-        self.project1 = Project.objects.create(
-            name="project1", is_public=False, owner=self.user
-        )
 
         delete_db_and_role("test", self.user.username)
 
@@ -54,47 +64,6 @@ class QfcTestCase(APITransactionTestCase):
             host="geodb",
             port=5432,
         )
-
-    def tearDown(self):
-        self.conn.close()
-
-    def test_push_file_to_qfield_always_allowed(self):
-        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token_qfield.key)
-
-        # FIXME TODO 'worker'
-        self.assertEqual(self.token_qfield.client_type, AuthToken.ClientType.QFIELD)
-
-        # Check 'project owner' and 'client' user are same to ensure all scenarios
-        self.assertEqual(self.project1.owner.id, self.token_qfield.user.id)
-        account = self.user.useraccount
-        subscription = account.current_subscription
-        subscription.status = SubscriptionStatus.INACTIVE_DRAFT
-        subscription.save()
-
-        self.assertFalse(account.current_subscription.is_active)
-
-        plan = subscription.plan
-        plan.storage_mb = 0
-        plan.save()
-        self.assertEqual(account.storage_free_bytes, 0)
-
-        # Create a project that uses all the storage
-        # more_bytes_than_plan = (plan.storage_mb * 1000 * 1000) + 1
-        # Project.objects.create(
-        #     name="p1",
-        #     owner=self.user,
-        #     file_storage_bytes=more_bytes_than_plan,
-        # )
-
-        # A cross check that no delta apply or package jobs can be created on the project
-        with self.assertRaises(SubscriptionException):
-            PackageJob.objects.create(
-                type=Job.Type.PACKAGE, project=self.project1, created_by=self.user
-            )
-        with self.assertRaises(SubscriptionException):
-            ApplyJob.objects.create(
-                type=Job.Type.DELTA_APPLY, project=self.project1, created_by=self.user
-            )
 
         cur = self.conn.cursor()
 
@@ -117,16 +86,61 @@ class QfcTestCase(APITransactionTestCase):
         )
         self.conn.commit()
 
-        # Add the qgis project
+    def tearDown(self):
+        self.conn.close()
+
+    def test_push_file_to_qfield_always_allowed(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token_qfield.key)
+
+        # FIXME TODO 'worker'
+        self.assertEqual(self.token_qfield.client_type, AuthToken.ClientType.QFIELD)
+
+        # Check 'project owner' and 'client' user are same to ensure all scenarios
+        self.assertEqual(self.project.owner.id, self.token_qfield.user.id)
+        account = self.user.useraccount
+        subscription = account.current_subscription
+        subscription.status = SubscriptionStatus.INACTIVE_DRAFT
+        subscription.save()
+
+        self.assertFalse(account.current_subscription.is_active)
+
+        plan = subscription.plan
+        plan.storage_mb = 0
+        plan.save()
+        self.assertEqual(account.storage_free_bytes, 0)
+
+        self.add_qfis_project_file()
+        # Create a project that uses all the storage
+        # more_bytes_than_plan = (plan.storage_mb * 1000 * 1000) + 1
+        # Project.objects.create(
+        #     name="p1",
+        #     owner=self.user,
+        #     file_storage_bytes=more_bytes_than_plan,
+        # )
+
+        # A cross check that no delta apply or package jobs can be created on the project
+        with self.assertRaises(SubscriptionException):
+            PackageJob.objects.create(
+                type=Job.Type.PACKAGE, project=self.project, created_by=self.user
+            )
+        with self.assertRaises(SubscriptionException):
+            ApplyJob.objects.create(
+                type=Job.Type.DELTA_APPLY, project=self.project, created_by=self.user
+            )
+
+        response = self.client.post(
+            "/api/v1/qfield-files/export/{}/".format(self.project.id)
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def add_qfis_project_file(self):
         file = testdata_path("delta/project2.qgs")
         response = self.client.post(
-            "/api/v1/files/{}/project.qgs/".format(self.project1.id),
+            "/api/v1/files/{}/project.qgs/".format(self.project.id),
             {"file": open(file, "rb")},
             format="multipart",
         )
         self.assertTrue(status.is_success(response.status_code))
-
-        response = self.client.post(
-            "/api/v1/qfield-files/export/{}/".format(self.project1.id)
-        )
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        sleep(5)
+        self.project.refresh_from_db()
+        self.assertTrue(self.project.has_online_vector_data)

--- a/docker-app/qfieldcloud/core/tests/test_job.py
+++ b/docker-app/qfieldcloud/core/tests/test_job.py
@@ -141,16 +141,16 @@ class QfcTestCase(APITestCase):
             self.check_can_update_existing_jobs()
 
     def check_cannot_create_jobs(self, error):
+        # Can still create processprojectfile job
+        ProcessProjectfileJob.objects.create(
+            type=Job.Type.PROCESS_PROJECTFILE,
+            project=self.project1,
+            created_by=self.user1,
+        )
+
         with self.assertRaises(error):
             PackageJob.objects.create(
                 type=Job.Type.PACKAGE, project=self.project1, created_by=self.user1
-            )
-
-        with self.assertRaises(error):
-            ProcessProjectfileJob.objects.create(
-                type=Job.Type.PROCESS_PROJECTFILE,
-                project=self.project1,
-                created_by=self.user1,
             )
 
         with self.assertRaises(error):

--- a/docker-app/qfieldcloud/core/tests/test_packages.py
+++ b/docker-app/qfieldcloud/core/tests/test_packages.py
@@ -27,12 +27,7 @@ from qfieldcloud.core.utils2.storage import get_stored_package_ids
 from rest_framework import status
 from rest_framework.test import APITransactionTestCase
 
-from .utils import (
-    assert_eventually_project_has,
-    setup_subscription_plans,
-    testdata_path,
-    wait_for_project_ok_status,
-)
+from .utils import setup_subscription_plans, testdata_path, wait_for_project_ok_status
 
 logging.disable(logging.CRITICAL)
 
@@ -378,8 +373,9 @@ class QfcTestCase(APITransactionTestCase):
         )
 
     def test_needs_repackaging_without_online_vector(self):
+        self.project1.refresh_from_db()
         # newly uploaded project should always need to be packaged at least once
-        assert_eventually_project_has(self.project1, {"needs_repackaging": True})
+        self.assertTrue(self.project1.needs_repackaging)
 
         self.upload_files_and_check_package(
             token=self.token1.key,
@@ -398,8 +394,9 @@ class QfcTestCase(APITransactionTestCase):
             ],
         )
 
+        self.project1.refresh_from_db()
         # no longer needs repackaging since geopackage layers cannot change without deltas/reupload
-        assert_eventually_project_has(self.project1, {"needs_repackaging": False})
+        self.assertFalse(self.project1.needs_repackaging)
 
         self.upload_files(
             self.token1.key,
@@ -422,8 +419,9 @@ class QfcTestCase(APITransactionTestCase):
         )
         self.conn.commit()
 
+        self.project1.refresh_from_db()
         # newly uploaded project should always need to be packaged at least once
-        assert_eventually_project_has(self.project1, {"needs_repackaging": True})
+        self.assertTrue(self.project1.needs_repackaging)
 
         self.upload_files_and_check_package(
             token=self.token1.key,
@@ -439,8 +437,9 @@ class QfcTestCase(APITransactionTestCase):
             ],
         )
 
+        self.project1.refresh_from_db()
         # projects with online vector layer should always show as it needs repackaging
-        assert_eventually_project_has(self.project1, {"needs_repackaging": True})
+        self.assertTrue(self.project1.needs_repackaging)
 
     def test_connects_via_pgservice(self):
         cur = self.conn.cursor()
@@ -497,6 +496,7 @@ class QfcTestCase(APITransactionTestCase):
             "project_details"
         ]["layers_by_id"]
 
+        self.assertEqual(last_process_job.status, Job.Status.FINISHED)
         self.assertTrue(
             layers_by_id["point_6b900fa7_af52_4082_bbff_6077f4a91d02"]["is_valid"]
         )
@@ -515,7 +515,8 @@ class QfcTestCase(APITransactionTestCase):
         )
 
         wait_for_project_ok_status(self.project1)
-        assert_eventually_project_has(self.project1, {"has_online_vector_data": True})
+
+        self.project1.refresh_from_db()
 
         self.assertTrue(self.project1.has_online_vector_data)
 
@@ -529,7 +530,6 @@ class QfcTestCase(APITransactionTestCase):
         )
 
         wait_for_project_ok_status(self.project1)
-        assert_eventually_project_has(self.project1, {"has_online_vector_data": False})
 
         self.project1.refresh_from_db()
 

--- a/docker-app/qfieldcloud/core/tests/test_packages.py
+++ b/docker-app/qfieldcloud/core/tests/test_packages.py
@@ -488,6 +488,7 @@ class QfcTestCase(APITransactionTestCase):
         )
 
         wait_for_project_ok_status(self.project1)
+        self.project1.refresh_from_db()
 
         last_process_job = Job.objects.filter(type=Job.Type.PROCESS_PROJECTFILE).latest(
             "updated_at"
@@ -514,7 +515,7 @@ class QfcTestCase(APITransactionTestCase):
         )
 
         wait_for_project_ok_status(self.project1)
-        assert_eventually_project_has(self.project, {"has_online_vector_data": True})
+        assert_eventually_project_has(self.project1, {"has_online_vector_data": True})
 
         self.assertTrue(self.project1.has_online_vector_data)
 
@@ -528,7 +529,7 @@ class QfcTestCase(APITransactionTestCase):
         )
 
         wait_for_project_ok_status(self.project1)
-        assert_eventually_project_has(self.project, {"has_online_vector_data": False})
+        assert_eventually_project_has(self.project1, {"has_online_vector_data": False})
 
         self.project1.refresh_from_db()
 

--- a/docker-app/qfieldcloud/core/tests/test_qfield_file.py
+++ b/docker-app/qfieldcloud/core/tests/test_qfield_file.py
@@ -3,7 +3,6 @@ import logging
 import os
 import tempfile
 import time
-from qfieldcloud.subscription.exceptions import SubscriptionException
 
 import psycopg2
 import requests
@@ -11,6 +10,7 @@ from django.http.response import HttpResponse, HttpResponseRedirect
 from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core.geodb_utils import delete_db_and_role
 from qfieldcloud.core.models import ApplyJob, Geodb, Job, PackageJob, Person, Project
+from qfieldcloud.subscription.exceptions import SubscriptionException
 from qfieldcloud.subscription.models import SubscriptionStatus
 from rest_framework import status
 from rest_framework.test import APITransactionTestCase

--- a/docker-app/qfieldcloud/core/tests/test_qfield_file.py
+++ b/docker-app/qfieldcloud/core/tests/test_qfield_file.py
@@ -9,9 +9,7 @@ import requests
 from django.http.response import HttpResponse, HttpResponseRedirect
 from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core.geodb_utils import delete_db_and_role
-from qfieldcloud.core.models import ApplyJob, Geodb, Job, PackageJob, Person, Project
-from qfieldcloud.subscription.exceptions import SubscriptionException
-from qfieldcloud.subscription.models import SubscriptionStatus
+from qfieldcloud.core.models import Geodb, Job, PackageJob, Person, Project
 from rest_framework import status
 from rest_framework.test import APITransactionTestCase
 
@@ -29,11 +27,7 @@ class QfcTestCase(APITransactionTestCase):
 
         self.user2 = Person.objects.create_user(username="user2", password="abc123")
 
-        self.token1 = AuthToken.objects.get_or_create(
-            user=self.user1,
-            client_type=AuthToken.ClientType.QFIELD,
-            user_agent="qfield|dev",
-        )[0]
+        self.token1 = AuthToken.objects.get_or_create(user=self.user1)[0]
 
         # Create a project
         self.project1 = Project.objects.create(
@@ -89,79 +83,6 @@ class QfcTestCase(APITransactionTestCase):
         except Exception:
             self.assertTrue(status.is_success(response.status_code), response.content)
 
-    def test_push_file_to_qfield_always_allowed(self):
-        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
-
-        # FIXME TODO 'worker'
-        self.assertEqual(self.token1.client_type, AuthToken.ClientType.QFIELD)
-
-        # Check 'project owner' and 'client' user are same to ensure all scenarios
-        self.assertEqual(self.project1.owner.id, self.token1.user.id)
-        account = self.user1.useraccount
-        subscription = account.current_subscription
-        subscription.status = SubscriptionStatus.INACTIVE_DRAFT
-        subscription.save()
-
-        self.assertFalse(account.current_subscription.is_active)
-
-        plan = subscription.plan
-        plan.storage_mb = 0
-        plan.save()
-        self.assertEqual(account.storage_free_bytes, 0)
-
-        # Create a project that uses all the storage
-        # more_bytes_than_plan = (plan.storage_mb * 1000 * 1000) + 1
-        # Project.objects.create(
-        #     name="p1",
-        #     owner=self.user1,
-        #     file_storage_bytes=more_bytes_than_plan,
-        # )
-
-        # A cross check that no delta apply or package jobs can be created on the project
-        with self.assertRaises(SubscriptionException):
-            PackageJob.objects.create(
-                type=Job.Type.PACKAGE, project=self.project1, created_by=self.user1
-            )
-        with self.assertRaises(SubscriptionException):
-            ApplyJob.objects.create(
-                type=Job.Type.DELTA_APPLY, project=self.project1, created_by=self.user1
-            )
-
-        cur = self.conn.cursor()
-
-        cur.execute(
-            """
-            CREATE TABLE point (
-                id          integer,
-                geometry   geometry(point, 2056)
-            );
-            """
-        )
-
-        self.conn.commit()
-
-        cur.execute(
-            """
-            INSERT INTO point(id, geometry)
-            VALUES(1, ST_GeomFromText('POINT(2725505 1121435)', 2056));
-            """
-        )
-        self.conn.commit()
-
-        # Add the qgis project
-        file = testdata_path("delta/project2.qgs")
-        response = self.client.post(
-            "/api/v1/files/{}/project.qgs/".format(self.project1.id),
-            {"file": open(file, "rb")},
-            format="multipart",
-        )
-        self.assertTrue(status.is_success(response.status_code))
-
-        response = self.client.post(
-            "/api/v1/qfield-files/export/{}/".format(self.project1.id)
-        )
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
     def test_list_files_for_qfield(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
 
@@ -198,7 +119,6 @@ class QfcTestCase(APITransactionTestCase):
         response = self.client.post(
             "/api/v1/qfield-files/export/{}/".format(self.project1.id)
         )
-
         self.assertTrue(status.is_success(response.status_code))
 
         # Wait for the worker to finish

--- a/docker-app/qfieldcloud/core/tests/utils.py
+++ b/docker-app/qfieldcloud/core/tests/utils.py
@@ -94,7 +94,7 @@ def wait_for_project_ok_status(project: Project, wait_s: int = 30):
 
     has_pending_jobs = True
     for _ in range(wait_s):
-        if Job.objects.filter(project=project, status=Job.Status.PENDING).exists():
+        if not Job.objects.filter(project=project, status=Job.Status.PENDING).exists():
             has_pending_jobs = False
             break
 

--- a/docker-app/qfieldcloud/core/tests/utils.py
+++ b/docker-app/qfieldcloud/core/tests/utils.py
@@ -6,8 +6,6 @@ from typing import IO, Iterable, Union
 from qfieldcloud.core.models import Job, Project, User
 from qfieldcloud.subscription.models import Plan, Subscription
 
-# FIXME from unittest import fail
-
 
 def testdata_path(path):
     basepath = os.path.dirname(os.path.abspath(__file__))
@@ -119,4 +117,4 @@ def wait_for_project_ok_status(project: Project, wait_s: int = 30):
 
 
 def fail(msg):
-    raise Exception(msg)
+    raise AssertionError(msg or "Test case failed")

--- a/docker-app/qfieldcloud/core/tests/utils.py
+++ b/docker-app/qfieldcloud/core/tests/utils.py
@@ -84,7 +84,10 @@ def get_random_file(mb: int) -> IO:
 
 def wait_for_project_ok_status(project: Project, wait_s: int = 30):
     """
-    Helper that waits for any jobs of the project to finish"""
+    Helper that waits for any jobs (worker) of the project to finish.
+    NOTE this does not mean the project is updated yet as there
+    is some processing to be done and saved to the project in the app.
+    """
     jobs = Job.objects.filter(project=project).exclude(
         status__in=[Job.Status.FAILED, Job.Status.FINISHED]
     )

--- a/docker-app/qfieldcloud/core/tests/utils.py
+++ b/docker-app/qfieldcloud/core/tests/utils.py
@@ -1,10 +1,11 @@
 import io
 import os
-from typing import IO, Iterable, Union
 from time import sleep
+from typing import IO, Iterable, Union
 
-from qfieldcloud.core.models import User, Project, Job
+from qfieldcloud.core.models import Job, Project, User
 from qfieldcloud.subscription.models import Plan, Subscription
+
 # FIXME from unittest import fail
 
 
@@ -85,7 +86,7 @@ def get_random_file(mb: int) -> IO:
 
 def wait_for_project_ok_status(project: Project, wait_s: int = 30):
     """
-    Helper that waits for any jobs of the project to finish """
+    Helper that waits for any jobs of the project to finish"""
     jobs = Job.objects.filter(project=project).exclude(
         status__in=[Job.Status.FAILED, Job.Status.FINISHED]
     )
@@ -95,10 +96,7 @@ def wait_for_project_ok_status(project: Project, wait_s: int = 30):
 
     has_no_pending_jobs = False
     for _ in range(wait_s):
-        if (
-            Job.objects.filter(project=project, status=Job.Status.PENDING).count()
-            == 0
-        ):
+        if Job.objects.filter(project=project, status=Job.Status.PENDING).count() == 0:
             has_no_pending_jobs = True
             break
 

--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -167,15 +167,7 @@ class DownloadPushDeleteFileView(views.APIView):
 
         request_file = request.FILES.get("file")
 
-        if not permissions_utils.can_always_upload_files(request.auth.client_type):
-            # Accept file uploads from QField or delta_apply jobs no matter what
-            file_size_bytes = request_file.size
-            quota_left_bytes = project.owner.useraccount.storage_free_bytes
-
-            if file_size_bytes > quota_left_bytes:
-                raise QuotaError(
-                    f"Requiring {file_size_bytes} bytes of storage but only {quota_left_bytes} bytes available."
-                )
+        permissions_utils.check_can_upload_file(project, request.auth.client_type, request_file.size)
 
         old_object = get_project_file_with_versions(project.id, filename)
         sha256sum = utils.get_sha256(request_file)

--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -12,7 +12,6 @@ from qfieldcloud.core.utils2.storage import (
     get_attachment_dir_prefix,
     purge_old_file_versions,
 )
-from qfieldcloud.subscription.exceptions import QuotaError
 from rest_framework import permissions, status, views
 from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
@@ -167,7 +166,9 @@ class DownloadPushDeleteFileView(views.APIView):
 
         request_file = request.FILES.get("file")
 
-        permissions_utils.check_can_upload_file(project, request.auth.client_type, request_file.size)
+        permissions_utils.check_can_upload_file(
+            project, request.auth.client_type, request_file.size
+        )
 
         old_object = get_project_file_with_versions(project.id, filename)
         sha256sum = utils.get_sha256(request_file)

--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -4,7 +4,6 @@ from pathlib import PurePath
 import qfieldcloud.core.utils2 as utils2
 from django.db import transaction
 from django.utils import timezone
-from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core import exceptions, permissions_utils, utils
 from qfieldcloud.core.models import Job, ProcessProjectfileJob, Project
 from qfieldcloud.core.utils import S3ObjectVersion, get_project_file_with_versions
@@ -168,12 +167,7 @@ class DownloadPushDeleteFileView(views.APIView):
 
         request_file = request.FILES.get("file")
 
-        client_type = request.auth.client_type
-
-        if client_type not in (
-            AuthToken.ClientType.QFIELD,
-            AuthToken.ClientType.WORKER,
-        ):
+        if not permissions_utils.can_always_upload_files(request.auth.client_type):
             # Accept file uploads from QField or delta_apply jobs no matter what
             file_size_bytes = request_file.size
             quota_left_bytes = project.owner.useraccount.storage_free_bytes

--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -4,6 +4,7 @@ from pathlib import PurePath
 import qfieldcloud.core.utils2 as utils2
 from django.db import transaction
 from django.utils import timezone
+from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core import exceptions, permissions_utils, utils
 from qfieldcloud.core.models import Job, ProcessProjectfileJob, Project
 from qfieldcloud.core.utils import S3ObjectVersion, get_project_file_with_versions
@@ -167,13 +168,20 @@ class DownloadPushDeleteFileView(views.APIView):
 
         request_file = request.FILES.get("file")
 
-        file_size_bytes = request_file.size
-        quota_left_bytes = project.owner.useraccount.storage_free_bytes
+        client_type = request.auth.client_type
 
-        if file_size_bytes > quota_left_bytes:
-            raise QuotaError(
-                f"Requiring {file_size_bytes} bytes of storage but only {quota_left_bytes} bytes available."
-            )
+        if client_type not in (
+            AuthToken.ClientType.QFIELD,
+            AuthToken.ClientType.WORKER,
+        ):
+            # Accept file uploads from QField or delta_apply jobs no matter what
+            file_size_bytes = request_file.size
+            quota_left_bytes = project.owner.useraccount.storage_free_bytes
+
+            if file_size_bytes > quota_left_bytes:
+                raise QuotaError(
+                    f"Requiring {file_size_bytes} bytes of storage but only {quota_left_bytes} bytes available."
+                )
 
         old_object = get_project_file_with_versions(project.id, filename)
         sha256sum = utils.get_sha256(request_file)

--- a/docker-app/qfieldcloud/core/views/qfield_files_views.py
+++ b/docker-app/qfieldcloud/core/views/qfield_files_views.py
@@ -45,7 +45,6 @@ class PackageView(views.APIView):
     permission_classes = [permissions.IsAuthenticated, PackageViewPermissions]
 
     def post(self, request, projectid):
-        request.user
 
         project_obj = Project.objects.get(id=projectid)
 

--- a/docker-app/qfieldcloud/core/views/qfield_files_views.py
+++ b/docker-app/qfieldcloud/core/views/qfield_files_views.py
@@ -7,7 +7,7 @@ from django.utils.decorators import method_decorator
 from drf_yasg.utils import swagger_auto_schema
 from qfieldcloud.core import exceptions, permissions_utils, serializers, utils
 from qfieldcloud.core.models import PackageJob, Project
-from qfieldcloud.core.permissions_utils import is_supported_regarding_owner_account
+from qfieldcloud.core.permissions_utils import is_supported_regarding_owner_account, check_supported_regarding_owner_account
 from rest_framework import permissions, views
 from rest_framework.response import Response
 
@@ -21,7 +21,9 @@ class PackageViewPermissions(permissions.BasePermission):
             return False
         user = request.user
 
-        return permissions_utils.can_read_files(user, project) and is_supported_regarding_owner_account(project)
+        check_supported_regarding_owner_account(project)
+
+        return permissions_utils.can_read_files(user, project)
 
 
 @method_decorator(

--- a/docker-app/qfieldcloud/core/views/qfield_files_views.py
+++ b/docker-app/qfieldcloud/core/views/qfield_files_views.py
@@ -7,6 +7,7 @@ from django.utils.decorators import method_decorator
 from drf_yasg.utils import swagger_auto_schema
 from qfieldcloud.core import exceptions, permissions_utils, serializers, utils
 from qfieldcloud.core.models import PackageJob, Project
+from qfieldcloud.core.permissions_utils import check_supported_regarding_owner_account
 from rest_framework import permissions, views
 from rest_framework.response import Response
 
@@ -46,6 +47,10 @@ class PackageView(views.APIView):
 
         if not project_obj.project_filename:
             raise exceptions.NoQGISProjectError()
+
+        # NOTE fail early, only for performance reasons
+        # TODO maybe can be implemented somewhere generic
+        check_supported_regarding_owner_account(project_obj)
 
         # Check if active packaging job already exists
         # TODO: !!!!!!!!!!!! cache results for some minutes

--- a/docker-app/qfieldcloud/core/views/qfield_files_views.py
+++ b/docker-app/qfieldcloud/core/views/qfield_files_views.py
@@ -7,7 +7,7 @@ from django.utils.decorators import method_decorator
 from drf_yasg.utils import swagger_auto_schema
 from qfieldcloud.core import exceptions, permissions_utils, serializers, utils
 from qfieldcloud.core.models import PackageJob, Project
-from qfieldcloud.core.permissions_utils import is_supported_regarding_owner_account, check_supported_regarding_owner_account
+from qfieldcloud.core.permissions_utils import check_supported_regarding_owner_account
 from rest_framework import permissions, views
 from rest_framework.response import Response
 

--- a/docker-app/qfieldcloud/core/views/qfield_files_views.py
+++ b/docker-app/qfieldcloud/core/views/qfield_files_views.py
@@ -21,8 +21,6 @@ class PackageViewPermissions(permissions.BasePermission):
             return False
         user = request.user
 
-        check_supported_regarding_owner_account(project)
-
         return permissions_utils.can_read_files(user, project)
 
 
@@ -47,6 +45,7 @@ class PackageView(views.APIView):
     def post(self, request, projectid):
 
         project_obj = Project.objects.get(id=projectid)
+        check_supported_regarding_owner_account(project_obj)
 
         if not project_obj.project_filename:
             raise exceptions.NoQGISProjectError()


### PR DESCRIPTION
This PR adds:
- in `files_views.py` that we do not throw QoutaError if client_type is `worker` or `qfield`
- in `qfield_files_views.py` throw early before packaging for qfield
- in `models.py` that we never throw on ProcessProjectFileJob

The rest is testing related because https://github.com/opengisch/qfieldcloud/pull/655 still needs some fixes