### PR TITLE
Fix geometry-less exported as empty layers

### DIFF
--- a/docker-qgis/requirements_libqfieldsync.txt
+++ b/docker-qgis/requirements_libqfieldsync.txt
@@ -1,1 +1,1 @@
-libqfieldsync @ git+https://github.com/opengisch/libqfieldsync@8ee725ca401b5d083edd8feed733803b8709d496
+libqfieldsync @ git+https://github.com/opengisch/libqfieldsync@e3647e9b0fcbaf74cbb4c3f72bc8f34d99cb44e0


### PR DESCRIPTION
This was wrongly applied on non-spatial layers, which caused them to be exported as empty layers.

Fix #874 