### PR TITLE
Speed up packaging

### DIFF
--- a/docker-qgis/entrypoint.py
+++ b/docker-qgis/entrypoint.py
@@ -147,7 +147,7 @@ def _extract_layer_data(project_filename: Union[str, Path]) -> dict:
 
 
 def _open_project(project_filename: Union[str, Path]):
-    open_qgis_project(str(project_filename), force_reload=True)
+    return open_qgis_project(str(project_filename), force_reload=True)
 
 
 def cmd_package_project(args: argparse.Namespace):
@@ -323,7 +323,7 @@ def cmd_process_projectfile(args: argparse.Namespace):
                 arguments={
                     "project_filename": WorkDirPath("files", args.project_file),
                 },
-                method=qfc_worker.process_projectfile.load_project_file,
+                method=_open_project,
                 return_names=["project"],
             ),
             Step(

--- a/docker-qgis/qfc_worker/process_projectfile.py
+++ b/docker-qgis/qfc_worker/process_projectfile.py
@@ -44,18 +44,6 @@ def check_valid_project_file(project_filename: Path) -> None:
     logger.info("QGIS project file is valid!")
 
 
-def load_project_file(project_filename: Path) -> QgsProject:
-    logger.info("Open QGIS project file…")
-
-    project = QgsProject.instance()
-    if not project.read(str(project_filename)):
-        raise InvalidXmlFileException(error=project.error())
-
-    logger.info("QGIS project file opened!")
-
-    return project
-
-
 def extract_project_details(project: QgsProject) -> dict[str, str]:
     """Extract project details"""
     logger.info("Extract project details…")

--- a/docker-qgis/requirements_libqfieldsync.txt
+++ b/docker-qgis/requirements_libqfieldsync.txt
@@ -1,1 +1,1 @@
-libqfieldsync @ git+https://github.com/opengisch/libqfieldsync@3ffdb4b97eae1a648051f2477f7db314b85cc332
+libqfieldsync @ git+https://github.com/opengisch/libqfieldsync@fefa28fc0b63fa5e7646fcb5065a19f02378206f

--- a/docker-qgis/requirements_libqfieldsync.txt
+++ b/docker-qgis/requirements_libqfieldsync.txt
@@ -1,1 +1,1 @@
-libqfieldsync @ git+https://github.com/opengisch/libqfieldsync@e20ff5be177c3a221ba4641d8b73a26a35016f66
+libqfieldsync @ git+https://github.com/opengisch/libqfieldsync@3ffdb4b97eae1a648051f2477f7db314b85cc332


### PR DESCRIPTION
This PR reworks the packaging job workflow to prevent _3_ project loads and instead rely on a single initial load. This can lead to massive speed gains on complex projects and/or projects containing remote sources that are slow.

Requires the following libqfieldsync improvements: https://github.com/opengisch/libqfieldsync/pull/68