### PR TITLE
QF-2704 Making sure strings are encoded when sending to Sentry

### DIFF
--- a/docker-app/qfieldcloud/core/tests/test_sentry.py
+++ b/docker-app/qfieldcloud/core/tests/test_sentry.py
@@ -38,5 +38,5 @@ class QfcTestCase(APITestCase):
             "buffer": StringIO("The traceback of the exception to raise"),
             "capture_message": True,  # so that sentry receives attachments even when there's no exception/event
         }
-        is_sent = report_serialization_diff_to_sentry(**mock_payload)
-        self.assertTrue(is_sent)
+        will_be_sent = report_serialization_diff_to_sentry(**mock_payload)
+        self.assertTrue(will_be_sent)

--- a/docker-app/qfieldcloud/core/tests/test_sentry.py
+++ b/docker-app/qfieldcloud/core/tests/test_sentry.py
@@ -1,11 +1,15 @@
 from io import StringIO
 
 from rest_framework.test import APITestCase
+from sentry_sdk import capture_message
 
 from ..utils2.sentry import report_serialization_diff_to_sentry
 
 
 class QfcTestCase(APITestCase):
+    def test_sending_message_to_sentry(self):
+        capture_message("Hello Sentry from test_sentry!")
+
     def test_logging_with_sentry(self):
         mock_payload = {
             "name": "request_id_file_name",
@@ -36,6 +40,7 @@ class QfcTestCase(APITestCase):
                 }
             ),
             "buffer": StringIO("The traceback of the exception to raise"),
+            "capture_message": True,
         }
-        result = report_serialization_diff_to_sentry(**mock_payload)
-        self.assertTrue(result)
+        is_sent = report_serialization_diff_to_sentry(**mock_payload)
+        self.assertTrue(is_sent)

--- a/docker-app/qfieldcloud/core/tests/test_sentry.py
+++ b/docker-app/qfieldcloud/core/tests/test_sentry.py
@@ -9,16 +9,16 @@ class QfcTestCase(APITestCase):
     def test_logging_with_sentry(self):
         mock_payload = {
             "name": "request_id_file_name",
-            "pre_serialization": {
-                "data": str(["some", "pre-serialization", "data", "keys"]),
-                "files": str(["some", "files", "to be", "listed"]),
-                "meta": str({"metadata": "of the request pre-serialization"}),
-            },
-            "post_serialization": {
-                "data": str(["some", "post-serialization", "data", "keys"]),
-                "files": str(["some", "files", "to be", "listed"]),
-                "meta": str({"metadata": "of the request post-serialization"}),
-            },
+            "pre_serialization": str({
+                "data": ["some", "pre-serialization", "data", "keys"],
+                "files": ["some", "files", "to be", "listed"],
+                "meta": ["metadata": "of the request pre-serialization"],
+            }),
+            "post_serialization": str({
+                "data": ["some", "post-serialization", "data", "keys"],
+                "files": ["some", "files", "to be", "listed"],
+                "meta": {"metadata": "of the request post-serialization"},
+            }),
             "buffer": StringIO("The traceback of the exception to raise"),
         }
         result = report_serialization_diff_to_sentry(**mock_payload)

--- a/docker-app/qfieldcloud/core/tests/test_sentry.py
+++ b/docker-app/qfieldcloud/core/tests/test_sentry.py
@@ -1,0 +1,25 @@
+from io import StringIO
+
+from rest_framework.test import APITestCase
+
+from ..utils2.sentry import report_serialization_diff_to_sentry
+
+
+class QfcTestCase(APITestCase):
+    def test_logging_with_sentry(self):
+        mock_payload = {
+            "name": "request_id_file_name",
+            "pre_serialization": {
+                "data": str(["some", "pre-serialization", "data", "keys"]),
+                "files": str(["some", "files", "to be", "listed"]),
+                "meta": str({"metadata": "of the request pre-serialization"}),
+            },
+            "post_serialization": {
+                "data": str(["some", "post-serialization", "data", "keys"]),
+                "files": str(["some", "files", "to be", "listed"]),
+                "meta": str({"metadata": "of the request post-serialization"}),
+            },
+            "buffer": StringIO("The traceback of the exception to raise"),
+        }
+        result = report_serialization_diff_to_sentry(**mock_payload)
+        self.assertTrue(result)

