### PR TITLE
Slight readability improvement on etag preparation for files

### DIFF
--- a/docker-app/qfieldcloud/core/utils.py
+++ b/docker-app/qfieldcloud/core/utils.py
@@ -59,7 +59,10 @@ class S3ObjectVersion:
 
     @property
     def e_tag(self) -> str:
-        return self._data.e_tag
+        if self._data.e_tag is None:
+            return ""
+        else:
+            return self._data.e_tag
 
     @property
     def md5sum(self) -> str:

--- a/docker-app/qfieldcloud/core/utils.py
+++ b/docker-app/qfieldcloud/core/utils.py
@@ -59,10 +59,7 @@ class S3ObjectVersion:
 
     @property
     def e_tag(self) -> str:
-        if self._data.e_tag is None:
-            return ""
-        else:
-            return self._data.e_tag
+        return self._data.e_tag
 
     @property
     def md5sum(self) -> str:

--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -83,7 +83,7 @@ class ListFilesView(views.APIView):
             path = PurePath(version.key)
             filename = str(path.relative_to(*path.parts[:3]))
             last_modified = version.last_modified.strftime("%d.%m.%Y %H:%M:%S %Z")
-            md5sum = version.e_tag.replace('"', "")
+            md5sum = version.e_tag.replace('"', "") if version.e_tag is not None else ""
 
             version_data = {
                 "size": version.size,

--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -83,7 +83,11 @@ class ListFilesView(views.APIView):
             path = PurePath(version.key)
             filename = str(path.relative_to(*path.parts[:3]))
             last_modified = version.last_modified.strftime("%d.%m.%Y %H:%M:%S %Z")
-            md5sum = version.e_tag.replace('"', "") if version.e_tag is not None else ""
+
+            if version.e_tag is None:
+                md5sum = ""
+            else:
+                md5sum = version.e_tag.replace('"', "")
 
             version_data = {
                 "size": version.size,

--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -83,11 +83,7 @@ class ListFilesView(views.APIView):
             path = PurePath(version.key)
             filename = str(path.relative_to(*path.parts[:3]))
             last_modified = version.last_modified.strftime("%d.%m.%Y %H:%M:%S %Z")
-
-            if version.e_tag is None:
-                md5sum = ""
-            else:
-                md5sum = version.e_tag.replace('"', "")
+            md5sum = version.e_tag.replace('"', "")
 
             version_data = {
                 "size": version.size,

--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -83,10 +83,11 @@ class ListFilesView(views.APIView):
             path = PurePath(version.key)
             filename = str(path.relative_to(*path.parts[:3]))
             last_modified = version.last_modified.strftime("%d.%m.%Y %H:%M:%S %Z")
+            md5sum = version.e_tag.replace('"', "")
 
             version_data = {
                 "size": version.size,
-                "md5sum": version.e_tag.replace('"', ""),
+                "md5sum": md5sum,
                 "version_id": version.version_id,
                 "last_modified": last_modified,
                 "is_latest": version.is_latest,
@@ -119,7 +120,7 @@ class ListFilesView(views.APIView):
 
                 files[version.key]["name"] = filename
                 files[version.key]["size"] = version.size
-                files[version.key]["md5sum"] = version.e_tag.replace('"', "")
+                files[version.key]["md5sum"] = md5sum
                 files[version.key]["last_modified"] = last_modified
                 files[version.key]["is_attachment"] = is_attachment
 


### PR DESCRIPTION
As of current `master` the `e_tag` property of `S3ObjectVersion` will evaluate to `None` in certain edge cases, causing Exceptions (see for example https://github.com/opengisch/qfieldcloud-private/pull/474). This PR ensures `S3ObjectVersion.e_tag` never lies about its type.