### PR TITLE
Do not steal the ownership of the project if not explicitly provided

### DIFF
--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -57,7 +57,8 @@ class ProjectSerializer(serializers.ModelSerializer):
                     code="invalid",
                 )
         else:
-            internal_data["owner"] = self.context["request"].user
+            if not self.instance or not self.instance.owner:
+                internal_data["owner"] = self.context["request"].user
 
         if "private" in internal_data:
             if internal_data["private"] is not None:


### PR DESCRIPTION
Otherwise updating the project using the API will automatically change the project owner to the currently authenticated user.