### PR TITLE
Fix the failing worker_wrapper and tests by requests==2.32.0

### DIFF
--- a/docker-app/qfieldcloud/core/utils2/storage.py
+++ b/docker-app/qfieldcloud/core/utils2/storage.py
@@ -629,7 +629,7 @@ def get_project_file_storage_in_bytes(project_id: str) -> int:
     total_bytes = 0
     prefix = f"projects/{project_id}/files/"
 
-    logger.info(f"Project file storage size requrested for {project_id=}")
+    logger.info(f"Project file storage size requested for {project_id=}")
 
     if not re.match(r"^projects/[\w]{8}(-[\w]{4}){3}-[\w]{12}/files/$", prefix):
         raise RuntimeError(

--- a/docker-app/requirements.txt
+++ b/docker-app/requirements.txt
@@ -68,7 +68,7 @@ pyrsistent==0.19.3
 python-dateutil==2.8.2
 python3-openid==3.2.0
 pytz==2023.3
-requests==2.32.0
+requests==2.32.2
 requests-oauthlib==1.3.1
 ruamel.yaml==0.17.26
 ruamel.yaml.clib==0.2.7

--- a/docker-app/requirements_worker_wrapper.txt
+++ b/docker-app/requirements_worker_wrapper.txt
@@ -1,2 +1,2 @@
-docker==4.2.2
-tenacity==8.1.0
+docker==7.1.0
+tenacity==8.3.0


### PR DESCRIPTION
The CI tests returned error messages like:
> Exception: Processing did no finish, did the worker hang ?

This was cause because the `worker_wrapper` gets on start:
> docker.errors.DockerException: Error while fetching server API version: Not supported URL scheme http+docker

NOTE since we are using multi-stage builds in docker, the `requests`
dependency was forced on the previous layer than the `worker_wrapper`
itself.