### PR TITLE
Fix init_letsencrypt.sh CONFIG_PATH

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -162,7 +162,3 @@ DEBUG_DEBUGPY_APP_PORT=5678
 # Debugpy port used for the `worker_wrapper` service
 # DEFAULT: 5679
 DEBUG_DEBUGPY_WORKER_WRAPPER_PORT=5679
-
-# Path to the nginx, letsencrypt, etc configuration files, used by script in `./scripts/`.
-# DEFAULT: ./conf
-CONFIG_PATH=./

--- a/.env.example
+++ b/.env.example
@@ -165,4 +165,4 @@ DEBUG_DEBUGPY_WORKER_WRAPPER_PORT=5679
 
 # Path to the nginx, letsencrypt, etc configuration files, used by script in `./scripts/`.
 # DEFAULT: ./conf
-CONFIG_PATH=./conf
+CONFIG_PATH=./

--- a/scripts/check_envvars.sh
+++ b/scripts/check_envvars.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-python3 scripts/check_envvars.py .env.example --docker-compose-dir . --ignored-varnames CONFIG_PATH DEBUG_DEBUGPY_APP_PORT DEBUG_DEBUGPY_WORKER_WRAPPER_PORT
+python3 scripts/check_envvars.py .env.example --docker-compose-dir . --ignored-varnames DEBUG_DEBUGPY_APP_PORT DEBUG_DEBUGPY_WORKER_WRAPPER_PORT

--- a/scripts/init_letsencrypt.sh
+++ b/scripts/init_letsencrypt.sh
@@ -7,12 +7,12 @@ set -o allexport
 source .env
 set +o allexport
 
-CONFIG_PATH="${CONFIG_PATH:-'./'}"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-if [ ! -e "${CONFIG_PATH}/docker-nginx/options-ssl-nginx.conf" ] || [ ! -e "${CONFIG_PATH}/docker-nginx/ssl-dhparams.pem" ]; then
+if [ ! -e "${SCRIPT_DIR}/../docker-nginx/options-ssl-nginx.conf" ] || [ ! -e "${SCRIPT_DIR}/../docker-nginx/ssl-dhparams.pem" ]; then
   echo "### Downloading recommended TLS parameters ..."
-  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "${CONFIG_PATH}/docker-nginx/options-ssl-nginx.conf"
-  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "${CONFIG_PATH}/docker-nginx/ssl-dhparams.pem"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "${SCRIPT_DIR}/../docker-nginx/options-ssl-nginx.conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "${SCRIPT_DIR}/../docker-nginx/ssl-dhparams.pem"
   echo
 fi
 
@@ -34,8 +34,8 @@ docker compose run --rm --entrypoint "\
 echo
 
 echo "### Copy the certificate and key to their final destination ..."
-cp ${CONFIG_PATH}/conf/certbot/conf/live/${QFIELDCLOUD_HOST}/fullchain.pem ${CONFIG_PATH}/docker-nginx/certs/${QFIELDCLOUD_HOST}.pem
-cp ${CONFIG_PATH}/conf/certbot/conf/live/${QFIELDCLOUD_HOST}/privkey.pem ${CONFIG_PATH}/docker-nginx/certs/${QFIELDCLOUD_HOST}-key.pem
+cp ${SCRIPT_DIR}/../conf/certbot/conf/live/${QFIELDCLOUD_HOST}/fullchain.pem ${SCRIPT_DIR}/../docker-nginx/certs/${QFIELDCLOUD_HOST}.pem
+cp ${SCRIPT_DIR}/../conf/certbot/conf/live/${QFIELDCLOUD_HOST}/privkey.pem ${SCRIPT_DIR}/../docker-nginx/certs/${QFIELDCLOUD_HOST}-key.pem
 echo
 
 echo "### Reloading nginx ..."

--- a/scripts/init_letsencrypt.sh
+++ b/scripts/init_letsencrypt.sh
@@ -7,12 +7,12 @@ set -o allexport
 source .env
 set +o allexport
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+QFIELDCLOUD_DIR="$(dirname "$(realpath "$0")")/.."
 
-if [ ! -e "${SCRIPT_DIR}/../docker-nginx/options-ssl-nginx.conf" ] || [ ! -e "${SCRIPT_DIR}/../docker-nginx/ssl-dhparams.pem" ]; then
+if [ ! -e "${QFIELDCLOUD_DIR}/docker-nginx/options-ssl-nginx.conf" ] || [ ! -e "${QFIELDCLOUD_DIR}/docker-nginx/ssl-dhparams.pem" ]; then
   echo "### Downloading recommended TLS parameters ..."
