### PR TITLE
Do not exclude vector layers when estimating the extent of the project

### DIFF
--- a/docker-qgis/entrypoint.py
+++ b/docker-qgis/entrypoint.py
@@ -22,7 +22,7 @@ from qfc_worker.utils import (
     layers_data_to_string,
     open_qgis_project,
 )
-from qgis.core import QgsCoordinateTransform, QgsProject, QgsRectangle, QgsVectorLayer
+from qgis.core import QgsCoordinateTransform, QgsProject, QgsRectangle
 
 PGSERVICE_FILE_CONTENTS = os.environ.get("PGSERVICE_FILE_CONTENTS")
 
@@ -51,9 +51,6 @@ def _call_libqfieldsync_packager(
     else:
         vl_extent = QgsRectangle()
         for layer in layers.values():
-            if isinstance(layer, QgsVectorLayer):
-                continue
-
             layer_extent = layer.extent()
 
             if layer_extent.isNull() or not layer_extent.isFinite():


### PR DESCRIPTION
The removed if condition somehow slipped in, I don't see why it was added in the first place. I guess it was part poor attempt to rewrite the original code from commit `1df4f4090d847e50422881aca1af2595eb2ddb09`:

```
    # Only vector layers
    mapsettings.setLayers(
        [layers[key] for key in layers if type(layers[key]) == QgsVectorLayer]
    )

    extent = mapsettings.fullExtent()
```

However, it is not clear why the if condition has been inverted, neither why the if condition was needed in the first place. If one says it's to prevent the infinite extent of the XYZ layers, the current code already checks for that a few lines below:
```
            if layer_extent.isNull() or not layer_extent.isFinite():
                continue
```

In any case, this line is removed for good now.