### PR TITLE
Make sure the qgis continues to run

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,7 @@ services:
     tty: true
     command: bash -c "echo QGIS built"
     logging: *default-logging
+    stop_grace_period: 15m
 
   worker_wrapper:
     <<: *default-django


### PR DESCRIPTION
Had to verify that the qgis container gets immediately killed, which is not great.

How to test:
1) add `sleep(10000)` to the start of `docker-qgis/entrypoint.py` 
2) verify it is still running after a few minutes
3) `docker compose stop`
4) check if QGIS is still running:
- before the changes: it is not
- after QGIS: it is waiting for the end