### PR TITLE
Prevents a crash when feature count is enabled on layers on thumbnail…

### DIFF
--- a/docker-qgis/entrypoint.py
+++ b/docker-qgis/entrypoint.py
@@ -147,7 +147,9 @@ def _extract_layer_data(project_filename: Union[str, Path]) -> dict:
 
 
 def _open_project(project_filename: Union[str, Path]):
-    return open_qgis_project(str(project_filename), force_reload=True)
+    return open_qgis_project(
+        str(project_filename), force_reload=True, disable_feature_count=True
+    )
 
 
 def cmd_package_project(args: argparse.Namespace):

--- a/docker-qgis/qfc_worker/utils.py
+++ b/docker-qgis/qfc_worker/utils.py
@@ -261,7 +261,7 @@ def strip_feature_count_from_project_xml(project_filename: str) -> None:
 
             raise Exception(f"Failed to unzip {project_filename} file!")
 
-    logging.error("Parsing QGIS project file XML…")
+    logging.info("Parsing QGIS project file XML…")
 
     tree = ET.parse(xml_file)
     root = tree.getroot()


### PR DESCRIPTION
… generation

Certain QGIS expressions refer to layers. Somehow when such expressions are used for symbology, and the feature count is enabled, the project crashes or hangs forever on `QgsApplication.exitQgis()`.