### PR TITLE
use ports for port mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,7 +148,7 @@ services:
       args:
         REDIS_PASSWORD: ${REDIS_PASSWORD}
     restart: unless-stopped
-    expose:
+    ports:
       - "6379:6379"
     logging: *default-logging
 
@@ -191,7 +191,7 @@ services:
 
   memcached:
     image: memcached:1
-    expose:
+    ports:
       - "11211:11211"
 
 volumes:


### PR DESCRIPTION
On Ubuntu 22.04 docker-compose fails with this error
```
# docker-compose build qgis
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.memcached.expose is invalid: should be of the format 'PORT[/PROTOCOL]'
services.redis.expose is invalid: should be of the format 'PORT[/PROTOCOL]
``` 