### PR TITLE
QfcLimitOffsetPagination default limit

### DIFF
--- a/docker-app/qfieldcloud/core/pagination.py
+++ b/docker-app/qfieldcloud/core/pagination.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable
+from itertools import islice
+from typing import Callable
 
 from django.conf import settings
 from rest_framework import pagination, response
@@ -28,21 +29,19 @@ class QfcLimitOffsetPagination(pagination.LimitOffsetPagination):
     """
 
     count_entries = True
-    default_limit = settings.QFIELDCLOUD_API_DEFAULT_PAGE_LIMIT
 
-    def get_headers(self) -> dict[str, Any]:
+    def get_headers(self) -> dict[str, int]:
         """
         Initializes a new header field to carry the number of paginated entries
         if the class method `count_entries` is `True`.
         """
-        if self.count_entries:
-            return {"X-Total-Count": self.count}
-        else:
-            return {}
+        return {"X-Total-Count": self.count}
 
     def get_paginated_response(self, data) -> response.Response:
         """
         Sets the header field initialized in the previous method to the number of paginated entries.
-        Return just the entries in the response body.
+        Return just the entries in the response body, slicing them to never exceed `settings.QFIELDCLOUD_API_DEFAULT_PAGE_LIMIT`.
         """
+        if self.request.GET.get("offset") and not self.request.GET.get("limit"):
+            data = islice(data, settings.QFIELDCLOUD_API_DEFAULT_PAGE_LIMIT)
         return response.Response(data, headers=self.get_headers())


### PR DESCRIPTION
- changed behaviour of QfcLimitOffset pagination class to not limit results unless a limit offset param is found in the request
- adjusted tests