### PR TITLE
Cleanup @deprecated code that affect only tests

### DIFF
--- a/docker-app/qfieldcloud/core/exceptions.py
+++ b/docker-app/qfieldcloud/core/exceptions.py
@@ -1,4 +1,3 @@
-from deprecated import deprecated
 from rest_framework import status
 
 
@@ -177,12 +176,3 @@ class ProjectAlreadyExistsError(QFieldCloudException):
     code = "project_already_exists"
     message = "This user already owns a project with the same name."
     status_code = status.HTTP_400_BAD_REQUEST
-
-
-@deprecated("moved to subscription")
-class ReachedMaxOrganizationMembersError(QFieldCloudException):
-    """Raised when an organization has exhausted its quota of members"""
-
-    code = "organization_has_max_number_of_members"
-    message = "Cannot add new organization members, account limit has been reached."
-    status_code = status.HTTP_403_FORBIDDEN

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -416,11 +416,6 @@ class UserAccount(models.Model):
         return Subscription.get_or_create_current_subscription(self)
 
     @property
-    @deprecated("Use `current_subscription` instead")
-    def active_subscription(self):
-        return self.current_subscription()
-
-    @property
     def upcoming_subscription(self):
         from qfieldcloud.subscription.models import get_subscription_model
 
@@ -438,13 +433,6 @@ class UserAccount(models.Model):
             return None
 
     @property
-    @deprecated("Use `UserAccount().storage_used_bytes` instead")
-    # TODO delete this method after refactoring tests so it's no longer used there
-    def storage_used_mb(self) -> float:
-        """Returns the storage used in MB"""
-        return self.storage_used_bytes / 1000 / 1000
-
-    @property
     def storage_used_bytes(self) -> float:
         """Returns the storage used in bytes"""
         used_quota = (
@@ -456,14 +444,6 @@ class UserAccount(models.Model):
         )
 
         return used_quota
-
-    @property
-    @deprecated("Use `UserAccount().storage_free_bytes` instead")
-    # TODO delete this method after refactoring tests so it's no longer used there
-    def storage_free_mb(self) -> float:
-        """Returns the storage quota left in MB (quota from account and packages minus storage of all owned projects)"""
-
-        return self.storage_free_bytes / 1000 / 1000
 
     @property
     def storage_free_bytes(self) -> float:

--- a/docker-app/qfieldcloud/core/permissions_utils.py
+++ b/docker-app/qfieldcloud/core/permissions_utils.py
@@ -1,6 +1,5 @@
 from typing import List, Literal, Union
 
-from deprecated import deprecated
 from django.utils.translation import gettext as _
 from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core.models import (
@@ -336,33 +335,6 @@ def can_apply_pending_deltas_for_project(user: QfcUser, project: Project) -> boo
     )
 
 