-  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "${SCRIPT_DIR}/../docker-nginx/options-ssl-nginx.conf"
-  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "${SCRIPT_DIR}/../docker-nginx/ssl-dhparams.pem"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "${QFIELDCLOUD_DIR}/docker-nginx/options-ssl-nginx.conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "${QFIELDCLOUD_DIR}/docker-nginx/ssl-dhparams.pem"
   echo
 fi
 
@@ -34,8 +34,8 @@ docker compose run --rm --entrypoint "\
 echo
 
 echo "### Copy the certificate and key to their final destination ..."
-cp ${SCRIPT_DIR}/../conf/certbot/conf/live/${QFIELDCLOUD_HOST}/fullchain.pem ${SCRIPT_DIR}/../docker-nginx/certs/${QFIELDCLOUD_HOST}.pem
-cp ${SCRIPT_DIR}/../conf/certbot/conf/live/${QFIELDCLOUD_HOST}/privkey.pem ${SCRIPT_DIR}/../docker-nginx/certs/${QFIELDCLOUD_HOST}-key.pem
+cp ${QFIELDCLOUD_DIR}/conf/certbot/conf/live/${QFIELDCLOUD_HOST}/fullchain.pem ${QFIELDCLOUD_DIR}/docker-nginx/certs/${QFIELDCLOUD_HOST}.pem
+cp ${QFIELDCLOUD_DIR}/conf/certbot/conf/live/${QFIELDCLOUD_HOST}/privkey.pem ${QFIELDCLOUD_DIR}/docker-nginx/certs/${QFIELDCLOUD_HOST}-key.pem
 echo
 
 echo "### Reloading nginx ..."

--- a/scripts/init_letsencrypt.sh
+++ b/scripts/init_letsencrypt.sh
@@ -7,12 +7,12 @@ set -o allexport
 source .env
 set +o allexport
 
-CONFIG_PATH="${CONFIG_PATH:-'./conf'}"
+CONFIG_PATH="${CONFIG_PATH:-'./'}"
 
-if [ ! -e "docker-nginx/options-ssl-nginx.conf" ] || [ ! -e "docker-nginx/ssl-dhparams.pem" ]; then
+if [ ! -e "${CONFIG_PATH}/docker-nginx/options-ssl-nginx.conf" ] || [ ! -e "${CONFIG_PATH}/docker-nginx/ssl-dhparams.pem" ]; then
   echo "### Downloading recommended TLS parameters ..."
-  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "docker-nginx/options-ssl-nginx.conf"
-  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "docker-nginx/ssl-dhparams.pem"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "${CONFIG_PATH}/docker-nginx/options-ssl-nginx.conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "${CONFIG_PATH}/docker-nginx/ssl-dhparams.pem"
   echo
 fi
 
@@ -34,8 +34,8 @@ docker compose run --rm --entrypoint "\
 echo
 
 echo "### Copy the certificate and key to their final destination ..."
-cp ${CONFIG_PATH}/certbot/conf/live/${QFIELDCLOUD_HOST}/fullchain.pem docker-nginx/certs/${QFIELDCLOUD_HOST}.pem
-cp ${CONFIG_PATH}/certbot/conf/live/${QFIELDCLOUD_HOST}/privkey.pem docker-nginx/certs/${QFIELDCLOUD_HOST}-key.pem
+cp ${CONFIG_PATH}/conf/certbot/conf/live/${QFIELDCLOUD_HOST}/fullchain.pem ${CONFIG_PATH}/docker-nginx/certs/${QFIELDCLOUD_HOST}.pem
+cp ${CONFIG_PATH}/conf/certbot/conf/live/${QFIELDCLOUD_HOST}/privkey.pem ${CONFIG_PATH}/docker-nginx/certs/${QFIELDCLOUD_HOST}-key.pem
 echo
 
 echo "### Reloading nginx ..."


### PR DESCRIPTION
Problem for nginx cert update was `init_letsencrypt.sh` uses `CONFIG_PATH=./conf`, but qfieldcloud-nginx config has been moved to the `docker-nginx` folder.

Hence changing `CONFIG_PATH=./` by default and completing the subsequent paths in `init_letsencrypt.sh`