### PR TITLE
Set new user's default timezone to the settings one

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -398,7 +398,7 @@ class UserAccount(models.Model):
     twitter = models.CharField(max_length=255, default="", blank=True)
     is_email_public = models.BooleanField(default=False)
     avatar_uri = models.CharField(_("Profile Picture URI"), max_length=255, blank=True)
-    timezone = TimeZoneField(default="Europe/Zurich", choices_display="WITH_GMT_OFFSET")
+    timezone = TimeZoneField(default=settings.TIME_ZONE, choices_display="WITH_GMT_OFFSET")
 
     notifs_frequency = models.DurationField(
         verbose_name=_("Email frequency for notifications"),


### PR DESCRIPTION
When creating a new user in the QFieldCloud admin interface, the user's timezone is always "Europe/Zürich", even if the `QFIELDCLOUD_DEFAULT_TIME_ZONE` / `TIME_ZONE` variables are different

This PR sets the timezone of a new user to the env timezone by default