### PR TITLE
Add a differentiation between login+pwd vs token errors in the API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           ln -s docker-compose.override.local.yml docker-compose.override.yml
 
-      - name: Check env vars coniguration
+      - name: Check env vars configuration
         run: |
           scripts/check_envvars.sh
 

--- a/docker-app/qfieldcloud/authentication/authentication.py
+++ b/docker-app/qfieldcloud/authentication/authentication.py
@@ -4,11 +4,11 @@ from django.http.request import HttpRequest
 from django.utils import timezone
 from django.utils.translation import gettext as _
 from qfieldcloud.core.models import User
-from rest_framework import exceptions
 from rest_framework.authentication import (
     TokenAuthentication as DjangoRestFrameworkTokenAuthentication,
 )
 
+from ..core.exceptions import AuthenticationViaTokenFailedError
 from .models import AuthToken
 
 
@@ -54,13 +54,13 @@ class TokenAuthentication(DjangoRestFrameworkTokenAuthentication):
         try:
             token = model.objects.get(key=key)
         except model.DoesNotExist:
-            raise exceptions.AuthenticationFailed(_("Invalid token."))
+            raise AuthenticationViaTokenFailedError(_("Invalid token."))
 
         if not token.is_active:
-            raise exceptions.AuthenticationFailed(_("Token has expired."))
+            raise AuthenticationViaTokenFailedError(_("Token has expired."))
 
         if not token.user.is_active:
-            raise exceptions.AuthenticationFailed(_("User inactive or deleted."))
+            raise AuthenticationViaTokenFailedError(_("User inactive or deleted."))
 
         # update the token last used time
         # NOTE the UPDATE may be performed already on the `token = model.objects.get(key=key)`, but we lose "token has expired" exception.

--- a/docker-app/qfieldcloud/core/exceptions.py
+++ b/docker-app/qfieldcloud/core/exceptions.py
@@ -48,6 +48,14 @@ class AuthenticationFailedError(QFieldCloudException):
     status_code = status.HTTP_401_UNAUTHORIZED
 
 
+class AuthenticationViaTokenFailedError(QFieldCloudException):
+    """Raised when QFieldCloud incoming request includes incorrect authentication token."""
+
+    code = "token_authentication_failed"
+    message = "Token authentication failed"
+    status_code = status.HTTP_401_UNAUTHORIZED
+
+
 class NotAuthenticatedError(QFieldCloudException):
     """Raised when QFieldCloud unauthenticated request fails the permission checks."""
 


### PR DESCRIPTION
@nirvn @mbernasocchi as discussed

token related stuff is like this:
```
{
  "code": "token_authentication_failed",
  "message": "Token authentication failed"
}
```

vs login failed:
```
{
  "code": "authentication_failed",
  "message": "Authentication failed"
}
```