### PR TITLE
QF-2711 Adding a few failsafes around ListFilesView.get()

### DIFF
--- a/docker-app/qfieldcloud/core/tests/test_qgis_file.py
+++ b/docker-app/qfieldcloud/core/tests/test_qgis_file.py
@@ -56,6 +56,16 @@ class QfcTestCase(APITransactionTestCase):
         else:
             return response.content
 
+    def test_try_to_get_nonexistent_project(self):
+        empty_string = ""
+        nonexistent_id = "007"
+        with self.subTest(
+            "Ensure that '/api/v1/files' handles missing resources correctly."
+        ):
+            one = self.client.get(f"/api/v1/files/{empty_string}")
+            two = self.client.get(f"/api/v1/files/{nonexistent_id}")
+            assert all(r.status_code == 404 for r in (one, two))
+
     def test_push_file(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
 

--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -13,9 +13,9 @@ from qfieldcloud.core.utils2.storage import (
     purge_old_file_versions,
 )
 from rest_framework import permissions, status, views
+from rest_framework.exceptions import bad_request, server_error
 from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
-from rest_framework.exceptions import server_error, bad_request
 
 logger = logging.getLogger(__name__)
 

--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -2,6 +2,7 @@ import logging
 from pathlib import PurePath
 
 import qfieldcloud.core.utils2 as utils2
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.utils import timezone
 from qfieldcloud.core import exceptions, permissions_utils, utils
@@ -43,8 +44,11 @@ class ListFilesView(views.APIView):
             project = Project.objects.get(id=projectid)
             bucket = utils.get_s3_bucket()
             assert hasattr(bucket, "object_versions")
-        except exceptions.ObjectNotFoundError as exception:
-            return bad_request(request=request, reason=exception.message)
+        except ObjectDoesNotExist:
+            return bad_request(
+                request=request,
+                reason=f"Unable to retrieve this project: {projectid}. Are you sure it exists?",
+            )
         except Exception as unknown_reason:
             return server_error(request=request, reason=unknown_reason)
 


### PR DESCRIPTION
_Source_:
https://app.clickup.com/t/2192114/QF-2711.

_Problem_:
The `download_project` step used in the `process_projectfile` workflow makes a call to `qfieldcloud_sdk` to the effect that the sdk will try and GET project files under a given project id. However, the attempt sometimes fails on "500: Internal Error", with the caller being offered little to no information about the error. 

_Proposal_:
This PR proposes to offer callers more information about such failures. It delineates all the I/O actions that might raise, collect the possible exceptions, and returns the first one raised as part of the response.