-@deprecated("Use `can_set_delta_status_for_project` instead")
-def can_apply_deltas(user: QfcUser, project: Project) -> bool:
-    return user_has_project_roles(
-        user,
-        project,
-        [
-            ProjectCollaborator.Roles.ADMIN,
-            ProjectCollaborator.Roles.MANAGER,
-            ProjectCollaborator.Roles.EDITOR,
-            ProjectCollaborator.Roles.REPORTER,
-        ],
-    )
-
-
-@deprecated("Use `can_set_delta_status_for_project` instead")
-def can_overwrite_deltas(user: QfcUser, project: Project) -> bool:
-    return user_has_project_roles(
-        user,
-        project,
-        [
-            ProjectCollaborator.Roles.ADMIN,
-            ProjectCollaborator.Roles.MANAGER,
-            ProjectCollaborator.Roles.EDITOR,
-        ],
-    )
-
-
 def can_set_delta_status_for_project(user: QfcUser, project: Project) -> bool:
     return user_has_project_roles(
         user,
@@ -412,47 +384,6 @@ def can_create_delta(user: QfcUser, delta: Delta) -> bool:
             return True
 
     return False
-
-
-@deprecated("Use `can_set_delta_status` instead")
-def can_retry_delta(user: QfcUser, delta: Delta) -> bool:
-    if not can_apply_deltas(user, delta.project):
-        return False
-
-    if delta.last_status not in (
-        Delta.Status.CONFLICT,
-        Delta.Status.NOT_APPLIED,
-        Delta.Status.ERROR,
-    ):
-        return False
-
-    return True
-
-
-@deprecated("Use `can_set_delta_status` instead")
-def can_overwrite_delta(user: QfcUser, delta: Delta) -> bool:
-    if not can_overwrite_deltas(user, delta.project):
-        return False
-
-    if delta.last_status not in (Delta.Status.CONFLICT):
-        return False
-
-    return True
-
-
-@deprecated("Use `can_set_delta_status` instead")
-def can_ignore_delta(user: QfcUser, delta: Delta) -> bool:
-    if not can_apply_deltas(user, delta.project):
-        return False
-
-    if delta.last_status not in (
-        Delta.Status.CONFLICT,
-        Delta.Status.NOT_APPLIED,
-        Delta.Status.ERROR,
-    ):
-        return False
-
-    return True
 
 
 def can_read_jobs(user: QfcUser, project: Project) -> bool:

--- a/docker-app/qfieldcloud/notifs/cron.py
+++ b/docker-app/qfieldcloud/notifs/cron.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from django.conf import settings
 from django.core.mail import send_mail
@@ -43,12 +44,14 @@ class SendNotificationsJob(CronJobBase):
                     logging.warning(f"{user} has notifications, but no email set !")
                     continue
 
+                QFIELDCLOUD_HOST = os.environ.get("QFIELDCLOUD_HOST")
+
                 logging.debug(f"Sending an email to {user} !")
 
                 context = {
                     "notifs": notifs,
                     "username": user.username,
-                    "hostname": settings.ALLOWED_HOSTS[0],
+                    "hostname": QFIELDCLOUD_HOST,
                 }
 
                 subject = render_to_string(

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -368,10 +368,6 @@ class SubscriptionQuerySet(models.QuerySet):
 
         return qs
 
-    @deprecated("Use `current` instead. Remove this once parent repo uses current")
-    def active(self):
-        return self.current()
-
     def managed_by(self, user_id: int):
         """Returns all subscriptions that are managed by given `user_id`. It means the owner personal account and all organizations they own.
 
@@ -697,11 +693,6 @@ class AbstractSubscription(models.Model):
             subscription = cls.create_default_plan_subscription(account)
 
         return subscription
-
-    @property
-    @deprecated("Use `get_or_create_current_subscription` instead")
-    def get_or_create_active_subscription(cls, account: UserAccount) -> "Subscription":
-        return cls.get_or_create_current_subscription(account)
 
     @classmethod
     def get_upcoming_subscription(cls, account: UserAccount) -> "Subscription":

--- a/docker-app/qfieldcloud/subscription/tests/test_package.py
+++ b/docker-app/qfieldcloud/subscription/tests/test_package.py
@@ -64,8 +64,8 @@ class QfcTestCase(APITransactionTestCase):
         future_storage_package_quantity,
         future_storage_package_mb,
         future_storage_package_changed_mb,
-        storage_used_bytes,
-        storage_free_bytes,
+        storage_used_mb,
+        storage_free_mb,
         user=None,
     ):
         if user is None:
@@ -107,8 +107,8 @@ class QfcTestCase(APITransactionTestCase):
             user.useraccount.current_subscription.future_storage_package_changed_mb,
             future_storage_package_changed_mb,
         )
-        self.assertEqual(user.useraccount.storage_used_bytes, storage_used_bytes)
-        self.assertEqual(user.useraccount.storage_free_bytes, storage_free_bytes)
+        self.assertEqual(user.useraccount.storage_used_bytes, storage_used_mb * 1000 * 1000)
+        self.assertEqual(user.useraccount.storage_free_bytes, storage_free_mb * 1000 * 1000)
 
     def test_get_storage_package_type(self):
         PackageType.objects.all().delete()
@@ -139,8 +139,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=0,
-            storage_free_bytes=self.plan_default.storage_mb * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=self.plan_default.storage_mb,
         )
 
     def test_default_plan_raises_when_adding_active_storage(self):
@@ -163,8 +163,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=0,
-            storage_free_bytes=self.plan_default.storage_mb * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=self.plan_default.storage_mb,
         )
 
     def test_default_plan_ignores_active_package(self):
@@ -190,8 +190,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=0,
-            storage_free_bytes=self.plan_default.storage_mb * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=self.plan_default.storage_mb,
         )
 
     def test_premium_plan_without_additional_storage(self):
@@ -205,8 +205,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=0,
-            storage_free_bytes=1 * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=1,
         )
 
     def test_premium_plan_with_active_storage(self):
@@ -228,8 +228,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=-1000,
-            storage_used_bytes=0,
-            storage_free_bytes=1001 * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=1001,
         )
 
     def test_premium_plan_with_active_storage_without_end_date(self):
@@ -251,8 +251,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=1,
             future_storage_package_mb=1000,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=0,
-            storage_free_bytes=1001 * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=1001,
         )
 
     def test_premium_plan_with_expired_storage(self):
@@ -274,8 +274,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=0,
-            storage_free_bytes=1 * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=1,
         )
 
     def test_premium_plan_with_future_storage(self):
@@ -297,8 +297,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=1,
             future_storage_package_mb=1000,
             future_storage_package_changed_mb=1000,
-            storage_used_bytes=0,
-            storage_free_bytes=1 * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=1,
         )
 
     def test_premium_plan_with_active_and_future_and_expired_storage(self):
@@ -335,8 +335,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=1,
             future_storage_package_mb=1000,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=0,
-            storage_free_bytes=1001 * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=1001,
         )
 
     def test_premium_plan_can_add_active_storage(self):
@@ -354,8 +354,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=1,
             future_storage_package_mb=1000,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=0,
-            storage_free_bytes=1001 * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=1001,
         )
 
     def test_premium_plan_can_add_active_storage_with_quantity_of_42(self):
@@ -373,8 +373,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=42,
             future_storage_package_mb=42000,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=0,
-            storage_free_bytes=42001 * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=42001,
         )
 
     def test_premium_plan_can_add_future_storage(self):
@@ -394,8 +394,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=1,
             future_storage_package_mb=1000,
             future_storage_package_changed_mb=1000,
-            storage_used_bytes=0,
-            storage_free_bytes=1 * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=1,
         )
 
     def test_premium_plan_can_replace_active_storage(self):
@@ -417,8 +417,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=1,
             future_storage_package_mb=1000,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=0,
-            storage_free_bytes=1001 * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=1001,
         )
 
         (
@@ -443,8 +443,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=2,
             future_storage_package_mb=2000,
             future_storage_package_changed_mb=1000,
-            storage_used_bytes=0,
-            storage_free_bytes=1001 * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=1001,
         )
 
     def test_storage_with_custom_additional_storage(self):
@@ -475,8 +475,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=1,
             future_storage_package_mb=2,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=0,
-            storage_free_bytes=3 * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=3,
         )
 
     def test_storage_cannot_have_packages_with_time_overlaps(self):
@@ -499,8 +499,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=-1000,
-            storage_used_bytes=0,
-            storage_free_bytes=1001 * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=1001,
         )
 
         with self.assertRaises(django.db.utils.IntegrityError):
@@ -523,8 +523,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=-1000,
-            storage_used_bytes=0,
-            storage_free_bytes=1001 * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=1001,
         )
 
     def test_storage_cannot_add_new_package_when_active_until_is_null(self):
@@ -546,8 +546,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=1,
             future_storage_package_mb=1000,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=0,
-            storage_free_bytes=1001 * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=1001,
         )
 
         with self.assertRaises(django.db.utils.IntegrityError):
@@ -569,8 +569,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=1,
             future_storage_package_mb=1000,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=0,
-            storage_free_bytes=1001 * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=1001,
         )
 
     def test_used_storage_changes_when_uploading_and_deleting_files_and_versions(self):
@@ -584,8 +584,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=0,
-            storage_free_bytes=1 * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=1,
         )
 
         p1 = Project.objects.create(name="p1", owner=self.u1)
@@ -604,8 +604,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=0.3 * 1000 * 1000,
-            storage_free_bytes=0.7 * 1000 * 1000,
+            storage_used_mb=0.3,
+            storage_free_mb=0.7,
         )
 
         bucket.upload_fileobj(get_random_file(mb=0.1), storage_path)
@@ -621,8 +621,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=0.4 * 1000 * 1000,
-            storage_free_bytes=0.6 * 1000 * 1000,
+            storage_used_mb=0.4,
+            storage_free_mb=0.6,
         )
 
         version = list(list_versions(bucket, storage_path))[0]
@@ -639,8 +639,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=0.1 * 1000 * 1000,
-            storage_free_bytes=0.9 * 1000 * 1000,
+            storage_used_mb=0.1,
+            storage_free_mb=0.9,
         )
 
         delete_project_file_permanently(p1, "test.data")
@@ -656,8 +656,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=0 * 1000 * 1000,
-            storage_free_bytes=1 * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=1,
         )
 
     def test_api_enforces_storage_limit(self):
@@ -711,8 +711,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=0,
-            storage_free_bytes=10 * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=10,
             user=u10mb,
         )
         self.assertStorage(
@@ -725,8 +725,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=0,
-            storage_free_bytes=20 * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=20,
             user=u20mb,
         )
 
@@ -749,8 +749,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=15 * 1000 * 1000,
-            storage_free_bytes=5 * 1000 * 1000,
+            storage_used_mb=15,
+            storage_free_mb=5,
             user=u20mb,
         )
 
@@ -779,8 +779,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=1,
             future_storage_package_mb=1000,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=0,
-            storage_free_bytes=1010 * 1000 * 1000,
+            storage_used_mb=0,
+            storage_free_mb=1010,
             user=u10mb,
         )
 
@@ -799,7 +799,7 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=1,
             future_storage_package_mb=1000,
             future_storage_package_changed_mb=0,
-            storage_used_bytes=15 * 1000 * 1000,
-            storage_free_bytes=995 * 1000 * 1000,
+            storage_used_mb=15,
+            storage_free_mb=995,
             user=u10mb,
         )

--- a/docker-app/qfieldcloud/subscription/tests/test_package.py
+++ b/docker-app/qfieldcloud/subscription/tests/test_package.py
@@ -64,8 +64,8 @@ class QfcTestCase(APITransactionTestCase):
         future_storage_package_quantity,
         future_storage_package_mb,
         future_storage_package_changed_mb,
-        storage_used_mb,
-        storage_free_mb,
+        storage_used_bytes,
+        storage_free_bytes,
         user=None,
     ):
         if user is None:
@@ -107,8 +107,8 @@ class QfcTestCase(APITransactionTestCase):
             user.useraccount.current_subscription.future_storage_package_changed_mb,
             future_storage_package_changed_mb,
         )
-        self.assertEqual(user.useraccount.storage_used_mb, storage_used_mb)
-        self.assertEqual(user.useraccount.storage_free_mb, storage_free_mb)
+        self.assertEqual(user.useraccount.storage_used_bytes, storage_used_bytes)
+        self.assertEqual(user.useraccount.storage_free_bytes, storage_free_bytes)
 
     def test_get_storage_package_type(self):
         PackageType.objects.all().delete()
@@ -139,8 +139,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_mb=0,
-            storage_free_mb=self.plan_default.storage_mb,
+            storage_used_bytes=0,
+            storage_free_bytes=self.plan_default.storage_mb * 1000 * 1000,
         )
 
     def test_default_plan_raises_when_adding_active_storage(self):
@@ -163,8 +163,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_mb=0,
-            storage_free_mb=self.plan_default.storage_mb,
+            storage_used_bytes=0,
+            storage_free_bytes=self.plan_default.storage_mb * 1000 * 1000,
         )
 
     def test_default_plan_ignores_active_package(self):
@@ -190,8 +190,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_mb=0,
-            storage_free_mb=self.plan_default.storage_mb,
+            storage_used_bytes=0,
+            storage_free_bytes=self.plan_default.storage_mb * 1000 * 1000,
         )
 
     def test_premium_plan_without_additional_storage(self):
@@ -205,8 +205,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_mb=0,
-            storage_free_mb=1,
+            storage_used_bytes=0,
+            storage_free_bytes=1 * 1000 * 1000,
         )
 
     def test_premium_plan_with_active_storage(self):
@@ -228,8 +228,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=-1000,
-            storage_used_mb=0,
-            storage_free_mb=1001,
+            storage_used_bytes=0,
+            storage_free_bytes=1001 * 1000 * 1000,
         )
 
     def test_premium_plan_with_active_storage_without_end_date(self):
@@ -251,8 +251,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=1,
             future_storage_package_mb=1000,
             future_storage_package_changed_mb=0,
-            storage_used_mb=0,
-            storage_free_mb=1001,
+            storage_used_bytes=0,
+            storage_free_bytes=1001 * 1000 * 1000,
         )
 
     def test_premium_plan_with_expired_storage(self):
@@ -274,8 +274,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_mb=0,
-            storage_free_mb=1,
+            storage_used_bytes=0,
+            storage_free_bytes=1 * 1000 * 1000,
         )
 
     def test_premium_plan_with_future_storage(self):
@@ -297,8 +297,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=1,
             future_storage_package_mb=1000,
             future_storage_package_changed_mb=1000,
-            storage_used_mb=0,
-            storage_free_mb=1,
+            storage_used_bytes=0,
+            storage_free_bytes=1 * 1000 * 1000,
         )
 
     def test_premium_plan_with_active_and_future_and_expired_storage(self):
@@ -335,8 +335,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=1,
             future_storage_package_mb=1000,
             future_storage_package_changed_mb=0,
-            storage_used_mb=0,
-            storage_free_mb=1001,
+            storage_used_bytes=0,
+            storage_free_bytes=1001 * 1000 * 1000,
         )
 
     def test_premium_plan_can_add_active_storage(self):
@@ -354,8 +354,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=1,
             future_storage_package_mb=1000,
             future_storage_package_changed_mb=0,
-            storage_used_mb=0,
-            storage_free_mb=1001,
+            storage_used_bytes=0,
+            storage_free_bytes=1001 * 1000 * 1000,
         )
 
     def test_premium_plan_can_add_active_storage_with_quantity_of_42(self):
@@ -373,8 +373,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=42,
             future_storage_package_mb=42000,
             future_storage_package_changed_mb=0,
-            storage_used_mb=0,
-            storage_free_mb=42001,
+            storage_used_bytes=0,
+            storage_free_bytes=42001 * 1000 * 1000,
         )
 
     def test_premium_plan_can_add_future_storage(self):
@@ -394,8 +394,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=1,
             future_storage_package_mb=1000,
             future_storage_package_changed_mb=1000,
-            storage_used_mb=0,
-            storage_free_mb=1,
+            storage_used_bytes=0,
+            storage_free_bytes=1 * 1000 * 1000,
         )
 
     def test_premium_plan_can_replace_active_storage(self):
@@ -417,8 +417,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=1,
             future_storage_package_mb=1000,
             future_storage_package_changed_mb=0,
-            storage_used_mb=0,
-            storage_free_mb=1001,
+            storage_used_bytes=0,
+            storage_free_bytes=1001 * 1000 * 1000,
         )
 
         (
@@ -443,8 +443,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=2,
             future_storage_package_mb=2000,
             future_storage_package_changed_mb=1000,
-            storage_used_mb=0,
-            storage_free_mb=1001,
+            storage_used_bytes=0,
+            storage_free_bytes=1001 * 1000 * 1000,
         )
 
     def test_storage_with_custom_additional_storage(self):
@@ -475,8 +475,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=1,
             future_storage_package_mb=2,
             future_storage_package_changed_mb=0,
-            storage_used_mb=0,
-            storage_free_mb=3,
+            storage_used_bytes=0,
+            storage_free_bytes=3 * 1000 * 1000,
         )
 
     def test_storage_cannot_have_packages_with_time_overlaps(self):
@@ -499,8 +499,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=-1000,
-            storage_used_mb=0,
-            storage_free_mb=1001,
+            storage_used_bytes=0,
+            storage_free_bytes=1001 * 1000 * 1000,
         )
 
         with self.assertRaises(django.db.utils.IntegrityError):
@@ -523,8 +523,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=-1000,
-            storage_used_mb=0,
-            storage_free_mb=1001,
+            storage_used_bytes=0,
+            storage_free_bytes=1001 * 1000 * 1000,
         )
 
     def test_storage_cannot_add_new_package_when_active_until_is_null(self):
@@ -546,8 +546,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=1,
             future_storage_package_mb=1000,
             future_storage_package_changed_mb=0,
-            storage_used_mb=0,
-            storage_free_mb=1001,
+            storage_used_bytes=0,
+            storage_free_bytes=1001 * 1000 * 1000,
         )
 
         with self.assertRaises(django.db.utils.IntegrityError):
@@ -569,8 +569,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=1,
             future_storage_package_mb=1000,
             future_storage_package_changed_mb=0,
-            storage_used_mb=0,
-            storage_free_mb=1001,
+            storage_used_bytes=0,
+            storage_free_bytes=1001 * 1000 * 1000,
         )
 
     def test_used_storage_changes_when_uploading_and_deleting_files_and_versions(self):
@@ -584,8 +584,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_mb=0,
-            storage_free_mb=1,
+            storage_used_bytes=0,
+            storage_free_bytes=1 * 1000 * 1000,
         )
 
         p1 = Project.objects.create(name="p1", owner=self.u1)
@@ -604,8 +604,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_mb=0.3,
-            storage_free_mb=0.7,
+            storage_used_bytes=0.3 * 1000 * 1000,
+            storage_free_bytes=0.7 * 1000 * 1000,
         )
 
         bucket.upload_fileobj(get_random_file(mb=0.1), storage_path)
@@ -621,8 +621,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_mb=0.4,
-            storage_free_mb=0.6,
+            storage_used_bytes=0.4 * 1000 * 1000,
+            storage_free_bytes=0.6 * 1000 * 1000,
         )
 
         version = list(list_versions(bucket, storage_path))[0]
@@ -639,8 +639,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_mb=0.1,
-            storage_free_mb=0.9,
+            storage_used_bytes=0.1 * 1000 * 1000,
+            storage_free_bytes=0.9 * 1000 * 1000,
         )
 
         delete_project_file_permanently(p1, "test.data")
@@ -656,8 +656,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_mb=0,
-            storage_free_mb=1,
+            storage_used_bytes=0 * 1000 * 1000,
+            storage_free_bytes=1 * 1000 * 1000,
         )
 
     def test_api_enforces_storage_limit(self):
@@ -711,8 +711,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_mb=0,
-            storage_free_mb=10,
+            storage_used_bytes=0,
+            storage_free_bytes=10 * 1000 * 1000,
             user=u10mb,
         )
         self.assertStorage(
@@ -725,8 +725,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_mb=0,
-            storage_free_mb=20,
+            storage_used_bytes=0,
+            storage_free_bytes=20 * 1000 * 1000,
             user=u20mb,
         )
 
@@ -749,8 +749,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=0,
             future_storage_package_mb=0,
             future_storage_package_changed_mb=0,
-            storage_used_mb=15,
-            storage_free_mb=5,
+            storage_used_bytes=15 * 1000 * 1000,
+            storage_free_bytes=5 * 1000 * 1000,
             user=u20mb,
         )
 
@@ -779,8 +779,8 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=1,
             future_storage_package_mb=1000,
             future_storage_package_changed_mb=0,
-            storage_used_mb=0,
-            storage_free_mb=1010,
+            storage_used_bytes=0,
+            storage_free_bytes=1010 * 1000 * 1000,
             user=u10mb,
         )
 
@@ -799,7 +799,7 @@ class QfcTestCase(APITransactionTestCase):
             future_storage_package_quantity=1,
             future_storage_package_mb=1000,
             future_storage_package_changed_mb=0,
-            storage_used_mb=15,
-            storage_free_mb=995,
+            storage_used_bytes=15 * 1000 * 1000,
+            storage_free_bytes=995 * 1000 * 1000,
             user=u10mb,
         )

--- a/docker-app/qfieldcloud/subscription/tests/test_package.py
+++ b/docker-app/qfieldcloud/subscription/tests/test_package.py
@@ -107,8 +107,12 @@ class QfcTestCase(APITransactionTestCase):
             user.useraccount.current_subscription.future_storage_package_changed_mb,
             future_storage_package_changed_mb,
         )
-        self.assertEqual(user.useraccount.storage_used_bytes, storage_used_mb * 1000 * 1000)
-        self.assertEqual(user.useraccount.storage_free_bytes, storage_free_mb * 1000 * 1000)
+        self.assertEqual(
+            user.useraccount.storage_used_bytes, storage_used_mb * 1000 * 1000
+        )
+        self.assertEqual(
+            user.useraccount.storage_free_bytes, storage_free_mb * 1000 * 1000
+        )
 
     def test_get_storage_package_type(self):
         PackageType.objects.all().delete()


### PR DESCRIPTION
Remove @deprecated objects that are referenced only in tests or nowhere.

Should remove some noise / unused code.