### PR TITLE
Track remaining_trial_organizations on org owner

### DIFF
--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -836,10 +836,12 @@ class AbstractSubscription(models.Model):
 
             if (
                 account.user.is_organization
-                and account.user.owner.remaining_trial_organizations > 0
+                and account.user.organization_owner.remaining_trial_organizations > 0
             ):
-                account.user.owner.remaining_trial_organizations -= 1
-                account.user.owner.save(update_fields=["remaining_trial_organizations"])
+                account.user.organization_owner.remaining_trial_organizations -= 1
+                account.user.organization_owner.save(
+                    update_fields=["remaining_trial_organizations"]
+                )
 
             # the trial plan should be the default plan
             regular_plan = Plan.objects.get(

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -834,9 +834,12 @@ class AbstractSubscription(models.Model):
             # NOTE to get annotations, mostly `is_active`
             trial_subscription_obj = cls.objects.get(pk=trial_subscription.pk)
 
-            if created_by.remaining_trial_organizations > 0:
-                created_by.remaining_trial_organizations -= 1
-                created_by.save(update_fields=["remaining_trial_organizations"])
+            if (
+                account.user.is_organization
+                and account.user.owner.remaining_trial_organizations > 0
+            ):
+                account.user.owner.remaining_trial_organizations -= 1
+                account.user.owner.save(update_fields=["remaining_trial_organizations"])
 
             # the trial plan should be the default plan
             regular_plan = Plan.objects.get(
@@ -854,10 +857,11 @@ class AbstractSubscription(models.Model):
             # NOTE in case the user had a custom amount set (e.g manually set by support) this will
             # be overwritten by a subscription plan change.
             # But taking care of this would add quite some complexity.
-            created_by.remaining_trial_organizations = (
-                regular_plan.max_trial_organizations
-            )
-            created_by.save(update_fields=["remaining_trial_organizations"])
+            if account.user.is_person:
+                account.user.remaining_trial_organizations = (
+                    regular_plan.max_trial_organizations
+                )
+                account.user.save(update_fields=["remaining_trial_organizations"])
 
         logger.info(f"Creating regular subscription from {regular_active_since}")
         regular_subscription = cls.objects.create(

--- a/docker-app/qfieldcloud/subscription/tests/test_subscription.py
+++ b/docker-app/qfieldcloud/subscription/tests/test_subscription.py
@@ -764,6 +764,8 @@ class QfcTestCase(APITransactionTestCase):
         u2.refresh_from_db()
         self.assertEqual(u2.remaining_trial_organizations, 0)
 
+        # NOTE changing ownership does not affect the `remaining_trial_organizations` and is not tested
+
     def test_project_lists_duplicates_if_multiple_subscriptions(self):
         u1 = Person.objects.create(username="u1")
         old_subscription = u1.useraccount.current_subscription

--- a/docker-app/qfieldcloud/subscription/tests/test_subscription.py
+++ b/docker-app/qfieldcloud/subscription/tests/test_subscription.py
@@ -731,33 +731,38 @@ class QfcTestCase(APITransactionTestCase):
         user_plan.max_trial_organizations = 2
         user_plan.save(update_fields=["max_trial_organizations"])
         u1 = Person.objects.create(username="u1")
+        u2 = Person.objects.create(username="u2")
 
         # remaining_trial_organizations is set on create_subscription
         self.assertEqual(u1.remaining_trial_organizations, 2)
+        self.assertEqual(u2.remaining_trial_organizations, 2)
 
         trial_plan = Plan.objects.get(code="default_org")
         trial_plan.is_trial = True
         trial_plan.save(update_fields=["is_trial"])
 
-        def assert_create_org_decrements_count(
-            org_name, user, remaining_trial_organizations
-        ):
-            Organization.objects.create(
-                username=org_name, organization_owner=user, created_by=user
-            )
-            user.refresh_from_db()
-            self.assertEqual(
-                user.remaining_trial_organizations, remaining_trial_organizations
-            )
-
-        # remaining_trial_organizations is decremented when creating a trial organization
-        assert_create_org_decrements_count("org1", u1, 1)
+        # remaining_trial_organizations is decremented for owner when creating a trial organization
+        Organization.objects.create(
+            username="org2", organization_owner=u2, created_by=u1
+        )
+        u2.refresh_from_db()
+        self.assertEqual(u2.remaining_trial_organizations, 1)
+        u1.refresh_from_db()
+        self.assertEqual(u2.remaining_trial_organizations, 2)
 
         # remaining_trial_organizations is decremented down to 0
-        assert_create_org_decrements_count("org2", u1, 0)
+        Organization.objects.create(
+            username="org3", organization_owner=u2, created_by=u1
+        )
+        u2.refresh_from_db()
+        self.assertEqual(u2.remaining_trial_organizations, 0)
 
         # It doesn't directly prevent creating more trials, is just a counter that stays at 0
-        assert_create_org_decrements_count("org3", u1, 0)
+        Organization.objects.create(
+            username="org4", organization_owner=u2, created_by=u1
+        )
+        u2.refresh_from_db()
+        self.assertEqual(u2.remaining_trial_organizations, 0)
 
     def test_project_lists_duplicates_if_multiple_subscriptions(self):
         u1 = Person.objects.create(username="u1")

--- a/docker-app/qfieldcloud/subscription/tests/test_subscription.py
+++ b/docker-app/qfieldcloud/subscription/tests/test_subscription.py
@@ -748,7 +748,7 @@ class QfcTestCase(APITransactionTestCase):
         u2.refresh_from_db()
         self.assertEqual(u2.remaining_trial_organizations, 1)
         u1.refresh_from_db()
-        self.assertEqual(u2.remaining_trial_organizations, 2)
+        self.assertEqual(u1.remaining_trial_organizations, 2)
 
         # remaining_trial_organizations is decremented down to 0
         Organization.objects.create(


### PR DESCRIPTION
It does not track changing organization ownership yet. IMO not necessary?