### PR TITLE
Fix missing active subscription creation by reverting the timezone fixes in #912

### DIFF
--- a/docker-app/qfieldcloud/core/middleware/timezone.py
+++ b/docker-app/qfieldcloud/core/middleware/timezone.py
@@ -9,7 +9,7 @@ class TimezoneMiddleware:
 
     def __call__(self, request):
         if request.user.is_authenticated and hasattr(
-            request.user.useraccount, "timezone"
+            request.user.useraccount, "useraccount"
         ):
             user_tz = request.user.useraccount.timezone
         elif settings.TIME_ZONE:


### PR DESCRIPTION
This reverts commit 8510d2369a5b53fda10c99f7cd683c861a6b0638. 

Reverts #912 . 

Prevents creating subscriptions active in the future. Proper fix will be issued in calmer times, sorry fellow friends from other parts of the world.