### PR TITLE
Create a link to the project jobs in the project admin view

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -652,6 +652,8 @@ class ProjectAdmin(QFieldCloudModelAdmin):
 
     ordering = ("-updated_at",)
 
+    change_form_template = "admin/project_change_form.html"
+
     def get_form(self, *args, **kwargs):
         help_texts = {
             "file_storage_bytes": _(
@@ -778,6 +780,7 @@ class JobAdmin(QFieldCloudModelAdmin):
         "project__name__iexact",
         "project__owner__username__iexact",
         "id",
+        "project__id__iexact",
     )
     readonly_fields = (
         "project",

--- a/docker-app/qfieldcloud/core/templates/admin/project_change_form.html
+++ b/docker-app/qfieldcloud/core/templates/admin/project_change_form.html
@@ -1,0 +1,10 @@
+{% extends 'admin/change_form.html' %}
+{% load i18n %}
+
+{% block submit_buttons_bottom %}
+  {{ block.super }}
+
+  <div class="submit-row">
+    <a href="{% url 'admin:core_job_changelist' %}?q={{original.id}}">{% trans 'Project jobs' %}</a>
+  </div>
+{% endblock %}


### PR DESCRIPTION
- This adds a link to the project admin form in order to navigate to the list of jobs filtered by the project id

![Screenshot from 2024-05-27 12-14-29](https://github.com/opengisch/qfieldcloud/assets/591241/de77f71c-13a2-4ac8-aa8a-c54575865bab)

![Screenshot from 2024-05-27 12-15-02](https://github.com/opengisch/qfieldcloud/assets/591241/284e28c4-2f67-4da5-9c35-31c661a3cf18)
