### PR TITLE
Show active members in the Organization Admin

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -1083,7 +1083,7 @@ class OrganizationAdmin(QFieldCloudModelAdmin):
     autocomplete_fields = ("organization_owner",)
 
     @admin.display(description=_("Active members"))
-    def active_users_count(self, instance) -> int | None:
+    def active_users_count(self, instance) -> int:
         return instance.useraccount.current_subscription.active_users_count
 
     @admin.display(description=_("Active members"))

--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -1051,7 +1051,7 @@ class OrganizationAdmin(QFieldCloudModelAdmin):
         "email",
         "organization_owner",
         "date_joined",
-        "active_users",
+        "active_users_links",
     )
     list_display = (
         "username",
@@ -1073,7 +1073,7 @@ class OrganizationAdmin(QFieldCloudModelAdmin):
         "date_joined",
         "storage_usage__field",
         "active_users_count",
-        "active_users",
+        "active_users_links",
     )
 
     list_select_related = ("organization_owner", "useraccount")
@@ -1087,11 +1087,15 @@ class OrganizationAdmin(QFieldCloudModelAdmin):
         return instance.useraccount.current_subscription.active_users_count
 
     @admin.display(description=_("Active members"))
-    def active_users(self, instance) -> str:
+    def active_users_links(self, instance) -> str:
         persons = instance.useraccount.current_subscription.active_users
         if persons.exists():
             userlinks = " ".join(model_admin_url(p, p.username) for p in persons)
-            help_text = "<p>(Active users have triggererd at least one job or uploaded at least one delta in the current billing period. These are all the users who will be billed -- plan included or additional.)</p>"
+            help_text = """
+            <p style='font-size: 11px; color: var(--body-quiet-color)'>
+                Active users have triggererd at least one job or uploaded at least one delta in the current billing period. These are all the users who will be billed -- plan included or additional.
+            </p>
+            """
             return format_html(f"{userlinks} <br> {help_text}")
 
     @admin.display(description=_("Owner"))

--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -1058,7 +1058,7 @@ class OrganizationAdmin(QFieldCloudModelAdmin):
         "organization_owner__link",
         "date_joined",
         # "storage_usage__field",
-        "active_users",
+        "active_users_count",
     )
 
     search_fields = (
@@ -1068,22 +1068,17 @@ class OrganizationAdmin(QFieldCloudModelAdmin):
         "organization_owner__email__iexact",
     )
 
-    readonly_fields = ("date_joined", "storage_usage__field", "active_users")
+    readonly_fields = ("date_joined", "storage_usage__field", "active_users_count")
 
-    list_select_related = ("organization_owner",)
+    list_select_related = ("organization_owner", "useraccount")
 
     list_filter = ("date_joined",)
 
     autocomplete_fields = ("organization_owner",)
 
-    @admin.display(description=_("Active users (last billing period)"))
-    def active_users(self, instance) -> int | None:
-        # The relation 'current_subscription_vw' is not instantiated unless the organization
-        # does have a current subscription
-        if hasattr(instance, "current_subscription_vw"):
-            return instance.current_subscription_vw.active_users_count
-        else:
-            return None
+    @admin.display(description=_("Active members"))
+    def active_users_count(self, instance) -> int | None:
+        return instance.useraccount.current_subscription.active_users_count
 
     @admin.display(description=_("Owner"))
     def organization_owner__link(self, instance):

--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -1058,8 +1058,6 @@ class OrganizationAdmin(QFieldCloudModelAdmin):
         "email",
         "organization_owner__link",
         "date_joined",
-        # "storage_usage__field",
-        "active_users_count",
     )
 
     search_fields = (
@@ -1072,7 +1070,6 @@ class OrganizationAdmin(QFieldCloudModelAdmin):
     readonly_fields = (
         "date_joined",
         "storage_usage__field",
-        "active_users_count",
         "active_users_links",
     )
 
@@ -1081,10 +1078,6 @@ class OrganizationAdmin(QFieldCloudModelAdmin):
     list_filter = ("date_joined",)
 
     autocomplete_fields = ("organization_owner",)
-
-    @admin.display(description=_("Active members"))
-    def active_users_count(self, instance) -> int:
-        return instance.useraccount.current_subscription.active_users_count
 
     @admin.display(description=_("Active members"))
     def active_users_links(self, instance) -> str:

--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -1087,7 +1087,7 @@ class OrganizationAdmin(QFieldCloudModelAdmin):
             userlinks = " ".join(model_admin_url(p, p.username) for p in persons)
         help_text = """
         <p style='font-size: 11px; color: var(--body-quiet-color)'>
-            Active users have triggererd at least one job or uploaded at least one delta in the current billing period.
+            Active members have triggererd at least one job or uploaded at least one delta in the current billing period.
             These are all the users who will be billed -- plan included or additional.
         </p>
         """

--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -1084,7 +1084,7 @@ class OrganizationAdmin(QFieldCloudModelAdmin):
         persons = instance.useraccount.current_subscription.active_users
         userlinks = "<p> - </p>"
         if persons:
-            userlinks = " ".join(model_admin_url(p, p.username) for p in persons)
+            userlinks = "<br>".join(model_admin_url(p, p.username) for p in persons)
         help_text = """
         <p style='font-size: 11px; color: var(--body-quiet-color)'>
             Active members have triggererd at least one job or uploaded at least one delta in the current billing period.

--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -1086,7 +1086,7 @@ class OrganizationAdmin(QFieldCloudModelAdmin):
         if persons:
             userlinks = "<br>".join(model_admin_url(p, p.username) for p in persons)
         help_text = """
-        <p style='font-size: 11px; color: var(--body-quiet-color)'>
+        <p style="font-size: 11px; color: var(--body-quiet-color)">
             Active members have triggererd at least one job or uploaded at least one delta in the current billing period.
             These are all the users who will be billed -- plan included or additional.
         </p>

--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -1089,14 +1089,16 @@ class OrganizationAdmin(QFieldCloudModelAdmin):
     @admin.display(description=_("Active members"))
     def active_users_links(self, instance) -> str:
         persons = instance.useraccount.current_subscription.active_users
-        if persons.exists():
+        userlinks = "<p> - </p>"
+        if persons:
             userlinks = " ".join(model_admin_url(p, p.username) for p in persons)
-            help_text = """
-            <p style='font-size: 11px; color: var(--body-quiet-color)'>
-                Active users have triggererd at least one job or uploaded at least one delta in the current billing period. These are all the users who will be billed -- plan included or additional.
-            </p>
-            """
-            return format_html(f"{userlinks} <br> {help_text}")
+        help_text = """
+        <p style='font-size: 11px; color: var(--body-quiet-color)'>
+            Active users have triggererd at least one job or uploaded at least one delta in the current billing period.
+            These are all the users who will be billed -- plan included or additional.
+        </p>
+        """
+        return format_html(f"{userlinks} {help_text}")
 
     @admin.display(description=_("Owner"))
     def organization_owner__link(self, instance):

--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -1051,6 +1051,7 @@ class OrganizationAdmin(QFieldCloudModelAdmin):
         "email",
         "organization_owner",
         "date_joined",
+        "active_users",
     )
     list_display = (
         "username",
@@ -1068,7 +1069,12 @@ class OrganizationAdmin(QFieldCloudModelAdmin):
         "organization_owner__email__iexact",
     )
 
