### PR TITLE
QF-3716 Add possibility to rerun job in the Admin

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -26,7 +26,7 @@ from django.db.models.functions import Lower
 from django.forms import ModelForm, fields, widgets
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.http.response import Http404, HttpResponseRedirect, StreamingHttpResponse
-from django.shortcuts import redirect, resolve_url
+from django.shortcuts import resolve_url
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
 from django.utils.decorators import method_decorator
@@ -878,7 +878,7 @@ class JobAdmin(QFieldCloudModelAdmin):
 
     def rerun_job(self, request, object_id):
         Job.objects.filter(pk=object_id).update(status="pending")
-        return redirect(request.META.get("HTTP_REFERER", "../.."))
+        return HttpResponseRedirect("..")
 
 
 class ApplyJobDeltaInline(admin.TabularInline):

--- a/docker-app/qfieldcloud/core/templates/admin/job_change_form.html
+++ b/docker-app/qfieldcloud/core/templates/admin/job_change_form.html
@@ -1,0 +1,11 @@
+{% extends 'admin/change_form.html' %}
+
+{% block submit_buttons_bottom %}
+  {{ block.super }}
+
+  <div class="submit-row">
+    {% if original %}
+        <a href="{% url 'admin:rerun_job' original.pk %}" class="button">Re-run</a>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/docker-app/qfieldcloud/core/templates/admin/job_change_form.html
+++ b/docker-app/qfieldcloud/core/templates/admin/job_change_form.html
@@ -1,11 +1,11 @@
 {% extends 'admin/change_form.html' %}
+{% load i18n %}
 
 {% block submit_buttons_bottom %}
   {{ block.super }}
 
   <div class="submit-row">
-    {% if original %}
-        <a href="{% url 'admin:rerun_job' original.pk %}" class="button">Re-run</a>
+    {% if original %}<a href="{% url 'admin:rerun_job' original.pk %}" class="button">{% trans 'Re-run job' %}</a>
     {% endif %}
   </div>
 {% endblock %}


### PR DESCRIPTION
The re-run button sets the job back to "pending" status.

However, on my local setup, jobs are systematically failing as the projects are missing their files.
Requires maybe some more tests?

![Screenshot from 2024-02-14 17-32-26](https://github.com/opengisch/qfieldcloud/assets/2746311/163e668b-de29-4641-ac76-a7402b8eefb9)
