### PR TITLE
Enhance shell_plut with ipython if DEBUG_BUILD

### DIFF
--- a/docker-app/Dockerfile
+++ b/docker-app/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=build /usr/local/lib/python3.10/site-packages/ /usr/local/lib/python
 
 # install debug dependencies
 ARG DEBUG_BUILD
-RUN if [ "$DEBUG_BUILD" = "1" ]; then pip3 install debugpy; fi
+RUN if [ "$DEBUG_BUILD" = "1" ]; then pip3 install debugpy ipython; fi
 
 # add app group
 RUN addgroup --system app && adduser --system app --ingroup app


### PR DESCRIPTION
I like ipython for block editing and much more. If installed, is used as default by `django manage.py shell_plus` . 
Suggest add it if DEBUG_BUILD is set.