### PR TITLE
Fix the usage of `GEODB_PORT`, it should be `HOST_GEODB_PORT`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,7 @@ GEODB_PORT=5432
 GEODB_USER=postgres
 GEODB_PASSWORD="KUAa7h!G&wQEmkS3"
 GEODB_DB=postgres
+HOST_GEODB_PORT=5434
 
 # Sentry DSN. Missing value disables Sentry logging. Can be found on https://opengisch.sentry.io/settings/projects/qfieldcloud/keys/ .
 # DEFAULT: <NO VALUE>

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Create an <code>.env.test</code> file with the following variables that override
     WEB_HTTP_PORT=8101
     WEB_HTTPS_PORT=8102
     HOST_POSTGRES_PORT=8103
-    GEODB_PORT=8107
+    HOST_GEODB_PORT=8107
     MEMCACHED_PORT=11212
     QFIELDCLOUD_DEFAULT_NETWORK=qfieldcloud_test_default
     QFIELDCLOUD_SUBSCRIPTION_MODEL=subscription.Subscription

--- a/docker-compose.override.dev.yml
+++ b/docker-compose.override.dev.yml
@@ -17,7 +17,7 @@ services:
       POSTGRES_USER: ${GEODB_USER}
       POSTGRES_PASSWORD: ${GEODB_PASSWORD}
     ports:
-      - ${GEODB_PORT}:5432
+      - ${HOST_GEODB_PORT}:5432
 
   nginx:
     volumes:

--- a/docker-compose.override.local.yml
+++ b/docker-compose.override.local.yml
@@ -82,7 +82,7 @@ services:
       POSTGRES_USER: ${GEODB_USER}
       POSTGRES_PASSWORD: ${GEODB_PASSWORD}
     ports:
-      - ${GEODB_PORT}:5432
+      - ${HOST_GEODB_PORT}:5432
 
   minio:
     image: minio/minio:RELEASE.2023-04-07T05-28-58Z


### PR DESCRIPTION
The `GEODB_PORT` is used as part of the connection string within the compose stack. The `HOST_GEODB_PORT` is used to expose the PG port to the host. The code was trying to connect to the host port from within the compose stack.