### PR TITLE
Remove the tmpdir with feedback and thumbnail after job is finished

### DIFF
--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import shutil
 import sys
 import tempfile
 import traceback
@@ -222,6 +223,8 @@ class JobRun:
             self.job.project.refresh_from_db()
 
             self.after_docker_run()
+
+            shutil.rmtree(str(self.shared_tempdir), ignore_errors=True)
 
             self.job.finished_at = timezone.now()
             self.job.status = Job.Status.FINISHED


### PR DESCRIPTION
Otherwise get out of /tmp storage with long uptime.