### PR TITLE
QF-2700 Run makemigrations --check right after building

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
 
       - name: Initial manage.py commands
         run: |
+          docker compose run app python manage.py makemigrations --no-input --check
           docker compose run app python manage.py migrate
           docker compose run app python manage.py collectstatic
       - name: Run unit and integration tests

--- a/docker-app/qfieldcloud/core/migrations/0009_geodb.py
+++ b/docker-app/qfieldcloud/core/migrations/0009_geodb.py
@@ -28,28 +28,28 @@ class Migration(migrations.Migration):
                 (
                     "username",
                     models.CharField(
-                        default=qfieldcloud.core.models.Geodb.random_string,
+                        default=qfieldcloud.core.models.random_string,
                         max_length=255,
                     ),
                 ),
                 (
                     "dbname",
                     models.CharField(
-                        default=qfieldcloud.core.models.Geodb.random_string,
+                        default=qfieldcloud.core.models.random_string,
                         max_length=255,
                     ),
                 ),
                 (
                     "hostname",
                     models.CharField(
-                        default=qfieldcloud.core.models.Geodb.default_hostname,
+                        default=qfieldcloud.core.models.default_hostname,
                         max_length=255,
                     ),
                 ),
                 (
                     "port",
                     models.PositiveIntegerField(
-                        default=qfieldcloud.core.models.Geodb.default_port
+                        default=qfieldcloud.core.models.default_port
                     ),
                 ),
                 ("created_at", models.DateTimeField(auto_now_add=True)),

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -510,40 +510,40 @@ class UserAccount(models.Model):
         return f"{self.user.username_with_full_name} ({self.__class__.__name__})"
 
 
+def random_string() -> str:
+    """Generate random sting starting with a lowercase letter and then
+    lowercase letters and digits"""
+
+    first_letter = secrets.choice(string.ascii_lowercase)
+    letters_and_digits = string.ascii_lowercase + string.digits
+    secure_str = first_letter + "".join(
+        secrets.choice(letters_and_digits) for i in range(15)
+    )
+    return secure_str
+
+
+def random_password() -> str:
+    """Generate secure random password composed of
+    letters, digits and special characters"""
+
+    password_characters = (
+        string.ascii_letters + string.digits + "!#$%&()*+,-.:;<=>?@[]_{}~"
+    )
+    secure_str = "".join(secrets.choice(password_characters) for i in range(16))
+    return secure_str
+
+
+def default_hostname() -> str:
+    return os.environ.get("GEODB_HOST")
+
+
+def default_port() -> str:
+    return os.environ.get("GEODB_PORT")
+
+
 class Geodb(models.Model):
-    @staticmethod
-    def random_string():
-        """Generate random sting starting with a lowercase letter and then
-        lowercase letters and digits"""
-
-        first_letter = secrets.choice(string.ascii_lowercase)
-        letters_and_digits = string.ascii_lowercase + string.digits
-        secure_str = first_letter + "".join(
-            secrets.choice(letters_and_digits) for i in range(15)
-        )
-        return secure_str
-
-    @staticmethod
-    def random_password():
-        """Generate secure random password composed of
-        letters, digits and special characters"""
-
-        password_characters = (
-            string.ascii_letters + string.digits + "!#$%&()*+,-.:;<=>?@[]_{}~"
-        )
-        secure_str = "".join(secrets.choice(password_characters) for i in range(16))
-        return secure_str
-
-    @staticmethod
-    def default_hostname():
-        return os.environ.get("GEODB_HOST")
-
-    @staticmethod
-    def default_port():
-        return os.environ.get("GEODB_PORT")
 
     user = models.OneToOneField(User, on_delete=models.CASCADE, primary_key=True)
-
     username = models.CharField(blank=False, max_length=255, default=random_string)
     dbname = models.CharField(blank=False, max_length=255, default=random_string)
     hostname = models.CharField(blank=False, max_length=255, default=default_hostname)

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -560,7 +560,7 @@ class Geodb(models.Model):
         self.password = password
 
         if not self.password:
-            self.password = Geodb.random_password()
+            self.password = random_password()
 
     def size(self):
         try:


### PR DESCRIPTION
What looked like adding a single line of code turned into me arm-wrestling the Django migration writer. 

The issue is basically that the migration writer doesn't know how to serialize bound functions -- functions parameterized with an implicit reference -- and that static methods seem to be considered as bound functions.

I went for the "brutal" way of solving this: i.e. extracting the static method to a top-level function. There are other ways. Please make a commit suggestion if you are not happy with the way I went for.
