### PR TITLE
pip install libqfieldsync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,10 @@ DEBUG=1
 # DEFAULT: test
 ENVIRONMENT=test
 
+# When developing it comes in handy to use the host's path to libqfieldsync
+# so that changes made there will be reflected in the Compose application
+HOST_PATH_LIBQFIELDSYNC=
+
 QFIELDCLOUD_HOST=localhost
 DJANGO_SETTINGS_MODULE=qfieldcloud.settings
 DJANGO_ALLOWED_HOSTS="localhost 127.0.0.1 0.0.0.0 app nginx"

--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ ENVIRONMENT=test
 
 # When developing it comes in handy to use the host's path to libqfieldsync
 # so that changes made there will be reflected in the Compose application
-HOST_PATH_LIBQFIELDSYNC=
+# HOST_PATH_LIBQFIELDSYNC=
 
 QFIELDCLOUD_HOST=localhost
 DJANGO_SETTINGS_MODULE=qfieldcloud.settings

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "docker-qgis/libqfieldsync"]
-	path = docker-qgis/libqfieldsync
-	url = https://github.com/opengisch/libqfieldsync.git

--- a/docker-compose.override.local.yml
+++ b/docker-compose.override.local.yml
@@ -128,12 +128,12 @@ services:
   qgis:
     build:
       target: dev
-    # Uncomment to use a local clone of the libqfieldsync repository
-    # that will be bind-mounted into this container for an editable installation
-      # environment:
-      #   - HOST_PATH_LIBQFIELDSYNC
-      # volumes:
-      #   - ${HOST_PATH_LIBQFIELDSYNC}:/libqfieldsync
+    environment:
+      - HOST_PATH_LIBQFIELDSYNC
+  # Uncomment to use a local clone of the libqfieldsync repository
+  # that will be bind-mounted into this container for an editable installation
+    # volumes:
+    #   - ${HOST_PATH_LIBQFIELDSYNC}:/libqfieldsync
 
 volumes:
   postgres_data:

--- a/docker-compose.override.local.yml
+++ b/docker-compose.override.local.yml
@@ -125,6 +125,13 @@ services:
       exit 0;
       "
 
+  qgis:
+    build:
+      target: dev
+#    volumes:
+# Uncomment to use a local libqfieldsync dev environment
+#      - /home/user/dev/libqfieldsync:/libqfieldsync
+
 volumes:
   postgres_data:
   geodb_data:

--- a/docker-compose.override.local.yml
+++ b/docker-compose.override.local.yml
@@ -128,9 +128,12 @@ services:
   qgis:
     build:
       target: dev
-#    volumes:
-# Uncomment to use a local libqfieldsync dev environment
-#      - /home/user/dev/libqfieldsync:/libqfieldsync
+    # Uncomment to use a local clone of the libqfieldsync repository
+    # that will be bind-mounted into this container for an editable installation
+      # environment:
+      #   - HOST_PATH_LIBQFIELDSYNC
+      # volumes:
+      #   - ${HOST_PATH_LIBQFIELDSYNC}:/libqfieldsync
 
 volumes:
   postgres_data:

--- a/docker-qgis/Dockerfile
+++ b/docker-qgis/Dockerfile
@@ -34,4 +34,5 @@ COPY ./schemas/deltafile_01.json ./schemas/
 ENTRYPOINT ["/bin/sh", "-c", "/usr/bin/xvfb-run -a \"$@\"", ""]
 
 FROM base AS dev
+# Install libqfieldsync in development mode (see https://setuptools.pypa.io/en/latest/userguide/development_mode.html)
 ENTRYPOINT ["/bin/sh", "-c", "pip install -e /libqfieldsync && /usr/bin/xvfb-run -a \"$@\"", ""]

--- a/docker-qgis/Dockerfile
+++ b/docker-qgis/Dockerfile
@@ -1,4 +1,4 @@
-FROM qgis/qgis:final-3_30_2
+FROM qgis/qgis:final-3_30_2 AS base
 
 RUN apt-get update \
     && apt-get upgrade -y \
@@ -22,6 +22,7 @@ ENV PYTHONPATH="/usr/src/app/lib:${PYTHONPATH}"
 ENV XDG_RUNTIME_DIR=/root
 
 COPY ./requirements.txt /tmp/
+RUN pip3 install --upgrade pip
 RUN pip3 install -r /tmp/requirements.txt
 
 COPY entrypoint.py .
@@ -29,6 +30,8 @@ COPY ./apply_deltas.py ./lib/qfieldcloud/qgis/
 COPY ./process_projectfile.py ./lib/qfieldcloud/qgis/
 COPY ./utils.py ./lib/qfieldcloud/qgis/
 COPY ./schemas/deltafile_01.json ./schemas/
-COPY ./libqfieldsync ./lib/libqfieldsync
 
 ENTRYPOINT ["/bin/sh", "-c", "/usr/bin/xvfb-run -a \"$@\"", ""]
+
+FROM base AS dev
+ENTRYPOINT ["/bin/sh", "-c", "pip install -e /libqfieldsync && /usr/bin/xvfb-run -a \"$@\"", ""]

--- a/docker-qgis/requirements.txt
+++ b/docker-qgis/requirements.txt
@@ -3,7 +3,7 @@ typing-extensions>=3.7.4.3,<3.7.5
 tabulate==v0.8.9
 sentry-sdk
 requests>=2.28.1
-qfieldcloud-sdk==0.6.1
+qfieldcloud-sdk==0.7.0
 
 # TODO: point to a commit on master after merging https://github.com/opengisch/libqfieldsync/pull/49
 libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/c3bcdbbe10542416324d6ffe6f6608a7fbc4aa69.tar.gz

--- a/docker-qgis/requirements.txt
+++ b/docker-qgis/requirements.txt
@@ -4,3 +4,6 @@ tabulate==v0.8.9
 sentry-sdk
 requests>=2.28.1
 qfieldcloud-sdk==0.6.1
+
+# TODO: point to a commit on master after merging https://github.com/opengisch/libqfieldsync/pull/49
+libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/c3bcdbbe10542416324d6ffe6f6608a7fbc4aa69.tar.gz


### PR DESCRIPTION
By default installs libqfieldsync via pip
For local development, allows mounting a volume into the qgis container

Depends on https://github.com/opengisch/libqfieldsync/pull/49