### PR TITLE
Fix typo to fix timezones for users from the other side of the world

### DIFF
--- a/docker-app/qfieldcloud/core/middleware/timezone.py
+++ b/docker-app/qfieldcloud/core/middleware/timezone.py
@@ -9,7 +9,7 @@ class TimezoneMiddleware:
 
     def __call__(self, request):
         if request.user.is_authenticated and hasattr(
-            request.user.useraccount, "useraccount"
+            request.user.useraccount, "timezone"
         ):
             user_tz = request.user.useraccount.timezone
         elif settings.TIME_ZONE:


### PR DESCRIPTION
We did the wrong check to get the user timezone and we never entered this if body. Note we already assume that the user has a `useraccount` which is safe assumption.