### PR TITLE
Make `AuthenticationFailed` errors just that instead of using `ValidationError`

### DIFF
--- a/docker-app/qfieldcloud/authentication/serializers.py
+++ b/docker-app/qfieldcloud/authentication/serializers.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
 from django.utils.translation import gettext as _
 from rest_framework import serializers
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import AuthenticationFailed
 
 from .models import AuthToken
 
@@ -26,7 +26,7 @@ class LoginSerializer(serializers.Serializer):
             user = self.authenticate(email=email, password=password)
         else:
             msg = _('Must include "email" and "password".')
-            raise ValidationError(msg)
+            raise AuthenticationFailed(msg)
 
         return user
 
@@ -37,7 +37,7 @@ class LoginSerializer(serializers.Serializer):
             user = self.authenticate(username=username, password=password)
         else:
             msg = _('Must include "username" and "password".')
-            raise ValidationError(msg)
+            raise AuthenticationFailed(msg)
 
         return user
 
@@ -50,7 +50,7 @@ class LoginSerializer(serializers.Serializer):
             user = self.authenticate(username=username, password=password)
         else:
             msg = _('Must include either "username" or "email" and "password".')
-            raise ValidationError(msg)
+            raise AuthenticationFailed(msg)
 
         return user
 
@@ -97,10 +97,10 @@ class LoginSerializer(serializers.Serializer):
         if user:
             if not user.is_active:
                 msg = _("User account is disabled.")
-                raise ValidationError(msg)
+                raise AuthenticationFailed(msg)
         else:
             msg = _("Unable to log in with provided credentials.")
-            raise ValidationError(msg)
+            raise AuthenticationFailed(msg)
 
         attrs["user"] = user
         return attrs

--- a/docker-app/qfieldcloud/authentication/tests/test_authentication.py
+++ b/docker-app/qfieldcloud/authentication/tests/test_authentication.py
@@ -233,7 +233,10 @@ class QfcTestCase(APITransactionTestCase):
         self.assertEqual(u1.auth_tokens.order_by("-created_at").count(), 1)
         self.assertEqual(o1.auth_tokens.order_by("-created_at").count(), 0)
         self.assertEqual(t1.auth_tokens.order_by("-created_at").count(), 0)
-        self.assertEqual(response.json(), {"code": "api_error", "message": "API Error"})
+        self.assertEqual(
+            response.json(),
+            {"code": "authentication_failed", "message": "Authentication failed"},
+        )
 
         # teams cannot login
         response = self.login("t1", "abc123", success=False)
@@ -241,4 +244,7 @@ class QfcTestCase(APITransactionTestCase):
         self.assertEqual(u1.auth_tokens.order_by("-created_at").count(), 1)
         self.assertEqual(o1.auth_tokens.order_by("-created_at").count(), 0)
         self.assertEqual(t1.auth_tokens.order_by("-created_at").count(), 0)
-        self.assertEqual(response.json(), {"code": "api_error", "message": "API Error"})
+        self.assertEqual(
+            response.json(),
+            {"code": "authentication_failed", "message": "Authentication failed"},
+        )


### PR DESCRIPTION
Makes QFieldSync nicer:

| before | after |
|--|--|
| ![image](https://github.com/opengisch/qfieldcloud/assets/2820439/12d2a8a6-8520-44b5-af88-8727eb6cc46f) | ![image](https://github.com/opengisch/qfieldcloud/assets/2820439/f1d24e10-9dc9-4c8b-b697-58472b48a1a4) | 
