### PR TITLE
Add draft for standalone config

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ Code style done with precommit
 
 ### Launch a server instance
 
+For small self-hosted environments you can run QFieldCloud on a single server. Therefore use `docker-compose.override.standalone.yml`.
+For large instances use dedicated DB and Storage Servers.
+
 Copy the `.env.example` into `.env` file and configure it to your
 desire with a good editor
 
@@ -207,9 +210,11 @@ desire with a good editor
     emacs .env
 
 Do not forget to set DEBUG=0 and to adapt COMPOSE_FILE to not load local
-development configurations.
+development configurations. For a standalone server use this:
 
-Create the directory for qfieldcloud logs and supervisor socket file
+    COMPOSE_FILE=docker-compose.yml:docker-compose.override.standalone.yml
+
+If you plan to use supervisord create the directory for qfieldcloud logs and supervisor socket file
 
     mkdir /var/local/qfieldcloud
 

--- a/docker-compose.override.standalone.yml
+++ b/docker-compose.override.standalone.yml
@@ -1,0 +1,86 @@
+version: '3.9'
+
+services:
+  nginx:
+    volumes:
+      - static_volume:/var/www/html/staticfiles/
+      - media_volume:/var/www/html/mediafiles/
+
+  db:
+    image: postgis/postgis:13-3.1-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
+    ports:
+      - ${HOST_POSTGRES_PORT}:5432
+
+  memcached:
+    ports:
+      - "${MEMCACHED_PORT}:11211"
+
+  geodb:
+    image: postgis/postgis:12-3.0
+    restart: unless-stopped
+    volumes:
+      - geodb_data:/var/lib/postgresql
+    environment:
+      POSTGRES_DB: ${GEODB_DB}
+      POSTGRES_USER: ${GEODB_USER}
+      POSTGRES_PASSWORD: ${GEODB_PASSWORD}
+    ports:
+      - ${GEODB_PORT}:5432
+
+  minio:
+    image: minio/minio:RELEASE.2023-04-07T05-28-58Z
+    restart: unless-stopped
+    volumes:
+      - minio_data1:/data1
+      - minio_data2:/data2
+      - minio_data3:/data3
+      - minio_data4:/data4
+    environment:
+      MINIO_ROOT_USER: ${STORAGE_ACCESS_KEY_ID}
+      MINIO_ROOT_PASSWORD: ${STORAGE_SECRET_ACCESS_KEY}
+      MINIO_BROWSER_REDIRECT_URL: http://${QFIELDCLOUD_HOST}:${MINIO_BROWSER_PORT}
+    command: server /data{1...4} --console-address :9001
+    healthcheck:
+        test: [
+          "CMD",
+          "curl",
+          "-A",
+          "Mozilla/5.0 (X11; Linux x86_64; rv:30.0) Gecko/20100101 Firefox/30.0",
+          "-f",
+          "${STORAGE_ENDPOINT_URL}/minio/index.html"
+        ]
+        interval: 5s
+        timeout: 20s
+        retries: 5
+    ports:
+      - ${MINIO_BROWSER_PORT}:9001
+      - ${MINIO_API_PORT}:9000
+
+  createbuckets:
+    image: minio/mc
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc config host add myminio ${STORAGE_ENDPOINT_URL} ${STORAGE_ACCESS_KEY_ID} ${STORAGE_SECRET_ACCESS_KEY};
+      /usr/bin/mc mb myminio/${STORAGE_BUCKET_NAME};
+      /usr/bin/mc policy set download myminio/${STORAGE_BUCKET_NAME}/users;
+      /usr/bin/mc version enable myminio/${STORAGE_BUCKET_NAME};
+      exit 0;
+      "
+
+volumes:
+  postgres_data:
+  geodb_data:
+  minio_data1:
+  minio_data2:
+  minio_data3:
+  minio_data4:


### PR DESCRIPTION
For small instance deployment, I added a standalone server configuration. It should be possible to simply run QFieldCloud with this only by launching it in docker. 

If this might be added and maintained to the repository, I would further work on this draft.

I think adding and get it working is not an issue here, but we should think about how to maintain and update the containers in the future. Any comments on this are welcome.