### PR TITLE
Sending raw body to sentry

### DIFF
--- a/docker-app/qfieldcloud/core/middleware/requests.py
+++ b/docker-app/qfieldcloud/core/middleware/requests.py
@@ -25,7 +25,7 @@ def attach_keys(get_response):
         request_attributes = {
             "file_key": str(request.FILES.keys()),
             "meta": str(request.META),
-            "files": request.FILES.getlist("file")
+            "files": request.FILES.getlist("file"),
         }
         request.attached_keys = str(request_attributes)
         response = get_response(request)

--- a/docker-app/qfieldcloud/core/middleware/requests.py
+++ b/docker-app/qfieldcloud/core/middleware/requests.py
@@ -1,3 +1,7 @@
+import io
+import shutil
+
+
 def attach_keys(get_response):
     """
     QF-2540
@@ -6,12 +10,25 @@ def attach_keys(get_response):
     """
 
     def middleware(request):
+        input_stream = io.BufferedReader(io.BytesIO(request.body))
+
         request_attributes = {
             "file_key": str(request.FILES.keys()),
             "meta": str(request.META),
         }
+
+        # only report rawbody of less-than-10MBs multipart requests
+        if (
+            "multipart/form-data;boundary" in request.headers["Content-Type"]
+            and input_stream.tell() < 10000000
+        ):
+            output_stream = io.BytesIO()
+            shutil.copyfileobj(input_stream, output_stream)
+            request.body_stream = output_stream
+
         if "file" in request.FILES.keys():
             request_attributes["files"] = request.FILES.getlist("file")
+
         request.attached_keys = str(request_attributes)
         response = get_response(request)
         return response

--- a/docker-app/qfieldcloud/core/middleware/requests.py
+++ b/docker-app/qfieldcloud/core/middleware/requests.py
@@ -10,7 +10,7 @@ def attach_keys(get_response):
     """
 
     def middleware(request):
-        input_stream = io.BufferedReader(io.BytesIO(request.body))
+        input_stream = io.BytesIO(request.body)
 
         request_attributes = {
             "file_key": str(request.FILES.keys()),
@@ -27,6 +27,7 @@ def attach_keys(get_response):
             and "multipart/form-data;boundary" in content_type
             and input_stream.tell() < 10000000
         ):
+            request_attributes["content_type"] = content_type
             output_stream = io.BytesIO()
             shutil.copyfileobj(input_stream, output_stream)
             request.body_stream = output_stream

--- a/docker-app/qfieldcloud/core/middleware/requests.py
+++ b/docker-app/qfieldcloud/core/middleware/requests.py
@@ -1,33 +1,28 @@
 import io
 import shutil
+from typing import Any
 
 
 def attach_keys(get_response):
     """
     QF-2540
-    Annotate request with a str representation of relevant fields, so as to obtain a diff
-    by comparing with the post-serialized request later in the callstack.
+    Annotate request with: 
+    - a `str` representation of relevant fields, so as to obtain a diff by comparing with the post-serialized request later in the callstack;
+    - a byte-for-byte, non stealing copy of the raw body to inspect multipart boundaries.
     """
-
     def middleware(request):
+        input_stream = io.BytesIO(request.body)
+
         request_attributes = {
             "file_key": str(request.FILES.keys()),
             "meta": str(request.META),
         }
 
-        content_type = request.headers.get("Content-Type") or request.headers.get(
-            "content-type"
-        )
-
-        # only report raw body multipart requests
-        if content_type and "multipart/form-data;boundary" in content_type:
-            request_attributes["content_type"] = content_type
-            input_stream = io.BytesIO(request.body)
+        # only report raw body of POST requests with a < 10MBs content length
+        if request.META["REQUEST_METHOD"] == "POST" and int(request.META["CONTENT_LENGTH"]) < 10000000:
             output_stream = io.BytesIO()
             shutil.copyfileobj(input_stream, output_stream)
             request.body_stream = output_stream
-
-        if "file" in request.FILES.keys():
             request_attributes["files"] = request.FILES.getlist("file")
 
         request.attached_keys = str(request_attributes)

--- a/docker-app/qfieldcloud/core/middleware/requests.py
+++ b/docker-app/qfieldcloud/core/middleware/requests.py
@@ -11,23 +11,22 @@ def attach_keys(get_response):
     """
 
     def middleware(request):
