### PR TITLE
When adding a collaborator via the API, add created_by/updated_by

### DIFF
--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -188,20 +188,34 @@ class OrganizationSerializer(serializers.ModelSerializer):
 
 class ProjectCollaboratorSerializer(serializers.ModelSerializer):
     collaborator = serializers.StringRelatedField()
-    role = serializers.CharField()
+    created_by = serializers.StringRelatedField()
+    updated_by = serializers.StringRelatedField()
 
     class Meta:
         model = ProjectCollaborator
-        fields = ("collaborator", "role")
+        fields = (
+            "project_id",
+            "collaborator",
+            "role",
+            "created_by",
+            "updated_by",
+            "created_at",
+            "updated_at",
+        )
 
 
 class OrganizationMemberSerializer(serializers.ModelSerializer):
+    organization = serializers.StringRelatedField()
     member = serializers.StringRelatedField()
-    role = serializers.CharField()
 
     class Meta:
         model = OrganizationMember
-        fields = ("member", "role")
+        fields = (
+            "organization",
+            "member",
+            "role",
+            "is_public",
+        )
 
 
 class TokenSerializer(serializers.ModelSerializer):

--- a/docker-app/qfieldcloud/core/views/collaborators_views.py
+++ b/docker-app/qfieldcloud/core/views/collaborators_views.py
@@ -2,7 +2,7 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from qfieldcloud.core import pagination, permissions_utils
-from qfieldcloud.core.models import Project, ProjectCollaborator
+from qfieldcloud.core.models import Person, Project, ProjectCollaborator
 from qfieldcloud.core.serializers import ProjectCollaboratorSerializer
 from rest_framework import generics, permissions, status
 from rest_framework.response import Response
@@ -50,9 +50,14 @@ class ListCreateCollaboratorsView(generics.ListCreateAPIView):
     def post(self, request, projectid):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        collaborator = User.objects.get(username=request.data["collaborator"])
+        collaborator = Person.objects.get(username=request.data["collaborator"])
         project = Project.objects.get(id=projectid)
-        serializer.save(collaborator=collaborator, project=project)
+        serializer.save(
+            collaborator=collaborator,
+            project=project,
+            created_by=request.user,
+            updated_by=request.user,
+        )
 
         try:
             headers = {"Location": str(serializer.data[api_settings.URL_FIELD_NAME])}


### PR DESCRIPTION
In addition, prevent attempts to add other `User` subclasses as project
collaborators