### PR TITLE
Bump to latest Ubuntu 24.04 and QGIS 3.36.2

### DIFF
--- a/docker-qgis/Dockerfile
+++ b/docker-qgis/Dockerfile
@@ -1,5 +1,5 @@
 # NOTE if the ubuntu version is changed, also change it in `Suites:` in apt sources, and in `QGIS_VERSION`
-FROM ubuntu:jammy
+FROM ubuntu:noble
 
 # Install dependencies needed to add QGIS repository
 RUN apt update \
@@ -13,7 +13,7 @@ RUN wget -O /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org
 COPY <<EOF /etc/apt/sources.list.d/qgis.sources
 Types: deb deb-src
 URIs: https://qgis.org/debian
-Suites: jammy
+Suites: noble
 Architectures: amd64
 Components: main
 Signed-By: /etc/apt/keyrings/qgis-archive-keyring.gpg
@@ -30,8 +30,8 @@ RUN apt update \
     git
 
 # Set QGIS version as in the debian repos
-# Choose your version from here: https://debian.qgis.org/debian/dists/jammy/main/binary-amd64/Packages
-ARG QGIS_VERSION=1:3.36.1+36jammy
+# Choose your version from here: https://debian.qgis.org/debian/dists/noble/main/binary-amd64/Packages
+ARG QGIS_VERSION=1:3.36.2+40noble
 
 # Install QGIS dependencies
 RUN apt update \
@@ -65,15 +65,15 @@ ENV XDG_RUNTIME_DIR=/root
 ENV PYTHONPATH=/libqfieldsync:${PYTHONPATH}
 
 # upgrade `pip`. If not upgraded, installing from GitHub repo (needed for `libqfieldsync`) will result in UNKNOWN package.
-RUN pip3 install --upgrade pip
+RUN pip3 install --break-system-packages --upgrade pip
 
 # Install regular dependencies that rarely change
 COPY requirements.txt /tmp/
-RUN pip3 install -r /tmp/requirements.txt
+RUN pip3 install --break-system-packages -r /tmp/requirements.txt
 
 # Install `libqfieldsync` dependecy since it changes more frequently compared to regular dependencies
 COPY requirements_libqfieldsync.txt /tmp/
-RUN pip3 install --use-deprecated=legacy-resolver -r /tmp/requirements_libqfieldsync.txt
+RUN pip3 install --break-system-packages --use-deprecated=legacy-resolver -r /tmp/requirements_libqfieldsync.txt
 
 COPY schemas schemas
 COPY qfc_worker qfc_worker

--- a/docker-qgis/requirements.txt
+++ b/docker-qgis/requirements.txt
@@ -1,6 +1,6 @@
-jsonschema>=3.2.0,<3.3
-typing-extensions>=3.7.4.3,<3.7.5
-tabulate==v0.8.9
+jsonschema>=3.2.0
+typing-extensions>=3
+tabulate>=v0.8.9
 sentry-sdk
 requests>=2.28.1
-qfieldcloud-sdk==0.8.2
+qfieldcloud-sdk==0.8.3


### PR DESCRIPTION
This will automagically bump `gdal` from 3.4.1 to 3.8.4. We actually care that the GPKG patch from 3.4.2 is present. See the QGIS patch here: https://github.com/qgis/QGIS/pull/47098/