-        input_stream = io.BytesIO(request.body)
+        # only report raw body of POST requests with a < 10MBs content length
+        if (
+            request.method == "POST"
+            and "Content-Length" in request.headers
+            and int(request.headers["Content-Length"]) < 10000000
+        ):
+            input_stream = io.BytesIO(request.body)
+            output_stream = io.BytesIO()
+            shutil.copyfileobj(input_stream, output_stream)
+            request.body_stream = output_stream
 
         request_attributes = {
             "file_key": str(request.FILES.keys()),
             "meta": str(request.META),
+            "files": request.FILES.getlist("file")
         }
-        # only report raw body of POST requests with a < 10MBs content length
-        if (
-            request.META["REQUEST_METHOD"] == "POST"
-            and "Content-Length" in request.headers
-            and int(request.headers["Content-Length"]) < 10000000
-        ):
-            output_stream = io.BytesIO()
-            shutil.copyfileobj(input_stream, output_stream)
-            request.body_stream = output_stream
-            request_attributes["files"] = request.FILES.getlist("file")
-
         request.attached_keys = str(request_attributes)
         response = get_response(request)
         return response

--- a/docker-app/qfieldcloud/core/middleware/requests.py
+++ b/docker-app/qfieldcloud/core/middleware/requests.py
@@ -17,15 +17,15 @@ def attach_keys(get_response):
     """
 
     def middleware(request):
-        # only report raw body of POST requests with a < 10MBs content length
+        # add a copy of the request body to the request
         if (
-            request.method == "POST"
+            settings.SENTRY_DSN
+            and request.method == "POST"
             and "Content-Length" in request.headers
             and (
                 int(request.headers["Content-Length"])
                 < config.SENTRY_REQUEST_MAX_SIZE_TO_SEND
             )
-            and settings.SENTRY_DSN
         ):
             logger.info("Making a temporary copy for request body.")
 

--- a/docker-app/qfieldcloud/core/middleware/requests.py
+++ b/docker-app/qfieldcloud/core/middleware/requests.py
@@ -1,15 +1,15 @@
 import io
 import shutil
-from typing import Any
 
 
 def attach_keys(get_response):
     """
     QF-2540
-    Annotate request with: 
+    Annotate request with:
     - a `str` representation of relevant fields, so as to obtain a diff by comparing with the post-serialized request later in the callstack;
     - a byte-for-byte, non stealing copy of the raw body to inspect multipart boundaries.
     """
+
     def middleware(request):
         input_stream = io.BytesIO(request.body)
 
@@ -19,7 +19,10 @@ def attach_keys(get_response):
         }
 
         # only report raw body of POST requests with a < 10MBs content length
-        if request.META["REQUEST_METHOD"] == "POST" and int(request.META["CONTENT_LENGTH"]) < 10000000:
+        if (
+            request.META["REQUEST_METHOD"] == "POST"
+            and int(request.META["CONTENT_LENGTH"]) < 10000000
+        ):
             output_stream = io.BytesIO()
             shutil.copyfileobj(input_stream, output_stream)
             request.body_stream = output_stream

--- a/docker-app/qfieldcloud/core/middleware/requests.py
+++ b/docker-app/qfieldcloud/core/middleware/requests.py
@@ -10,8 +10,6 @@ def attach_keys(get_response):
     """
 
     def middleware(request):
-        input_stream = io.BytesIO(request.body)
-
         request_attributes = {
             "file_key": str(request.FILES.keys()),
             "meta": str(request.META),
@@ -21,13 +19,13 @@ def attach_keys(get_response):
             "content-type"
         )
 
-        # only report rawbody of less-than-10MBs multipart requests
+        # only report raw body multipart requests
         if (
             content_type
             and "multipart/form-data;boundary" in content_type
-            and input_stream.tell() < 10000000
         ):
             request_attributes["content_type"] = content_type
+            input_stream = io.BytesIO(request.body)
             output_stream = io.BytesIO()
             shutil.copyfileobj(input_stream, output_stream)
             request.body_stream = output_stream

--- a/docker-app/qfieldcloud/core/middleware/requests.py
+++ b/docker-app/qfieldcloud/core/middleware/requests.py
@@ -17,9 +17,14 @@ def attach_keys(get_response):
             "meta": str(request.META),
         }
 
