### PR TITLE
Enable Groups model and groups field in People view in Django admin

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -18,7 +18,6 @@ from django.conf import settings
 from django.contrib import admin, messages
 from django.contrib.admin.templatetags.admin_urls import admin_urlname
 from django.contrib.admin.views.main import ChangeList
-from django.contrib.auth.models import Group
 from django.core.exceptions import PermissionDenied
 from django.db.models import Q, QuerySet
 from django.db.models.fields.json import JSONField
@@ -121,7 +120,6 @@ def admin_urlname_by_obj(value, arg):
 # Unregister admins from other Django apps
 admin.site.unregister(Invitation)
 admin.site.unregister(TokenProxy)
-admin.site.unregister(Group)
 admin.site.unregister(SocialAccount)
 admin.site.unregister(SocialApp)
 admin.site.unregister(SocialToken)
@@ -439,6 +437,7 @@ class PersonAdmin(QFieldCloudModelAdmin):
         "is_superuser",
         "is_staff",
         "is_active",
+        "groups",
         "remaining_invitations",
         "has_newsletter_subscription",
         "has_accepted_tos",


### PR DESCRIPTION
This way we can now configure certain staff users to have access to  certain Django admin models only. What is more, we can make this access read-only. I will do this manually in the admin after releasing this  branch.

@m-kuhn @faebebin ideally I would like to have this in the upcoming release. 