### PR TITLE
Use optimized packager by default for new projects

### DIFF
--- a/docker-app/qfieldcloud/core/migrations/0073_project_packaging_offliner.py
+++ b/docker-app/qfieldcloud/core/migrations/0073_project_packaging_offliner.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
                     ("qgiscore", "QGIS Core Offline Editing (deprecated)"),
                     ("pythonmini", "Optimized Packager"),
                 ],
-                default="qgiscore",
+                default="pythonmini",
                 help_text='The Packaging Offliner packages data for offline use with QField. The new "Optimized Packager" should be preferred over the deprecated "QGIS Core Offline Editing" for new projects.',
                 max_length=100,
                 verbose_name="Packaging Offliner",

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1062,7 +1062,7 @@ class Project(models.Model):
             'The Packaging Offliner packages data for offline use with QField. The new "Optimized Packager" should be preferred over the deprecated "QGIS Core Offline Editing" for new projects.'
         ),
         max_length=100,
-        default=PackagingOffliner.QGISCORE,
+        default=PackagingOffliner.PYTHONMINI,
         choices=PackagingOffliner.choices,
     )
 


### PR DESCRIPTION
Since the `QGIS Core Offline Editing` packager is deprecated, why not use the "Optimized packager" for new project as default ?

![image](https://github.com/user-attachments/assets/93f583c1-8b5a-4254-9c7e-358ac7edb9d4)