+        content_type = request.headers.get("Content-Type") or request.headers.get(
+            "content-type"
+        )
+
         # only report rawbody of less-than-10MBs multipart requests
         if (
-            "multipart/form-data;boundary" in request.headers["Content-Type"]
+            content_type
+            and "multipart/form-data;boundary" in content_type
             and input_stream.tell() < 10000000
         ):
             output_stream = io.BytesIO()

--- a/docker-app/qfieldcloud/core/middleware/requests.py
+++ b/docker-app/qfieldcloud/core/middleware/requests.py
@@ -17,11 +17,11 @@ def attach_keys(get_response):
             "file_key": str(request.FILES.keys()),
             "meta": str(request.META),
         }
-
         # only report raw body of POST requests with a < 10MBs content length
         if (
             request.META["REQUEST_METHOD"] == "POST"
-            and int(request.headers["CONTENT_LENGTH"]) < 10000000
+            and "Content-Length" in request.headers
+            and int(request.headers["Content-Length"]) < 10000000
         ):
             output_stream = io.BytesIO()
             shutil.copyfileobj(input_stream, output_stream)

--- a/docker-app/qfieldcloud/core/middleware/requests.py
+++ b/docker-app/qfieldcloud/core/middleware/requests.py
@@ -1,6 +1,8 @@
 import io
 import shutil
 
