### PR TITLE
QF-3857 Added dark theme

### DIFF
--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -629,4 +629,9 @@ JAZZMIN_SETTINGS = {
     "copyright": "OPENGIS.ch",
     # Additional custom CSS file for the Django Admin pages.
     "custom_css": "css/admin.css",
+    "show_ui_builder": True,
+}
+JAZZMIN_UI_TWEAKS = {
+    # CSS dark theme used, options here: https://django-jazzmin.readthedocs.io/ui_customisation/#light-themes
+    "dark_mode_theme": "superhero",
 }


### PR DESCRIPTION
However, doesn't show as advertised.

For example, for the `superhero` dark theme, it is advertised in the [documentation](https://django-jazzmin.readthedocs.io/ui_customisation/#dark-mode-enabled) as looking like [this](https://bootswatch.com/superhero/).

If I use the integrated jazzmin UI tweaker, I see this, which is ok (note the grey buttons on the right which is not nice in any case):
![Screenshot from 2024-02-22 15-15-11](https://github.com/opengisch/qfieldcloud/assets/2746311/3d81759e-d000-49d3-9c1c-65005f0010d0)

However, If I set `"dark_mode_theme": "superhero"` and my browser to dark mode, I see this, which is rather unpalatable:
![Screenshot from 2024-02-22 15-15-24](https://github.com/opengisch/qfieldcloud/assets/2746311/3cdd18fa-59a1-4096-8ff1-930f6f7456d7)

To be discussed, but the jazzmin dark themes don't seem so stable/ready yet.