### PR TITLE
New line handling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Handle line endings automatically for files detected as text
+# and leave all files detected as binary untouched.
+*           text=auto
+
+#
+# The above will handle all files NOT found below
+#
+# These files are text and should be normalized (Convert crlf => lf)
+*.bash      text eol=lf
+*.sh        text eol=lf


### PR DESCRIPTION
When the repository is cloned on Windows, all newline characters are converted to CLRF format. This causes a problem when running images that contain bash scripts. Linux scripts are not compatible with this newline character format and cause an error:
`standard_init_linux.go:228: exec user process caused: no such file or directory`