+from constance import config
+
 
 def attach_keys(get_response):
     """
@@ -15,7 +17,8 @@ def attach_keys(get_response):
         if (
             request.method == "POST"
             and "Content-Length" in request.headers
-            and int(request.headers["Content-Length"]) < 10000000
+            and int(request.headers["Content-Length"])
+            < config.SENTRY_REQUEST_MAX_SIZE_TO_SEND
         ):
             input_stream = io.BytesIO(request.body)
             output_stream = io.BytesIO()

--- a/docker-app/qfieldcloud/core/middleware/requests.py
+++ b/docker-app/qfieldcloud/core/middleware/requests.py
@@ -1,7 +1,11 @@
 import io
+import logging
 import shutil
 
 from constance import config
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
 
 
 def attach_keys(get_response):
@@ -17,9 +21,14 @@ def attach_keys(get_response):
         if (
             request.method == "POST"
             and "Content-Length" in request.headers
-            and int(request.headers["Content-Length"])
-            < config.SENTRY_REQUEST_MAX_SIZE_TO_SEND
+            and (
+                int(request.headers["Content-Length"])
+                < config.SENTRY_REQUEST_MAX_SIZE_TO_SEND
+            )
+            and settings.SENTRY_DSN
         ):
+            logger.info("Making a temporary copy for request body.")
+
             input_stream = io.BytesIO(request.body)
             output_stream = io.BytesIO()
             shutil.copyfileobj(input_stream, output_stream)

--- a/docker-app/qfieldcloud/core/middleware/requests.py
+++ b/docker-app/qfieldcloud/core/middleware/requests.py
@@ -20,10 +20,7 @@ def attach_keys(get_response):
         )
 
         # only report raw body multipart requests
-        if (
-            content_type
-            and "multipart/form-data;boundary" in content_type
-        ):
+        if content_type and "multipart/form-data;boundary" in content_type:
             request_attributes["content_type"] = content_type
             input_stream = io.BytesIO(request.body)
             output_stream = io.BytesIO()

--- a/docker-app/qfieldcloud/core/middleware/requests.py
+++ b/docker-app/qfieldcloud/core/middleware/requests.py
@@ -21,7 +21,7 @@ def attach_keys(get_response):
         # only report raw body of POST requests with a < 10MBs content length
         if (
             request.META["REQUEST_METHOD"] == "POST"
-            and int(request.META["CONTENT_LENGTH"]) < 10000000
+            and int(request.headers["CONTENT_LENGTH"]) < 10000000
         ):
             output_stream = io.BytesIO()
             shutil.copyfileobj(input_stream, output_stream)

--- a/docker-app/qfieldcloud/core/tests/test_sentry.py
+++ b/docker-app/qfieldcloud/core/tests/test_sentry.py
@@ -65,4 +65,3 @@ class QfcTestCase(TestCase):
         }
         will_be_sent = report_serialization_diff_to_sentry(**mock_payload)
         self.assertTrue(will_be_sent)
-        print(f"Body sent to Sentry: {self.body_stream.getvalue()}")

--- a/docker-app/qfieldcloud/core/tests/test_sentry.py
+++ b/docker-app/qfieldcloud/core/tests/test_sentry.py
@@ -42,7 +42,8 @@ class QfcTestCase(APITestCase):
                 }
             ),
             "buffer": StringIO("The traceback of the exception to raise"),
-            "capture_message": True,  # so that sentry receives attachments even when there's no exception/event
+            "capture_message": True,  # so that sentry receives attachments even when there's no exception/event,
+            "body_stream": None
         }
         will_be_sent = report_serialization_diff_to_sentry(**mock_payload)
         self.assertTrue(will_be_sent)

--- a/docker-app/qfieldcloud/core/tests/test_sentry.py
+++ b/docker-app/qfieldcloud/core/tests/test_sentry.py
@@ -43,7 +43,7 @@ class QfcTestCase(APITestCase):
             ),
             "buffer": StringIO("The traceback of the exception to raise"),
             "capture_message": True,  # so that sentry receives attachments even when there's no exception/event,
-            "body_stream": None
+            "body_stream": None,
         }
         will_be_sent = report_serialization_diff_to_sentry(**mock_payload)
         self.assertTrue(will_be_sent)

--- a/docker-app/qfieldcloud/core/tests/test_sentry.py
+++ b/docker-app/qfieldcloud/core/tests/test_sentry.py
@@ -1,11 +1,13 @@
 import shutil
 from io import BytesIO, StringIO
-from os import environ
 from unittest import skipIf
 
+from django.conf import settings
 from django.test import Client, TestCase
 
 from ..utils2.sentry import report_serialization_diff_to_sentry
+
+sentry_is_configured = all([settings.SENTRY_DSN, settings.SENTRY_REPORT_FULL_BODY])
 
 
 class QfcTestCase(TestCase):
@@ -25,7 +27,7 @@ class QfcTestCase(TestCase):
         cls.body_stream = output_stream
 
     @skipIf(
-        environ.get("SENTRY_DSN", False),
+        not sentry_is_configured,
         "Do not run this test when Sentry's DSN is not set.",
     )
     def test_logging_with_sentry(self):
@@ -63,3 +65,4 @@ class QfcTestCase(TestCase):
         }
         will_be_sent = report_serialization_diff_to_sentry(**mock_payload)
         self.assertTrue(will_be_sent)
+        print(f"Body sent to Sentry: {self.body_stream.getvalue()}")

--- a/docker-app/qfieldcloud/core/tests/test_sentry.py
+++ b/docker-app/qfieldcloud/core/tests/test_sentry.py
@@ -7,8 +7,6 @@ from django.test import Client, TestCase
 
 from ..utils2.sentry import report_serialization_diff_to_sentry
 
-sentry_is_configured = all([settings.SENTRY_DSN, settings.SENTRY_REPORT_FULL_BODY])
-
 
 class QfcTestCase(TestCase):
     @classmethod
@@ -27,7 +25,7 @@ class QfcTestCase(TestCase):
         cls.body_stream = output_stream
 
     @skipIf(
-        not sentry_is_configured,
+        not settings.SENTRY_DSN,
         "Do not run this test when Sentry's DSN is not set.",
     )
     def test_logging_with_sentry(self):

--- a/docker-app/qfieldcloud/core/tests/test_sentry.py
+++ b/docker-app/qfieldcloud/core/tests/test_sentry.py
@@ -1,4 +1,3 @@
-import shutil
 from io import BytesIO, StringIO
 from unittest import skipIf
 
@@ -19,10 +18,7 @@ class QfcTestCase(TestCase):
             format="multipart",
         )
         request = response.wsgi_request
-        input_stream = BytesIO(request.body)
-        output_stream = BytesIO()
-        shutil.copyfileobj(input_stream, output_stream)
-        cls.body_stream = output_stream
+        cls.body_stream = BytesIO(request.read())
 
     @skipIf(
         not settings.SENTRY_DSN,

--- a/docker-app/qfieldcloud/core/utils2/sentry.py
+++ b/docker-app/qfieldcloud/core/utils2/sentry.py
@@ -2,6 +2,7 @@ import logging
 from io import BytesIO, StringIO
 
 import sentry_sdk
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +43,7 @@ def report_serialization_diff_to_sentry(
                 filename=filename,
             )
 
-            if body_stream:
+            if body_stream and settings.SENTRY_REPORT_FULL_BODY:
                 filename = f"{name}_rawbody.txt"
                 scope.add_attachment(bytes=body_stream.getvalue(), filename=filename)
 

--- a/docker-app/qfieldcloud/core/utils2/sentry.py
+++ b/docker-app/qfieldcloud/core/utils2/sentry.py
@@ -43,8 +43,9 @@ def report_serialization_diff_to_sentry(
             )
 
             if body_stream:
+                initial_chunk = body_stream.read(500)
                 filename = f"{name}_rawbody.txt"
-                scope.add_attachment(bytes=body_stream.getvalue(), filename=filename)
+                scope.add_attachment(bytes=initial_chunk, filename=filename)
 
             if capture_message:
                 sentry_sdk.capture_message("Sending to Sentry...", scope=scope)

--- a/docker-app/qfieldcloud/core/utils2/sentry.py
+++ b/docker-app/qfieldcloud/core/utils2/sentry.py
@@ -11,7 +11,7 @@ def report_serialization_diff_to_sentry(
     pre_serialization: str,
     post_serialization: str,
     buffer: StringIO,
-    body_stream: BytesIO,
+    body_stream: BytesIO | None,
     capture_message=False,
 ) -> bool:
     """
