### PR TITLE
QF-2657 Improving tests on CI: parallel build/testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,15 @@ jobs:
   test:
     name: Run tests
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        django_apps:
+          - authentication
+          - notifs
+          - subscription
+          - core
+    continue-on-error: true
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -59,7 +68,7 @@ jobs:
           docker compose run app python manage.py collectstatic
       - name: Run unit and integration tests
         run: |
-          docker compose run app python manage.py test --keepdb -v2 qfieldcloud
+          docker compose run app python manage.py test --keepdb -v2 qfieldcloud.${{ matrix.django_apps }}
 
       - name: "failure logs"
         if: failure()


### PR DESCRIPTION
__TL;DR__
I am not able to make #674 work. I submit this as an ersatz. This PR borrows from design of the PR it supersedes, having each job in the matrix handle a separate batch of tests, grouped by Django app.

As for #674 it shaves off some precious minutes, and even more so if we are able to fix flakiness once and for all, because then we can run the tests on either `pull_request` or `push`.

__Comparison with #674__ 
- it runs to completion
- it is less efficient: while in #674 the Docker images where first built in parallel _once_ and then downloaded and used in each job in the matrix, now the images need to be built _for each job in the matrix_.
- it means much less maintainance
- it provides much faster feedback for PRs authors, especially for PRs not touching `core`