### PR TITLE
Add "id" to `SubscriptionAdmin.search_fields`"

### DIFF
--- a/docker-app/qfieldcloud/subscription/admin.py
+++ b/docker-app/qfieldcloud/subscription/admin.py
@@ -120,6 +120,7 @@ class SubscriptionAdmin(QFieldCloudModelAdmin):
     autocomplete_fields = ("account",)
 
     search_fields = (
+        "id",
         "account__user__email__iexact",
         "account__user__username__iexact",
     )


### PR DESCRIPTION
Because in Sentry we list the "id" it helps to find the Subscription of concern