### PR TITLE
QF-3851 Remove S3 ACL parameter for avatar/projects thumbnails

### DIFF
--- a/docker-app/qfieldcloud/core/utils2/storage.py
+++ b/docker-app/qfieldcloud/core/utils2/storage.py
@@ -293,7 +293,6 @@ def upload_user_avatar(
         file,
         key,
         {
-            "ACL": "public-read",
             "ContentType": mimetype.value,
         },
     )
@@ -357,8 +356,6 @@ def upload_project_thumbail(
         file,
         key,
         {
-            # TODO most probably this is not public-read, since the project might be private
-            "ACL": "public-read",
             "ContentType": mimetype,
         },
     )


### PR DESCRIPTION
Works fine for thumbnail, but I get `403 forbidden` for avatar at https://localhost/api/v1/files/public/users/<USER>/avatar.svg
Seems independant of `ACL` policy...