-    readonly_fields = ("date_joined", "storage_usage__field", "active_users_count")
+    readonly_fields = (
+        "date_joined",
+        "storage_usage__field",
+        "active_users_count",
+        "active_users",
+    )
 
     list_select_related = ("organization_owner", "useraccount")
 
@@ -1079,6 +1085,14 @@ class OrganizationAdmin(QFieldCloudModelAdmin):
     @admin.display(description=_("Active members"))
     def active_users_count(self, instance) -> int | None:
         return instance.useraccount.current_subscription.active_users_count
+
+    @admin.display(description=_("Active members"))
+    def active_users(self, instance) -> str:
+        persons = instance.useraccount.current_subscription.active_users
+        if persons.exists():
+            userlinks = " ".join(model_admin_url(p, p.username) for p in persons)
+            help_text = "<p>(Active users have triggererd at least one job or uploaded at least one delta in the current billing period. These are all the users who will be billed -- plan included or additional.)</p>"
+            return format_html(f"{userlinks} <br> {help_text}")
 
     @admin.display(description=_("Owner"))
     def organization_owner__link(self, instance):

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -656,7 +656,9 @@ class Organization(User):
     # updated at
     updated_at = models.DateTimeField(auto_now=True)
 
-    def active_users(self, period_since: datetime, period_until: datetime):
+    def active_users(
+        self, period_since: datetime, period_until: datetime
+    ) -> models.Queryset:
         """Returns the queryset of active users in the given time interval.
 
         Active users are users triggering a job or pushing a delta on a project owned by the organization.

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -656,9 +656,7 @@ class Organization(User):
     # updated at
     updated_at = models.DateTimeField(auto_now=True)
 
-    def active_users(
-        self, period_since: datetime, period_until: datetime
-    ) -> models.Queryset:
+    def active_users(self, period_since: datetime, period_until: datetime):
         """Returns the queryset of active users in the given time interval.
 
         Active users are users triggering a job or pushing a delta on a project owned by the organization.

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -581,7 +581,7 @@ class AbstractSubscription(models.Model):
         )
 
     @property
-    def active_users(self):
+    def active_users(self) -> models.Queryset | None:
         if not self.account.user.is_organization:
             return None
 

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -581,7 +581,7 @@ class AbstractSubscription(models.Model):
         )
 
     @property
-    def active_users(self) -> models.Queryset | None:
+    def active_users(self):
         if not self.account.user.is_organization:
             return None
 

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -582,6 +582,7 @@ class AbstractSubscription(models.Model):
 
     @property
     def active_users(self):
+        "Returns the queryset of active users for running stripe billing period or None."
         if not self.account.user.is_organization:
             return None
 


### PR DESCRIPTION
Shows the active members, that have created a Job or a Delta for the Organization during the running stripe billing period in the admin.

The list of users in the detail view
![image](https://github.com/opengisch/qfieldcloud/assets/21113500/6adec495-a6ab-4680-8bd4-f23b7525d997)
(if no active members)
![image](https://github.com/opengisch/qfieldcloud/assets/21113500/f34584fd-fe18-46ca-94af-15732edcbbeb)


Dropped the active members count in the list_view - it would slow down too much:
It adds 4 Queries per organization. Without it is 6 Queries in total.

now:
![image](https://github.com/opengisch/qfieldcloud/assets/21113500/a74ae602-68b7-4b72-a238-ecb381bd3bc6)

before:
![image](https://github.com/opengisch/qfieldcloud/assets/21113500/2cad2756-66dc-4bda-bf7e-cf7bcd9d4658)






