### PR TITLE
Set initial created subscription plan status to ACTIVE_PAID

### DIFF
--- a/docker-app/qfieldcloud/subscription/migrations/0004_auto_20220923_1602.py
+++ b/docker-app/qfieldcloud/subscription/migrations/0004_auto_20220923_1602.py
@@ -77,6 +77,14 @@ def add_packages_to_accounts(apps, schema_editor):
         package.save()
 
 
+def set_existing_plans_to_active_status(apps, schema_editor):
+    Plan = apps.get_model("subscription", "Plan")
+
+    Plan.objects.update(
+        initial_subscription_status="active_paid",
+    )
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ("subscription", "0003_auto_20221028_1901"),
@@ -345,6 +353,10 @@ class Migration(migrations.Migration):
                 default="inactive_draft",
                 max_length=100,
             ),
+        ),
+        migrations.RunPython(
+            set_existing_plans_to_active_status,
+            migrations.RunPython.noop,
         ),
         migrations.AddField(
             model_name="plan",

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -789,6 +789,8 @@ class AbstractSubscription(models.Model):
             active_since=active_since,
         )
 
+        regular_subscription.status = Subscription.Status.ACTIVE_PAID
+
         return regular_subscription
 
     @classmethod

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -70,6 +70,7 @@ class Plan(models.Model):
                     is_default=True,
                     is_public=False,
                     user_type=User.Type.PERSON,
+                    initial_subscription_status=SubscriptionStatus.ACTIVE_PAID,
                 )
                 cls.objects.create(
                     code="default_org",
@@ -77,6 +78,7 @@ class Plan(models.Model):
                     is_default=True,
                     is_public=False,
                     user_type=User.Type.ORGANIZATION,
+                    initial_subscription_status=SubscriptionStatus.ACTIVE_PAID,
                 )
         result = cls.objects.order_by("-is_default").first()
         return cast(Plan, result)
@@ -173,7 +175,7 @@ class Plan(models.Model):
     initial_subscription_status = models.CharField(
         max_length=100,
         choices=SubscriptionStatus.choices,
-        default=SubscriptionStatus.ACTIVE_PAID,
+        default=SubscriptionStatus.INACTIVE_DRAFT,
     )
 
     # comma separated list of plan codes, which given plan can upgrade to.

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -173,7 +173,7 @@ class Plan(models.Model):
     initial_subscription_status = models.CharField(
         max_length=100,
         choices=SubscriptionStatus.choices,
-        default=SubscriptionStatus.INACTIVE_DRAFT,
+        default=SubscriptionStatus.ACTIVE_PAID,
     )
 
     # comma separated list of plan codes, which given plan can upgrade to.
@@ -788,8 +788,6 @@ class AbstractSubscription(models.Model):
             created_by=created_by,
             active_since=active_since,
         )
-
-        regular_subscription.status = Subscription.Status.ACTIVE_PAID
 
         return regular_subscription
 


### PR DESCRIPTION
When hosting a new QFieldCloud instance, a default subscription plan is created. This change ensures that the status of this plan is `ACTIVE_PAID`, so that created users can create/use projects on that instance as expected.

This change won't affect existing QFieldCloud instances in any way.