@@ -42,8 +42,9 @@ def report_serialization_diff_to_sentry(
                 filename=filename,
             )
 
-            filename = f"{name}_rawbody.txt"
-            scope.add_attachment(bytes=body_stream.getvalue(), filename=filename)
+            if body_stream:
+                filename = f"{name}_rawbody.txt"
+                scope.add_attachment(bytes=body_stream.getvalue(), filename=filename)
 
             if capture_message:
                 sentry_sdk.capture_message("Sending to Sentry...", scope=scope)

--- a/docker-app/qfieldcloud/core/utils2/sentry.py
+++ b/docker-app/qfieldcloud/core/utils2/sentry.py
@@ -2,7 +2,6 @@ import logging
 from io import BytesIO, StringIO
 
 import sentry_sdk
-from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +42,7 @@ def report_serialization_diff_to_sentry(
                 filename=filename,
             )
 
-            if body_stream and settings.SENTRY_REPORT_FULL_BODY:
+            if body_stream:
                 filename = f"{name}_rawbody.txt"
                 scope.add_attachment(bytes=body_stream.getvalue(), filename=filename)
 

--- a/docker-app/qfieldcloud/core/utils2/sentry.py
+++ b/docker-app/qfieldcloud/core/utils2/sentry.py
@@ -43,9 +43,8 @@ def report_serialization_diff_to_sentry(
             )
 
             if body_stream:
-                initial_chunk = body_stream.read(500)
                 filename = f"{name}_rawbody.txt"
-                scope.add_attachment(bytes=initial_chunk, filename=filename)
+                scope.add_attachment(bytes=body_stream.getvalue(), filename=filename)
 
             if capture_message:
                 sentry_sdk.capture_message("Sending to Sentry...", scope=scope)

--- a/docker-app/qfieldcloud/core/utils2/sentry.py
+++ b/docker-app/qfieldcloud/core/utils2/sentry.py
@@ -1,5 +1,5 @@
 import logging
-from io import StringIO
+from io import BytesIO, StringIO
 
 import sentry_sdk
 
@@ -11,6 +11,7 @@ def report_serialization_diff_to_sentry(
     pre_serialization: str,
     post_serialization: str,
     buffer: StringIO,
+    body_stream: BytesIO,
     capture_message=False,
 ) -> bool:
     """
@@ -20,10 +21,12 @@ def report_serialization_diff_to_sentry(
         pre_serialization: str representing the request `files` keys and meta information before serialization and middleware.
         post_serialization: str representing the request `files` keys and meta information after serialization and middleware.
         buffer: StringIO buffer from which to extract traceback capturing callstack ahead of the calling function.
+        bodystream: BytesIO buffer capturing the request's raw body.
         capture_message: bool used as a flag by the caller to create an extra event against Sentry to attach the files to.
     """
     with sentry_sdk.configure_scope() as scope:
         try:
