### PR TITLE
Ignore validation errors for sentry

### DIFF
--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -284,6 +284,7 @@ if SENTRY_DSN:
             PlanInsufficientError,
             QuotaError,
         )
+        from rest_framework.exceptions import ValidationError as RestValidationError
 
         ignored_exceptions = (
             ValidationError,
@@ -291,6 +292,7 @@ if SENTRY_DSN:
             QuotaError,
             PlanInsufficientError,
             InactiveSubscriptionError,
+            RestValidationError,
         )
 
         if "exc_info" in hint:


### PR DESCRIPTION
Will ignore the number one "error" there is --> wrong login credentials provided.
I was wondering if we should only ignore exceptions that are unhandled (e.g. this one is handled, so it will still be hidden). @faebebin any idea?