### PR TITLE
Same number in comment and test_organization

### DIFF
--- a/docker-app/qfieldcloud/core/tests/test_organization.py
+++ b/docker-app/qfieldcloud/core/tests/test_organization.py
@@ -220,7 +220,7 @@ class QfcTestCase(APITestCase):
         # Initially, there is no billable user
         self.assertEqual(_active_users_count(), 0)
 
-        # User 1 creates a job
+        # 1. user2 creates a job
         Job.objects.create(
             project=project1,
             created_by=self.user2,
@@ -228,7 +228,7 @@ class QfcTestCase(APITestCase):
         # There is now 1 billable user
         self.assertEqual(_active_users_count(), 1)
 
-        # User 1 creates a delta
+        # 2. user2 creates a delta
         Delta.objects.create(
             deltafile_id=uuid.uuid4(),
             project=project1,
@@ -239,7 +239,7 @@ class QfcTestCase(APITestCase):
         # There is still 1 billable user
         self.assertEqual(_active_users_count(), 1)
 
-        # User 2 creates a job
+        # 3. user3 creates a job
         Job.objects.create(
             project=project1,
             created_by=self.user3,
@@ -247,7 +247,7 @@ class QfcTestCase(APITestCase):
         # There are 2 billable users
         self.assertEqual(_active_users_count(), 2)
 
-        # User 2 leaves the organization
+        # 4. user3 leaves the organization
         OrganizationMember.objects.filter(member=self.user3).delete()
 
         # There are still 2 billable users
@@ -256,10 +256,10 @@ class QfcTestCase(APITestCase):
         # Report at a different time is empty
         self.assertEqual(_active_users_count(now() + timedelta(days=365)), 0)
 
-        # User 3 creates a job
+        # 5. user4 creates a job
         Job.objects.create(
             project=project1,
             created_by=self.user4,
         )
-        # There are still 2 billable users, because self.user4 is staff
+        # There are still 2 billable users, because user4 is staff
         self.assertEqual(_active_users_count(), 2)


### PR DESCRIPTION
Some readability improvement as discussed here https://github.com/opengisch/qfieldcloud/pull/705#discussion_r1250774648