--- a/docker-app/qfieldcloud/core/tests/test_sentry.py
+++ b/docker-app/qfieldcloud/core/tests/test_sentry.py
@@ -9,16 +9,32 @@ class QfcTestCase(APITestCase):
     def test_logging_with_sentry(self):
         mock_payload = {
             "name": "request_id_file_name",
-            "pre_serialization": str({
-                "data": ["some", "pre-serialization", "data", "keys"],
-                "files": ["some", "files", "to be", "listed"],
-                "meta": ["metadata", "of the request pre-serialization"],
-            }),
-            "post_serialization": str({
-                "data": ["some", "post-serialization", "data", "keys"],
-                "files": ["some", "files", "to be", "listed"],
-                "meta": {"metadata": "of the request post-serialization"},
-            }),
+            "pre_serialization": str(
+                {
+                    "data": [
+                        "some",
+                        "pre-serialization",
+                        "data",
+                        "keys",
+                        "日本人 中國的 ~=[]()%+{}@;’#!$_&-  éè  ;∞¥₤€",
+                    ],
+                    "files": ["some", "files", "to be", "listed"],
+                    "meta": ["metadata", "of the request pre-serialization"],
+                }
+            ),
+            "post_serialization": str(
+                {
+                    "data": [
+                        "some",
+                        "post-serialization",
+                        "data",
+                        "keys",
+                        "日本人 中國的 ~=[]()%+{}@;’#!$_&-  éè  ;∞¥₤€",
+                    ],
+                    "files": ["some", "files", "to be", "listed"],
+                    "meta": {"metadata": "of the request post-serialization"},
+                }
+            ),
             "buffer": StringIO("The traceback of the exception to raise"),
         }
         result = report_serialization_diff_to_sentry(**mock_payload)

--- a/docker-app/qfieldcloud/core/tests/test_sentry.py
+++ b/docker-app/qfieldcloud/core/tests/test_sentry.py
@@ -40,7 +40,7 @@ class QfcTestCase(APITestCase):
                 }
             ),
             "buffer": StringIO("The traceback of the exception to raise"),
-            "capture_message": True,
+            "capture_message": True,  # so that sentry receives attachments even when there's no exception/event
         }
         is_sent = report_serialization_diff_to_sentry(**mock_payload)
         self.assertTrue(is_sent)

--- a/docker-app/qfieldcloud/core/tests/test_sentry.py
+++ b/docker-app/qfieldcloud/core/tests/test_sentry.py
@@ -1,15 +1,11 @@
 from io import StringIO
 
 from rest_framework.test import APITestCase
-from sentry_sdk import capture_message
 
 from ..utils2.sentry import report_serialization_diff_to_sentry
 
 
 class QfcTestCase(APITestCase):
