### PR TITLE
Add a Makefile to ease setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+SHELL:=bash
+ENV_FILE:=.env.example
+
+DJANGO_SUPERUSER_USERNAME="super_user"
+DJANGO_SUPERUSER_EMAIL="qfield@cloud.gis"
+DJANGO_SUPERUSER_PASSWORD="Ch@ngeM3Please;-)"
+
+env:
+	@echo "Configuring .env file from $(ENV_FILE)"
+	@grep -v -e '^#' -e '^$$' $(ENV_FILE) > .env
+
+build:
+	@echo "Build images"
+	docker compose build
+
+run:
+	@echo "Start QFieldCloud stack"
+	docker compose up -d
+
+#
+# Run initial configuration
+#
+# See https://github.com/opengisch/qfieldcloud#launch-a-local-instance
+# This is not really docker-friendly but django is to blame
+#
+init:
+	@echo "Initialize QFieldCloud stack (run django migration && collect static files)"
+	docker compose exec app python manage.py migrate
+	docker compose exec app python manage.py collectstatic --noinput
+	@echo "Waiting for 5s for workers to be up..."
+	@sleep 5
+
+status:
+	@echo "Check QFieldCloud status"
+	docker compose exec app python manage.py status
+
+create-superuser:
+	@echo "Create QFieldCloud super user"
+	@export DJANGO_SUPERUSER_PASSWORD=$(DJANGO_SUPERUSER_PASSWORD)
+	docker compose exec app python manage.py createsuperuser --noinput \
+	--username $(DJANGO_SUPERUSER_USERNAME) --email $(DJANGO_SUPERUSER_EMAIL)
+
+stop:
+	@echo "Stop QFieldCloud stack"
+	docker compose down


### PR DESCRIPTION
This is a proposal to add a Makefile to the project.

For example, the following commands can be used to launch a local instance:

```bash
# Copy environment file
make env

# Build (build stack)
make build

# Run (docker composer up)
make run

# Initialize (django migrations & static files)
make init

# Check status
make status

# Create super-user
make create-superuser

# Stop
make stop
```

This PR is a draft, as a first simple contribution. 