### PR TITLE
QF-3832 Add filter that shows all subscription that expire within 1, 2, or 4 weeks

### DIFF
--- a/docker-app/qfieldcloud/subscription/admin.py
+++ b/docker-app/qfieldcloud/subscription/admin.py
@@ -52,7 +52,7 @@ class SubscriptionPeriodFilter(admin.SimpleListFilter):
 
 
 class ActiveUntilFilter(admin.SimpleListFilter):
-    title = "expiration date"
+    title = _("expiration date")
     parameter_name = "active_until"
 
     def lookups(self, request, model_admin):

--- a/docker-app/qfieldcloud/subscription/admin.py
+++ b/docker-app/qfieldcloud/subscription/admin.py
@@ -1,6 +1,9 @@
+from datetime import timedelta
+
 from django import forms
 from django.contrib import admin
 from django.http import HttpRequest
+from django.utils import timezone
 from django.utils.translation import gettext as _
 from qfieldcloud.core.admin import QFieldCloudModelAdmin, model_admin_url
 
@@ -46,6 +49,24 @@ class SubscriptionPeriodFilter(admin.SimpleListFilter):
             return queryset.current()
 
         return queryset
+
+
+class ActiveUntilFilter(admin.SimpleListFilter):
+    title = "expiration date"
+    parameter_name = "active_until"
+
+    def lookups(self, request, model_admin):
+        return [
+            ("1", "Next week"),
+            ("2", "Next 2 weeks"),
+            ("4", "Next 4 weeks"),
+        ]
+
+    def queryset(self, request, queryset):
+        if self.value():
+            now = timezone.now()
+            future_date = now + timedelta(weeks=int(self.value()))
+            return queryset.filter(active_until__range=(now, future_date))
 
 
 class SubscriptionModelForm(forms.ModelForm):
@@ -109,6 +130,7 @@ class SubscriptionAdmin(QFieldCloudModelAdmin):
         SubscriptionPeriodFilter,
         "status",
         "plan",
+        ActiveUntilFilter,
     )
 
     readonly_fields = (


### PR DESCRIPTION
I understood the expiration date field to be the `active_until` field, correct me if I am mistaken (other related fields: `current_period_until`, `requested_cancel_at`).

![Screenshot from 2024-02-14 18-05-22](https://github.com/opengisch/qfieldcloud/assets/2746311/5511ef3d-9adc-4ecf-9700-5d23a4d2c34c)
