### PR TITLE
[WIP] #QF-3103 Use pg_advisory_locks against deadlocks and overlaps

### DIFF
--- a/docker-app/qfieldcloud/core/utils2/jobs.py
+++ b/docker-app/qfieldcloud/core/utils2/jobs.py
@@ -29,7 +29,7 @@ def apply_deltas(
     if not project.owner_can_create_job:
         return []
 
-    with advisory_lock(project.id):
+    with advisory_lock(int(project.created_at.timestamp())):
         # Ensure there is no concurrent request trying to apply these deltas.
         # This block of code can only run one at a time per project.
         #

--- a/docker-app/qfieldcloud/core/utils2/jobs.py
+++ b/docker-app/qfieldcloud/core/utils2/jobs.py
@@ -10,9 +10,6 @@ from qfieldcloud.core import exceptions
 
 logger = logging.getLogger(__name__)
 
-# Any number
-DELTAS_APPLY_LOCK_ID = 1001
-
 
 @transaction.atomic
 def apply_deltas(
@@ -32,9 +29,11 @@ def apply_deltas(
     if not project.owner_can_create_job:
         return []
 
-    with advisory_lock(DELTAS_APPLY_LOCK_ID):
+    with advisory_lock(project.id):
         # Ensure there is no concurrent request trying to apply these deltas.
-        # This block of code is only executed when the pg lock is released from previous transaction.
+        # This block of code can only run one at a time per project.
+        #
+        # NOTE Deltas could still be modified from elsewhere!
         #
         # NOTE `select_for_update` seem to create deadlocks sometimes
         # probably due to race conditions during the locking.

--- a/docker-app/requirements.txt
+++ b/docker-app/requirements.txt
@@ -36,6 +36,7 @@ django-migrate-sql-deux==0.5.0
 django-model-utils==4.3.1
 django-nonrelated-inlines==0.2
 django-notifications-hq==1.7.0
+django-pglocks==1.0.4
 django-phonenumber-field==7.1.0
 django-picklefield==3.1
 django-storages==1.11.1


### PR DESCRIPTION
I suspect locking race conditions to be the cause of deadlocks and overlapping jobs.

Using advisory_locks on blocks of code seems more solid than relying on `select_for_update`. I experimented locally with two workers doing update requests and timeouts. It seemed the locking did not work regardless the PG isolation level. Instead, using `SELECT pg_advisory_lock(lock_id)` worked as expected.

I guess it would not impact performance significantly as dequeueing jobs is not the bottleneck currently.

TODO take care of unlocking advisory locks in case of blackout.

#QF-3103
 
  