### PR TITLE
Hack a way to add extra HTML in `InlineTabular` admin templates

### DIFF
--- a/docker-app/qfieldcloud/core/templates/admin/edit_inline/tabular_customized.html
+++ b/docker-app/qfieldcloud/core/templates/admin/edit_inline/tabular_customized.html
@@ -1,0 +1,5 @@
+{% if qfc_admin_inline_included != 1 %}
+    {% include "admin/edit_inline/tabular_extended.html" with qfc_admin_inline_included=1 %}
+{% endif %}
+
+{{ fieldset.opts.bottom_html }}

--- a/docker-app/qfieldcloud/core/templates/admin/edit_inline/tabular_extended.html
+++ b/docker-app/qfieldcloud/core/templates/admin/edit_inline/tabular_extended.html
@@ -1,0 +1,1 @@
+{% extends "admin/edit_inline/tabular.html" %}


### PR DESCRIPTION
| before | after |
|-|-|
| ![image](https://github.com/opengisch/qfieldcloud/assets/2820439/c9412988-0d80-4604-a010-653070cda231) | ![image](https://github.com/opengisch/qfieldcloud/assets/2820439/23a34435-00b6-4b06-81ec-66193af5e31c) |

Clicking on the link also preloads the current project id.

@boardend it's super hacky way to do it without directly touching the template. No strong opinion if we have to merge it as it is, +0.5 on my side.