+
             filename = f"{name}_contents.txt"
             scope.add_attachment(
                 bytes=bytes(
@@ -38,9 +41,14 @@ def report_serialization_diff_to_sentry(
                 bytes=bytes(buffer.getvalue(), encoding="utf8"),
                 filename=filename,
             )
+
+            filename = f"{name}_rawbody.txt"
+            scope.add_attachment(bytes=body_stream.getvalue(), filename=filename)
+
             if capture_message:
                 sentry_sdk.capture_message("Sending to Sentry...", scope=scope)
             return True
+
         except Exception as error:
             sentry_sdk.capture_exception(error)
             logging.error(f"Unable to send file to Sentry: failed on {error}")

--- a/docker-app/qfieldcloud/core/utils2/sentry.py
+++ b/docker-app/qfieldcloud/core/utils2/sentry.py
@@ -26,6 +26,7 @@ def report_serialization_diff_to_sentry(
     """
     with sentry_sdk.configure_scope() as scope:
         try:
+            logger.info("Sending explicit sentry report!")
 
             filename = f"{name}_contents.txt"
             scope.add_attachment(
@@ -47,10 +48,10 @@ def report_serialization_diff_to_sentry(
                 scope.add_attachment(bytes=body_stream.getvalue(), filename=filename)
 
             if capture_message:
-                sentry_sdk.capture_message("Sending to Sentry...", scope=scope)
+                sentry_sdk.capture_message("Explicit Sentry report!", scope=scope)
             return True
 
         except Exception as error:
+            logger.error(f"Unable to send file to Sentry: failed on {error}")
             sentry_sdk.capture_exception(error)
-            logging.error(f"Unable to send file to Sentry: failed on {error}")
             return False

--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -222,6 +222,7 @@ class DownloadPushDeleteFileView(views.APIView):
                 pre_serialization=request.attached_keys,
                 post_serialization=str(request_attributes),
                 buffer=buffer,
+                body_stream=request.body_stream,
             )
             raise exceptions.EmptyContentError()
 

--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -222,9 +222,7 @@ class DownloadPushDeleteFileView(views.APIView):
                 pre_serialization=request.attached_keys,
                 post_serialization=str(request_attributes),
                 buffer=buffer,
-                body_stream=request.body_stream
-                if hasattr(request, "body_stream")
-                else None,
+                body_stream=getattr(request, "body_stream", None),
             )
             raise exceptions.EmptyContentError()
 

--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -222,7 +222,9 @@ class DownloadPushDeleteFileView(views.APIView):
                 pre_serialization=request.attached_keys,
                 post_serialization=str(request_attributes),
                 buffer=buffer,
-                body_stream=request.body_stream,
+                body_stream=request.body_stream
+                if hasattr(request, "body_stream")
+                else None,
             )
             raise exceptions.EmptyContentError()
 

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -320,6 +320,10 @@ if SENTRY_DSN:
         # environment=ENVIRONMENT,
     )
 
+# QF-2704
+# Flag to turn on/off byte-for-byte copy of request's body
+# Only requests with a < 10MB body will be reported
+SENTRY_REPORT_FULL_BODY = True
 
 # Django allauth configurations
 # https://django-allauth.readthedocs.io/en/latest/configuration.html

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -461,6 +461,10 @@ CONSTANCE_CONFIG = {
         "1000m",
         "Maximum memory for each QGIS worker container.",
     ),
+    "SENTRY_REQUEST_MAX_SIZE_TO_SEND": (
+        0,
+        "Maximum request size to send the raw request to Sentry. Value 0 disables the raw request copy.",
+    ),
     "WORKER_QGIS_CPU_SHARES": (
         512,
         "Share of CPUs for each QGIS worker container. By default all containers have value 1024 set by docker.",
@@ -481,6 +485,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
         "WORKER_QGIS_MEMORY_LIMIT",
         "WORKER_QGIS_CPU_SHARES",
     ),
+    "Debug": ("SENTRY_REQUEST_MAX_SIZE_TO_SEND",),
     "Subscription": ("TRIAL_PERIOD_DAYS",),
 }
 


### PR DESCRIPTION
A few clarifications and observations:
- Actually this is fine => ~~`DownloadPushDeleteFileView.post()` does not trigger the `parse()` method of its declared parser_class (MultiPartParser), because I did subclass this parser class in a previous version of this PR, and my override of `parse()` never triggered in my tests~~
- This is done => ~~room for improvement: ensure that the intended `parse()` function is called, so that we can debug more from that context; this might open the door to reading the request.body only for requests that fail, and not all of them as is the case here.~~