### PR TITLE
QF-3818 Make connexion to s3 more resilient

### DIFF
--- a/docker-app/qfieldcloud/core/management/commands/status.py
+++ b/docker-app/qfieldcloud/core/management/commands/status.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.core.management.base import BaseCommand
 from qfieldcloud.core import geodb_utils, utils
 
@@ -17,8 +16,7 @@ class Command(BaseCommand):
         results["storage"] = "ok"
         # Check if bucket exists (i.e. the connection works)
         try:
-            s3_client = utils.get_s3_client()
-            s3_client.head_bucket(Bucket=settings.STORAGE_BUCKET_NAME)
+            utils.get_s3_bucket()
         except Exception:
             results["storage"] = "error"
 

--- a/docker-app/qfieldcloud/core/utils.py
+++ b/docker-app/qfieldcloud/core/utils.py
@@ -386,21 +386,6 @@ def get_project_package_files_count(project_id: str) -> int:
     return len(files)
 
 
-def get_s3_object_url(
-    key: str, bucket: mypy_boto3_s3.service_resource.Bucket = get_s3_bucket()
-) -> str:
-    """Returns the block storage URL for a given key. The key may not exist in the bucket.
-
-    Args:
-        key (str): the object key
-        bucket (boto3.Bucket, optional): Bucket for that object. Defaults to `get_s3_bucket()`.
-
-    Returns:
-        str: URL
-    """
-    return f"{settings.STORAGE_ENDPOINT_URL}/{bucket.name}/{key}"
-
-
 def list_files(
     bucket: mypy_boto3_s3.service_resource.Bucket,
     prefix: str,

--- a/docker-app/qfieldcloud/core/utils2/storage.py
+++ b/docker-app/qfieldcloud/core/utils2/storage.py
@@ -196,7 +196,6 @@ def get_attachment_dir_prefix(
 def file_response(
     request: HttpRequest,
     key: str,
-    presigned: bool = False,
     expires: int = 60,
     version: str | None = None,
     as_attachment: bool = False,
@@ -213,25 +212,22 @@ def file_response(
     https_port = http_host.split(":")[-1] if ":" in http_host else "443"
 
     if https_port == settings.WEB_HTTPS_PORT and not settings.IN_TEST_SUITE:
-        if presigned:
-            if as_attachment:
-                extra_params["ResponseContentType"] = "application/force-download"
-                extra_params[
-                    "ResponseContentDisposition"
-                ] = f'attachment;filename="{filename}"'
+        if as_attachment:
+            extra_params["ResponseContentType"] = "application/force-download"
+            extra_params[
+                "ResponseContentDisposition"
+            ] = f'attachment;filename="{filename}"'
 
-            url = qfieldcloud.core.utils.get_s3_client().generate_presigned_url(
-                "get_object",
-                Params={
-                    **extra_params,
-                    "Key": key,
-                    "Bucket": qfieldcloud.core.utils.get_s3_bucket().name,
-                },
-                ExpiresIn=expires,
-                HttpMethod="GET",
-            )
-        else:
-            url = qfieldcloud.core.utils.get_s3_object_url(key)
+        url = qfieldcloud.core.utils.get_s3_client().generate_presigned_url(
+            "get_object",
+            Params={
+                **extra_params,
+                "Key": key,
+                "Bucket": qfieldcloud.core.utils.get_s3_bucket().name,
+            },
+            ExpiresIn=expires,
+            HttpMethod="GET",
+        )
 
         # Let's NGINX handle the redirect to the storage and streaming the file contents back to the client
         response = HttpResponse()

--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -207,7 +207,6 @@ class DownloadPushDeleteFileView(views.APIView):
         return utils2.storage.file_response(
             request,
             key,
-            presigned=True,
             expires=600,
             version=version,
             as_attachment=True,
@@ -374,7 +373,7 @@ class ProjectMetafilesView(views.APIView):
 
     def get(self, request, projectid, filename):
         key = utils.safe_join(f"projects/{projectid}/meta/", filename)
-        return utils2.storage.file_response(request, key, presigned=True)
+        return utils2.storage.file_response(request, key)
 
 
 @extend_schema_view(

--- a/docker-app/qfieldcloud/core/views/package_views.py
+++ b/docker-app/qfieldcloud/core/views/package_views.py
@@ -184,9 +184,7 @@ class LatestPackageDownloadFilesView(views.APIView):
             key = f"projects/{project_id}/files/{filename}"
 
         # NOTE the `expires` kwarg is sending the `Expires` header to the client, keep it a low value (in seconds).
-        return storage.file_response(
-            request, key, presigned=True, expires=10, as_attachment=True
-        )
+        return storage.file_response(request, key, expires=10, as_attachment=True)
 
 
 @extend_schema_view(

--- a/docker-app/qfieldcloud/core/views/status_views.py
+++ b/docker-app/qfieldcloud/core/views/status_views.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.core.cache import cache
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from qfieldcloud.core import geodb_utils, utils
@@ -25,8 +24,7 @@ class APIStatusView(views.APIView):
             results["storage"] = "ok"
             # Check if bucket exists (i.e. the connection works)
             try:
-                s3_client = utils.get_s3_client()
-                s3_client.head_bucket(Bucket=settings.STORAGE_BUCKET_NAME)
+                utils.get_s3_bucket()
             except Exception:
                 results["storage"] = "error"
 


### PR DESCRIPTION
Removed `utils.get_s3_object_url()` which was the main culprit for errors on AWS tests.