### PR TITLE
Support `skip_metadata` `on packages/<project-id>/latest` request to boost performance

### DIFF
--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -94,7 +94,7 @@ class ListFilesView(views.APIView):
                 "display": S3ObjectVersion(version.key, version).display,
             }
 
-            # NOTE Some clients (e.g. QField, QFieldSync) are still requiring the `sha256` key to check whether the files needs to be reuploaded.
+            # NOTE Some clients (e.g. QFieldSync) are still requiring the `sha256` key to check whether the files needs to be reuploaded.
             # Since we do not have control on these old client versions, we need to keep the API backward compatible for some time and assume `skip_metadata=0` by default.
             skip_metadata_param = request.GET.get("skip_metadata", "0")
             if skip_metadata_param == "0":


### PR DESCRIPTION
Serve only `md5` checksum instead of `sha256` checksum to gain extra performance when downloading packaged files in QField. The `sha256` causes N+1 requests to the S3 storage, therefore makes the QFieldCloud response on the `packages/<project-id>/latest` endpoint super slow.

See https://github.com/opengisch/QField/pull/5040