### PR TITLE
Added managed_by and activeness in Subscription QuerySet

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -182,7 +182,7 @@ class UserManager(InheritanceManagerMixin, DjangoUserManager):
     def get_queryset(self):
         return super().get_queryset().select_subclasses()
 
-    def managed_by(self, user_id: int):
+    def owned_by(self, user_id: int):
         return self.filter(
             Q(pk=user_id) | Q(organization__organization_owner_id=user_id)
         )

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -182,6 +182,11 @@ class UserManager(InheritanceManagerMixin, DjangoUserManager):
     def get_queryset(self):
         return super().get_queryset().select_subclasses()
 
+    def managed_by(self, user_id: int):
+        return self.filter(
+            Q(pk=user_id) | Q(organization__organization_owner_id=user_id)
+        )
+
 
 class PersonManager(UserManager):
     def get_queryset(self):

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -182,11 +182,6 @@ class UserManager(InheritanceManagerMixin, DjangoUserManager):
     def get_queryset(self):
         return super().get_queryset().select_subclasses()
 
-    def owned_by(self, user_id: int):
-        return self.filter(
-            Q(pk=user_id) | Q(organization__organization_owner_id=user_id)
-        )
-
 
 class PersonManager(UserManager):
     def get_queryset(self):

--- a/docker-app/qfieldcloud/core/tests/test_deleteorphanedfiles.py
+++ b/docker-app/qfieldcloud/core/tests/test_deleteorphanedfiles.py
@@ -6,7 +6,7 @@ from qfieldcloud.core.models import Person, Project
 from qfieldcloud.core.utils import get_project_files_count, get_s3_bucket
 from qfieldcloud.core.utils2 import storage
 
-from .utils import setup_subscription_plans
+from .utils import set_subscription, setup_subscription_plans
 
 
 class QfcTestCase(TestCase):
@@ -14,6 +14,7 @@ class QfcTestCase(TestCase):
         setup_subscription_plans()
 
         self.u1 = Person.objects.create(username="u1")
+        set_subscription(self.u1, "default_user")
         self.projects = []
 
         get_s3_bucket().objects.filter(Prefix="projects/").delete()

--- a/docker-app/qfieldcloud/core/tests/test_delta.py
+++ b/docker-app/qfieldcloud/core/tests/test_delta.py
@@ -497,7 +497,7 @@ class QfcTestCase(APITransactionTestCase):
 
             plan = subscription.plan
             # Make sure the user's plan is inactive and does not allow online vector data
-            self.assertFalse(subscription.is_active)
+            self.assertFalse(project.owner.useraccount.current_subscription.is_active)
             self.assertFalse(plan.is_external_db_supported)
 
             # Make project use all available storage

