### PR TITLE
QF-3728 ensure qfieldcloud-qgis image name in docker-compose file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
           eval $(egrep "^[^#;]" .env | xargs -d'\n' -n1 | sed -E 's/(\w+)=(.*)/export \1='"'"'\2'"'"'/g')
 
       - name: Pull docker containers
-        run: docker compose pull
+        run: docker compose pull --ignore-buildable
 
       - name: Build and run docker containers
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
           eval $(egrep "^[^#;]" .env | xargs -d'\n' -n1 | sed -E 's/(\w+)=(.*)/export \1='"'"'\2'"'"'/g')
 
       - name: Pull docker containers
-        run: docker compose pull --ignore-buildable
+        run: docker compose pull
 
       - name: Build and run docker containers
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,6 +135,7 @@ services:
       context: ./docker-qgis
       network: host
     image: qfieldcloud-qgis
+    pull_policy: build
     tty: true
     command: bash -c "echo QGIS built"
     logging: *default-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,6 +134,7 @@ services:
     build:
       context: ./docker-qgis
       network: host
+    image: qfieldcloud-qgis
     tty: true
     command: bash -c "echo QGIS built"
     logging: *default-logging


### PR DESCRIPTION
Problem is docker compose, depending on its version, uses dash (`qfieldcloud-qgis`) or underscore (`qfieldcloud_qgis`) as separator for image names.

Solution is to ensure the `qgis` always gets the `qfieldcloud-qgis` name using the `image` directive in `docker-compose.yml`