### PR TITLE
QF-3714 In Projects admin page, add a owner type filter - by user or by organization

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -569,24 +569,17 @@ class ProjectFilesWidget(widgets.Input):
 
 
 class OwnerTypeFilter(admin.SimpleListFilter):
-    # "owner__type" for the filter would suffice,
-    # But the filter title would then be "By type" in the UI,
-    # which is semantically unclear, hence the SimpleListFilter subclass
-    title = "owner type"
+    title = _("owner type")
     parameter_name = "owner_type"
 
     def lookups(self, request, model_admin):
-        return [
-            (User.Type.PERSON, "Person"),
-            (User.Type.ORGANIZATION, "Organization"),
-            (User.Type.TEAM, "Team"),
-        ]
+        return [(User.Type.PERSON, "Person"), (User.Type.ORGANIZATION, "Organization")]
 
     def queryset(self, request, queryset):
-        if self.value():
-            return queryset.filter(owner__type=self.value())
-        else:
+        value = self.value()
+        if value is None:
             return queryset
+        return queryset.filter(owner__type=value)
 
 
 class ProjectForm(ModelForm):

--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -577,8 +577,10 @@ class OwnerTypeFilter(admin.SimpleListFilter):
 
     def queryset(self, request, queryset):
         value = self.value()
+
         if value is None:
             return queryset
+
         return queryset.filter(owner__type=value)
 
 

--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -568,6 +568,27 @@ class ProjectFilesWidget(widgets.Input):
     template_name = "admin/project_files_widget.html"
 
 
+class OwnerTypeFilter(admin.SimpleListFilter):
+    # "owner__type" for the filter would suffice,
+    # But the filter title would then be "By type" in the UI,
+    # which is semantically unclear, hence the SimpleListFilter subclass
+    title = "owner type"
+    parameter_name = "owner_type"
+
+    def lookups(self, request, model_admin):
+        return [
+            (User.Type.PERSON, "Person"),
+            (User.Type.ORGANIZATION, "Organization"),
+            (User.Type.TEAM, "Team"),
+        ]
+
+    def queryset(self, request, queryset):
+        if self.value():
+            return queryset.filter(owner__type=self.value())
+        else:
+            return queryset
+
+
 class ProjectForm(ModelForm):
     project_files = fields.CharField(
         disabled=True, required=False, widget=ProjectFilesWidget
@@ -594,6 +615,7 @@ class ProjectAdmin(QFieldCloudModelAdmin):
         "is_public",
         "created_at",
         "updated_at",
+        OwnerTypeFilter,
     )
     fields = (
         "id",


### PR DESCRIPTION
"owner__type" for the filter would suffice functionality wise.
But the filter title would then be "By type" in the UI, which is semantically unclear, hence the SimpleListFilter subclass.

![Screenshot from 2024-01-29 11-08-41](https://github.com/opengisch/qfieldcloud/assets/2746311/35f0e95f-5a49-4a43-97e2-0b3131ff6381)