-    def test_sending_message_to_sentry(self):
-        capture_message("Hello Sentry from test_sentry!")
-
     def test_logging_with_sentry(self):
         mock_payload = {
             "name": "request_id_file_name",

--- a/docker-app/qfieldcloud/core/tests/test_sentry.py
+++ b/docker-app/qfieldcloud/core/tests/test_sentry.py
@@ -1,4 +1,6 @@
 from io import StringIO
+from os import environ
+from unittest import skipIf
 
 from rest_framework.test import APITestCase
 
@@ -6,6 +8,10 @@ from ..utils2.sentry import report_serialization_diff_to_sentry
 
 
 class QfcTestCase(APITestCase):
+    @skipIf(
+        environ.get("SENTRY_DSN", False),
+        "Do not run this test when Sentry's DSN is not set.",
+    )
     def test_logging_with_sentry(self):
         mock_payload = {
             "name": "request_id_file_name",

--- a/docker-app/qfieldcloud/core/tests/test_sentry.py
+++ b/docker-app/qfieldcloud/core/tests/test_sentry.py
@@ -12,7 +12,7 @@ class QfcTestCase(APITestCase):
             "pre_serialization": str({
                 "data": ["some", "pre-serialization", "data", "keys"],
                 "files": ["some", "files", "to be", "listed"],
-                "meta": ["metadata": "of the request pre-serialization"],
+                "meta": ["metadata", "of the request pre-serialization"],
             }),
             "post_serialization": str({
                 "data": ["some", "post-serialization", "data", "keys"],

--- a/docker-app/qfieldcloud/core/utils2/sentry.py
+++ b/docker-app/qfieldcloud/core/utils2/sentry.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 def report_serialization_diff_to_sentry(
     name: str, pre_serialization: str, post_serialization: str, buffer: StringIO
-):
+) -> bool:
     """
     Sends a report to sentry to debug QF-2540. The report includes request information from before and after middleware handle the request as well as a traceback.
 
@@ -33,6 +33,8 @@ def report_serialization_diff_to_sentry(
                 bytes=bytes(buffer.getvalue(), encoding="utf8"),
                 filename=filename,
             )
+            return True
         except Exception as error:
             sentry_sdk.capture_exception(error)
             logging.error(f"Unable to send file to Sentry: failed on {error}")
+            return False

--- a/docker-app/qfieldcloud/core/utils2/sentry.py
+++ b/docker-app/qfieldcloud/core/utils2/sentry.py
@@ -7,7 +7,11 @@ logger = logging.getLogger(__name__)
 
 
 def report_serialization_diff_to_sentry(
-    name: str, pre_serialization: str, post_serialization: str, buffer: StringIO
+    name: str,
+    pre_serialization: str,
+    post_serialization: str,
+    buffer: StringIO,
+    capture_message=False,
 ) -> bool:
     """
     Sends a report to sentry to debug QF-2540. The report includes request information from before and after middleware handle the request as well as a traceback.
@@ -33,6 +37,8 @@ def report_serialization_diff_to_sentry(
                 bytes=bytes(buffer.getvalue(), encoding="utf8"),
                 filename=filename,
             )
+            if capture_message:
+                sentry_sdk.capture_message("Sending to Sentry...", scope=scope)
             return True
         except Exception as error:
             sentry_sdk.capture_exception(error)

--- a/docker-app/qfieldcloud/core/utils2/sentry.py
+++ b/docker-app/qfieldcloud/core/utils2/sentry.py
@@ -17,18 +17,20 @@ def report_serialization_diff_to_sentry(
         post_serialization: str representing the request `files` keys and meta information after serialization and middleware.
         buffer: StringIO buffer from which to extract traceback capturing callstack ahead of the calling function.
     """
-
-    traceback = bytes(buffer.getvalue(), encoding="utf-8")
-    report = f"Pre:\n{pre_serialization}\n\nPost:{post_serialization}"
-
     with sentry_sdk.configure_scope() as scope:
         try:
             filename = f"{name}_contents.txt"
-            scope.add_attachment(bytes=bytes(report), filename=filename)
+            scope.add_attachment(
+                bytes=bytes(
+                    f"Pre:\n{pre_serialization}\n\nPost:{post_serialization}",
+                    encoding="utf8",
+                ),
+                filename=filename,
+            )
 
             filename = f"{name}_traceback.txt"
             scope.add_attachment(
-                bytes=traceback,
+                bytes=bytes(buffer.getvalue(), encoding="utf8"),
                 filename=filename,
             )
         except Exception as error:

--- a/docker-app/qfieldcloud/core/utils2/sentry.py
+++ b/docker-app/qfieldcloud/core/utils2/sentry.py
@@ -20,6 +20,7 @@ def report_serialization_diff_to_sentry(
         pre_serialization: str representing the request `files` keys and meta information before serialization and middleware.
         post_serialization: str representing the request `files` keys and meta information after serialization and middleware.
         buffer: StringIO buffer from which to extract traceback capturing callstack ahead of the calling function.
+        capture_message: bool used as a flag by the caller to create an extra event against Sentry to attach the files to.
     """
     with sentry_sdk.configure_scope() as scope:
         try:


### PR DESCRIPTION
In response to:

![image](https://github.com/opengisch/qfieldcloud/assets/19554213/7413546a-55c3-4581-8acc-f33f567228c0)
