### PR TITLE
Debug `EmptyContentError: Empty content`

### DIFF
--- a/docker-app/qfieldcloud/core/exceptions.py
+++ b/docker-app/qfieldcloud/core/exceptions.py
@@ -75,6 +75,15 @@ class EmptyContentError(QFieldCloudException):
     status_code = status.HTTP_503_SERVICE_UNAVAILABLE
 
 
+class MultipleContentsError(QFieldCloudException):
+    """Raised when a request contains multiple files
+    (i.e. when it should contain at most one)"""
+
+    code = "multiple_contents"
+    message = "Multiple contents"
+    status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+
+
 class ObjectNotFoundError(QFieldCloudException):
     """Raised when a requested object doesn't exist
     (e.g. wrong project id into the request)"""

--- a/docker-app/qfieldcloud/core/middleware/requests.py
+++ b/docker-app/qfieldcloud/core/middleware/requests.py
@@ -1,0 +1,19 @@
+def attach_keys(get_response):
+    """
+    QF-2540
+    Annotate request with a str representation of relevant fields, so as to obtain a diff
+    by comparing with the post-serialized request later in the callstack.
+    """
+
+    def middleware(request):
+        request_attributes = {
+            "file_key": str(request.FILES.keys()),
+            "meta": str(request.META),
+        }
+        if "file" in request.FILES.keys():
+            request_attributes["files"] = request.FILES.getlist("file")
+        request.attached_keys = str(request_attributes)
+        response = get_response(request)
+        return response
+
+    return middleware

--- a/docker-app/qfieldcloud/core/utils2/sentry.py
+++ b/docker-app/qfieldcloud/core/utils2/sentry.py
@@ -10,12 +10,11 @@ def report_serialization_diff_to_sentry(
     name: str, pre_serialization: str, post_serialization: str, buffer: StringIO
 ):
     """
-    QF-2540 |
-    Send the report to Sentry.
+    Sends a report to sentry to debug QF-2540. The report includes request information from before and after middleware handle the request as well as a traceback.
 
     Args:
-        pre_serialization: str representing important keys on request before serialization and middleware.
-        post_serialization: str representing important keys on request after serialization and middleware.
+        pre_serialization: str representing the request `files` keys and meta information before serialization and middleware.
+        post_serialization: str representing the request `files` keys and meta information after serialization and middleware.
         buffer: StringIO buffer from which to extract traceback capturing callstack ahead of the calling function.
     """
 

--- a/docker-app/qfieldcloud/core/utils2/sentry.py
+++ b/docker-app/qfieldcloud/core/utils2/sentry.py
@@ -1,12 +1,12 @@
 import logging
 from io import StringIO
 
-from sentry_sdk import configure_scope
+import sentry_sdk
 
 logger = logging.getLogger(__name__)
 
 
