### PR TITLE
Hide the organization prefix (`@<org>/) in the team admin

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -1259,7 +1259,11 @@ class TeamAdmin(QFieldCloudModelAdmin):
         obj.save()
 
     def get_form(
-        self, request: Any, obj: Any | None = None, change: bool | None = None, **kwargs: Any
+        self,
+        request: Any,
+        obj: Any | None = None,
+        change: bool | None = None,
+        **kwargs: Any,
     ) -> Any:
         if obj:
             # hide the organization prefix of the team, so the Team admin can be saved without

--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -1259,7 +1259,7 @@ class TeamAdmin(QFieldCloudModelAdmin):
         obj.save()
 
     def get_form(
-        self, request: Any, obj: Any | None = None, change: bool = None, **kwargs: Any
+        self, request: Any, obj: Any | None = None, change: bool | None = None, **kwargs: Any
     ) -> Any:
         if obj:
             # hide the organization prefix of the team, so the Team admin can be saved without
@@ -1268,7 +1268,7 @@ class TeamAdmin(QFieldCloudModelAdmin):
                 f"@{obj.team_organization.username}/", ""
             )
 
-        return super().get_form(request, obj, change, **kwargs)
+        return super().get_form(request, obj, bool(change), **kwargs)
 
 
 class InvitationAdmin(InvitationAdminBase):

--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -1258,6 +1258,18 @@ class TeamAdmin(QFieldCloudModelAdmin):
             obj.username = f"@{obj.team_organization.username}/{obj.username}"
         obj.save()
 
+    def get_form(
+        self, request: Any, obj: Any | None = None, change: bool = None, **kwargs: Any
+    ) -> Any:
+        if obj:
+            # hide the organization prefix of the team, so the Team admin can be saved without
+            # the need to manually edit the username
+            obj.username = obj.username.replace(
+                f"@{obj.team_organization.username}/", ""
+            )
+
+        return super().get_form(request, obj, change, **kwargs)
+
 
 class InvitationAdmin(InvitationAdminBase):
     list_display = ("email", "inviter", "created", "sent", "accepted")


### PR DESCRIPTION
Team admin can be saved without the need to manually edit the username

| before | after |
|-|-|
| ![image](https://github.com/opengisch/qfieldcloud/assets/2820439/7059a110-5476-4a3b-8fae-628d44bf0744) | ![image](https://github.com/opengisch/qfieldcloud/assets/2820439/04fa0e38-3092-4385-88e8-56ed236928c0) |



