### PR TITLE
Bump `qfieldcloud-sdk` from `0.6.1` to `0.7.0` to ignore the `sha256` metadata

### DIFF
--- a/docker-qgis/requirements.txt
+++ b/docker-qgis/requirements.txt
@@ -3,4 +3,4 @@ typing-extensions>=3.7.4.3,<3.7.5
 tabulate==v0.8.9
 sentry-sdk
 requests>=2.28.1
-qfieldcloud-sdk==0.6.1
+qfieldcloud-sdk==0.7.0


### PR DESCRIPTION
Should make the workers considerably faster as the number of project files increase.