-def report_to_sentry(
+def report_serialization_diff_to_sentry(
     name: str, pre_serialization: str, post_serialization: str, buffer: StringIO
 ):
     """
@@ -17,7 +17,7 @@ def report_to_sentry(
     traceback = bytes(buffer.getvalue(), encoding="utf-8")
     report = f"Pre:\n{pre_serialization}\n\nPost:{post_serialization}"
 
-    with configure_scope() as scope:
+    with sentry_sdk.configure_scope() as scope:
         try:
             filename = f"{name}_contents.txt"
             scope.add_attachment(bytes=bytes(report), filename=filename)

--- a/docker-app/qfieldcloud/core/utils2/sentry.py
+++ b/docker-app/qfieldcloud/core/utils2/sentry.py
@@ -10,8 +10,13 @@ def report_serialization_diff_to_sentry(
     name: str, pre_serialization: str, post_serialization: str, buffer: StringIO
 ):
     """
-    QF-2540
-    Send the report to Sentry
+    QF-2540 |
+    Send the report to Sentry.
+
+    Args:
+        pre_serialization: str representing important keys on request before serialization and middleware.
+        post_serialization: str representing important keys on request after serialization and middleware.
+        buffer: StringIO buffer from which to extract traceback capturing callstack ahead of the calling function.
     """
 
     traceback = bytes(buffer.getvalue(), encoding="utf-8")

--- a/docker-app/qfieldcloud/core/utils2/sentry.py
+++ b/docker-app/qfieldcloud/core/utils2/sentry.py
@@ -1,0 +1,31 @@
+import logging
+from io import StringIO
+
+from sentry_sdk import configure_scope
+
+logger = logging.getLogger(__name__)
+
+
+def report_to_sentry(
+    name: str, pre_serialization: str, post_serialization: str, buffer: StringIO
+):
+    """
+    QF-2540
+    Send the report to Sentry
+    """
+
+    traceback = bytes(buffer.getvalue(), encoding="utf-8")
+    report = f"Pre:\n{pre_serialization}\n\nPost:{post_serialization}"
+
+    with configure_scope() as scope:
+        try:
+            filename = f"{name}_contents.txt"
+            scope.add_attachment(bytes=bytes(report), filename=filename)
+
+            filename = f"{name}_traceback.txt"
+            scope.add_attachment(
+                bytes=traceback,
+                filename=filename,
+            )
+        except Exception as error:
+            logging.error(f"Unable to send file to Sentry: failed on {error}")

--- a/docker-app/qfieldcloud/core/utils2/sentry.py
+++ b/docker-app/qfieldcloud/core/utils2/sentry.py
@@ -28,4 +28,5 @@ def report_to_sentry(
                 filename=filename,
             )
         except Exception as error:
+            sentry_sdk.capture_exception(error)
             logging.error(f"Unable to send file to Sentry: failed on {error}")

--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -11,7 +11,7 @@ from qfieldcloud.core import exceptions, permissions_utils, utils
 from qfieldcloud.core.models import Job, ProcessProjectfileJob, Project
 from qfieldcloud.core.utils import S3ObjectVersion, get_project_file_with_versions
 from qfieldcloud.core.utils2.audit import LogEntry, audit
-from qfieldcloud.core.utils2.sentry import report_to_sentry
+from qfieldcloud.core.utils2.sentry import report_serialization_diff_to_sentry
 from qfieldcloud.core.utils2.storage import (
     get_attachment_dir_prefix,
     purge_old_file_versions,
@@ -166,8 +166,7 @@ class DownloadPushDeleteFileView(views.APIView):
             logging.warning(missing_error)
 
             # QF-2540
-            # Report to sentry
-            report_to_sentry(
+            report_serialization_diff_to_sentry(
                 # using the 'X-Request-Id' added to the request by RequestIDMiddleware
                 name=f"{request.META.get('X-Request-Id')}_{projectid}",
                 pre_serialization=request.attached_keys,

--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -139,7 +139,6 @@ class DownloadPushDeleteFileView(views.APIView):
 
     # TODO refactor this function by moving the actual upload and Project model updates to library function outside the view
     def post(self, request, projectid, filename, format=None):
-        """Handle POST requests."""
 
         if len(request.FILES.getlist("file")) > 1:
             raise exceptions.MultipleContentsError()

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -109,7 +109,6 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    "log_request_id.middleware.RequestIDMiddleware",
     "debug_toolbar.middleware.DebugToolbarMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -117,6 +116,8 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "qfieldcloud.core.middleware.requests.attach_keys",  # QF-2540: Inspecting request after Django middlewares
+    "log_request_id.middleware.RequestIDMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django_currentuser.middleware.ThreadLocalUserMiddleware",


### PR DESCRIPTION
This PR uploads to Sentry a string representation of some fields on `request.data` which _might_ be meddled with by serializers/middlewares (one pre- and one post-serialization representation, which together can be used to identify suspicious differences). 

The reasoning is: if we have differences and also miss files, then the cause of the missing files might manifest in the differences.

This PR also sends a 50-line long traceback allowing to follow calls to Django Middleware functions. This is useful in cases Sentry's built-in traceback falls short.

The hope is that these artifacts will help pinpoint the cause of the missing files error.

In addition to this debugging goal the PR adds logic for dealing with uploads featuring too many files and the corresponding unit test.

__Part 1 (extracting data and handling exceptions)__
- [x] rule out multipart boundary
- [x] add logs to sentry for inspecting data
- [x] request and report to sentry

__Part 2 (reproducing)__
- try to reproduce on a trimmed-down stack to determine if a middleware triggers the consumption of the request.data iterator-like object.

_outdated1_:
Since the `request.data` attribute features either `file` and `files` as a key depending on whether one or multiple files are multi-parted, I want to see if by any chance the multi-part boundaries mislead QField into considering a single file as many, leading to the absence of the `file` key.

_outdated2:_

__Plan__
This PR extracts and send to Sentry the following data:

from request.FILES:

> 'files': 'dict_keys([...])', 

from rquest.data: 

> {'data': '<QueryDict: {...}>'

from request.META:

> 'meta': "{'HTTP_COOKIE': '', 'PATH_INFO': '/api/v1/files/de17bad7-7e40-4f1a-8950-aa834f5d5a8f/file.txt/', 'REMOTE_ADDR': '127.0.0.1', 'REQUEST_METHOD': 'POST', 'SCRIPT_NAME': '', 'SERVER_NAME': 'testserver', 'SERVER_PORT': '80', 'SERVER_PROTOCOL': 'HTTP/1.1', 'wsgi.version': (1, 0), 'wsgi.url_scheme': 'http', 'wsgi.input': <django.test.client.FakePayload object at 0x7fe84a8b3280>, 'wsgi.errors': <_io.BytesIO object at 0x7fe84b430630>, 'wsgi.multiprocess': True, 'wsgi.multithread': False, 'wsgi.run_once': False, 'CONTENT_LENGTH': '20', 'CONTENT_TYPE': 'multipart/form-data; boundary=BoUnDaRyStRiNg; charset=utf-8', 'QUERY_STRING': '', 'HTTP_AUTHORIZATION': 'Token EwInbGXFOFfMC8Q9TgmB2H11mDivT7w3e6HVls2fFipJdWbgbTyWUVp9hOY0eeq5DbG5y1UT5gQPVz7WPgofq94MAeLX89PnFkrf'}"}