--- a/docker-app/qfieldcloud/core/tests/test_job.py
+++ b/docker-app/qfieldcloud/core/tests/test_job.py
@@ -18,7 +18,7 @@ from qfieldcloud.subscription.exceptions import (
 from qfieldcloud.subscription.models import Subscription
 from rest_framework.test import APITestCase
 
-from .utils import setup_subscription_plans
+from .utils import setup_subscription_plans, set_subscription
 
 logging.disable(logging.CRITICAL)
 
@@ -30,6 +30,7 @@ class QfcTestCase(APITestCase):
         # Create a user
         self.user1 = Person.objects.create_user(username="user1", password="abc123")
         self.token1 = AuthToken.objects.get_or_create(user=self.user1)[0]
+        set_subscription(self.user1, "default_user")
 
         # Create a project
         self.project1 = Project.objects.create(

--- a/docker-app/qfieldcloud/core/tests/test_job.py
+++ b/docker-app/qfieldcloud/core/tests/test_job.py
@@ -1,6 +1,8 @@
+from datetime import timedelta
 import logging
 from unittest import mock
 
+from django.utils import timezone
 from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core.models import (
     ApplyJob,
@@ -84,7 +86,7 @@ class QfcTestCase(APITestCase):
         subscription.save()
 
         # Make sure the user is inactive
-        self.assertFalse(subscription.is_active)
+        self.assertFalse(self.project1.owner.useraccount.current_subscription.is_active)
 
         self.check_cannot_create_jobs(InactiveSubscriptionError)
         self.check_can_update_existing_jobs()

--- a/docker-app/qfieldcloud/core/tests/test_job.py
+++ b/docker-app/qfieldcloud/core/tests/test_job.py
@@ -1,8 +1,6 @@
-from datetime import timedelta
 import logging
 from unittest import mock
 
-from django.utils import timezone
 from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core.models import (
     ApplyJob,
@@ -20,7 +18,7 @@ from qfieldcloud.subscription.exceptions import (
 from qfieldcloud.subscription.models import Subscription
 from rest_framework.test import APITestCase
 
-from .utils import setup_subscription_plans, set_subscription
+from .utils import set_subscription, setup_subscription_plans
 
 logging.disable(logging.CRITICAL)
 

--- a/docker-app/qfieldcloud/core/tests/test_organization.py
+++ b/docker-app/qfieldcloud/core/tests/test_organization.py
@@ -16,7 +16,7 @@ from qfieldcloud.core.models import (
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from .utils import setup_subscription_plans, set_subscription
+from .utils import set_subscription, setup_subscription_plans
 
 logging.disable(logging.CRITICAL)
 

--- a/docker-app/qfieldcloud/core/tests/test_organization.py
+++ b/docker-app/qfieldcloud/core/tests/test_organization.py
@@ -16,7 +16,7 @@ from qfieldcloud.core.models import (
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from .utils import setup_subscription_plans
+from .utils import setup_subscription_plans, set_subscription
 
 logging.disable(logging.CRITICAL)
 
@@ -50,6 +50,9 @@ class QfcTestCase(APITestCase):
             type=2,
             organization_owner=self.user1,
         )
+
+        # Activate Subscriptions
+        set_subscription(self.organization1, "default_org")
 
     def test_list_members(self):
 

--- a/docker-app/qfieldcloud/core/tests/test_permission.py
+++ b/docker-app/qfieldcloud/core/tests/test_permission.py
@@ -39,6 +39,10 @@ class QfcTestCase(APITestCase):
             organization_owner=self.user1,
         )
 
+        # Activate subscriptions
+        set_subscription((self.user1, self.user2), "default_user")
+        set_subscription(self.organization1, "default_org")
+
         # Create a project
         self.project1 = Project.objects.create(
             name="project1", is_public=False, owner=self.user1
@@ -159,10 +163,12 @@ class QfcTestCase(APITestCase):
         u1 = Person.objects.create_user(username="u1")
         u2 = Person.objects.create_user(username="u2")
         u3 = Person.objects.create_user(username="u3")
+        set_subscription((u1), "default_user")
 
         # Create organizations
         o1 = Organization.objects.create(username="o1", organization_owner=u1)
         o2 = Organization.objects.create(username="o2", organization_owner=u1)
+        set_subscription((o1, o2), "default_org")
 
         # Create a team
         o1_t1 = Team.objects.create(username="@o1/o1_t1", team_organization=o1)

--- a/docker-app/qfieldcloud/core/tests/test_project.py
+++ b/docker-app/qfieldcloud/core/tests/test_project.py
@@ -494,7 +494,7 @@ class QfcTestCase(APITransactionTestCase):
         subscription.save()
 
         # Make sure the user is inactive
-        self.assertFalse(subscription.is_active)
+        self.assertFalse(self.user1.useraccount.current_subscription.is_active)
 
         # Cannot create project if user's subscription is inactive
         with self.assertRaises(InactiveSubscriptionError):

--- a/docker-app/qfieldcloud/core/tests/test_user.py
+++ b/docker-app/qfieldcloud/core/tests/test_user.py
@@ -14,7 +14,7 @@ from qfieldcloud.core.models import (
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from .utils import setup_subscription_plans
+from .utils import setup_subscription_plans, set_subscription
 
 logging.disable(logging.CRITICAL)
 
@@ -53,6 +53,9 @@ class QfcTestCase(APITestCase):
             user_agent="qfield|dev",
         )[0]
 
+        # Activate Subscriptions
+        set_subscription((self.user1, self.user2, self.user3), "default_user")
+
         # Create an organization
         self.organization1 = Organization.objects.create(
             username="organization1",
@@ -64,6 +67,9 @@ class QfcTestCase(APITestCase):
         self.project1 = Project.objects.create(
             name="project1", is_public=False, owner=self.user1
         )
+
+        # Activate Subscriptions
+        set_subscription(self.organization1, "default_org")
 
         # Set user2 as member of organization1
         OrganizationMember.objects.create(

--- a/docker-app/qfieldcloud/core/tests/test_user.py
+++ b/docker-app/qfieldcloud/core/tests/test_user.py
@@ -14,7 +14,7 @@ from qfieldcloud.core.models import (
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from .utils import setup_subscription_plans, set_subscription
+from .utils import set_subscription, setup_subscription_plans
 
 logging.disable(logging.CRITICAL)
 

--- a/docker-app/qfieldcloud/core/tests/utils.py
+++ b/docker-app/qfieldcloud/core/tests/utils.py
@@ -1,6 +1,6 @@
-from datetime import timedelta, timezone
 import io
 import os
+from datetime import timedelta, timezone
 from time import sleep
 from typing import IO, Iterable, Union
 

--- a/docker-app/qfieldcloud/core/tests/utils.py
+++ b/docker-app/qfieldcloud/core/tests/utils.py
@@ -1,3 +1,4 @@
+from datetime import timedelta, timezone
 import io
 import os
 from time import sleep
@@ -70,8 +71,9 @@ def set_subscription(
         assert (
             user.type == plan.user_type
         ), 'All users must have the same type "{plan.user_type.value}", but "{user.username}" has "{user.type.value}"'
-        subscription = user.useraccount.current_subscription
+        subscription: Subscription = user.useraccount.current_subscription
         subscription.plan = plan
+        subscription.active_since = timezone.now() - timedelta(days=1)
         subscription.save(update_fields=["plan"])
 
     return subscription

--- a/docker-app/qfieldcloud/notifs/tests/test_notifs.py
+++ b/docker-app/qfieldcloud/notifs/tests/test_notifs.py
@@ -16,7 +16,7 @@ from qfieldcloud.core.models import (
     Team,
     UserAccount,
 )
-from qfieldcloud.core.tests.utils import set_supscriptions, setup_subscription_plans
+from qfieldcloud.core.tests.utils import set_subscription, setup_subscription_plans
 
 
 class QfcTestCase(TestCase):
@@ -153,7 +153,7 @@ class QfcTestCase(TestCase):
             username="org1", organization_owner=self.user1
         )
         # Activate Subscription
-        set_supscriptions(org1, "default_org")
+        set_subscription(org1, "default_org")
         org1.members.create(member=self.user2)
         t1 = Team.objects.create(username="t1", team_organization=org1)
         t1.members.create(member=self.user2)

--- a/docker-app/qfieldcloud/notifs/tests/test_notifs.py
+++ b/docker-app/qfieldcloud/notifs/tests/test_notifs.py
@@ -16,7 +16,7 @@ from qfieldcloud.core.models import (
     Team,
     UserAccount,
 )
-from qfieldcloud.core.tests.utils import setup_subscription_plans
+from qfieldcloud.core.tests.utils import set_supscriptions, setup_subscription_plans
 
 
 class QfcTestCase(TestCase):
@@ -152,6 +152,8 @@ class QfcTestCase(TestCase):
         org1 = Organization.objects.create(
             username="org1", organization_owner=self.user1
         )
+        # Activate Subscription
+        set_supscriptions(org1, "default_org")
         org1.members.create(member=self.user2)
         t1 = Team.objects.create(username="t1", team_organization=org1)
         t1.members.create(member=self.user2)

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -840,7 +840,9 @@ class AbstractSubscription(models.Model):
                 active_since=active_since,
                 active_until=active_until,
             )
-            # the regular plan should be the default plan
+            # NOTE to get annotations, mostly `is_active`
+            trial_subscription_obj = cls.objects.get(pk=trial_subscription.pk)
+            # the trial plan should be the default plan
             regular_plan = Plan.objects.get(
                 user_type=account.user.type,
                 is_default=True,
@@ -849,7 +851,7 @@ class AbstractSubscription(models.Model):
             # the end date of the trial is the start date of the regular
             regular_active_since = active_until
         else:
-            trial_subscription = None
+            trial_subscription_obj = None
             regular_plan = plan
             regular_active_since = active_since
 
@@ -861,8 +863,10 @@ class AbstractSubscription(models.Model):
             status=regular_plan.initial_subscription_status,
             active_since=regular_active_since,
         )
+        # NOTE to get annotations, mostly `is_active`
+        regular_subscription_obj = cls.objects.get(pk=regular_subscription.pk)
 
-        return trial_subscription, regular_subscription
+        return trial_subscription_obj, regular_subscription_obj
 
     def __str__(self):
         return f"{self.__class__.__name__} #{self.id} user:{self.account.user.username} plan:{self.plan.code} total:{self.active_storage_total_mb}MB"

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -384,11 +384,9 @@ class SubscriptionQuerySet(models.QuerySet):
         )
 
     def activeness(self):
-        """Annotates with three additional boolean fields.
+        """Annotates with additional `is_active` boolean field.
 
-        `is_period_active` - if the subscription period is active
-        `is_status_active` - if the status is active
-        `is_active` - if the period and status are active
+        `is_active` - if the period and status are active.
 
         NOTE This method is intended to be automatically called for each queryset.
         """
@@ -402,14 +400,6 @@ class SubscriptionQuerySet(models.QuerySet):
             )
         )
         return self.annotate(
-            is_period_active=Case(
-                When(is_period_active_condition, then=True),
-                default=False,
-            ),
-            is_status_active=Case(
-                When(is_status_active_condition, then=True),
-                default=False,
-            ),
             is_active=Case(
                 When(
                     is_period_active_condition & is_status_active_condition, then=True


### PR DESCRIPTION
Note there is a slight change in behaviour of `Subscription.is_active`, which now takes into account `the active_since`/`active_until`.