### PR TITLE
Make the information whether an error should be logged to sentry  part of the error class

### DIFF
--- a/docker-app/qfieldcloud/core/exceptions.py
+++ b/docker-app/qfieldcloud/core/exceptions.py
@@ -84,7 +84,7 @@ class EmptyContentError(QFieldCloudException):
 
     code = "empty_content"
     message = "Empty content"
-    status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    status_code = status.HTTP_400_BAD_REQUEST
 
 
 class MultipleContentsError(QFieldCloudException):

--- a/docker-app/qfieldcloud/core/exceptions.py
+++ b/docker-app/qfieldcloud/core/exceptions.py
@@ -8,7 +8,16 @@ class IntegrationError(QfcError): ...
 
 
 class QFieldCloudException(Exception):
-    """Generic QFieldCloud Exception"""
+    """Generic QFieldCloud Exception
+
+    Attributes:
+        code (str): error code
+        message (str): error message.
+        status_code (int): HTTP status code to be returned by the global Django error handler.
+        log_as_error (bool): If set to `False`, the error will be logged as info level, instead of error level.
+            This is useful for error that do not show problems in the system, but are server side client data assertions.
+            Default is True.
+    """
 
     code = "unknown_error"
     message = "QFieldcloud Unknown Error"

--- a/docker-app/qfieldcloud/core/exceptions.py
+++ b/docker-app/qfieldcloud/core/exceptions.py
@@ -13,6 +13,7 @@ class QFieldCloudException(Exception):
     code = "unknown_error"
     message = "QFieldcloud Unknown Error"
     status_code = None
+    log_as_error = True
 
     def __init__(self, detail="", status_code=None):
         self.detail = detail
@@ -44,6 +45,7 @@ class AuthenticationFailedError(QFieldCloudException):
     code = "authentication_failed"
     message = "Authentication failed"
     status_code = status.HTTP_401_UNAUTHORIZED
+    log_as_error = False
 
 
 class AuthenticationViaTokenFailedError(QFieldCloudException):
@@ -60,6 +62,7 @@ class NotAuthenticatedError(QFieldCloudException):
     code = "not_authenticated"
     message = "Not authenticated"
     status_code = status.HTTP_401_UNAUTHORIZED
+    log_as_error = False
 
 
 class TooManyLoginAttemptsError(QFieldCloudException):
@@ -76,6 +79,7 @@ class PermissionDeniedError(QFieldCloudException):
     code = "permission_denied"
     message = "Permission denied"
     status_code = status.HTTP_403_FORBIDDEN
+    log_as_error = False
 
 
 class EmptyContentError(QFieldCloudException):
@@ -103,6 +107,7 @@ class ObjectNotFoundError(QFieldCloudException):
     code = "object_not_found"
     message = "Object not found"
     status_code = status.HTTP_400_BAD_REQUEST
+    log_as_error = False
 
 
 class APIError(QFieldCloudException):
@@ -120,6 +125,7 @@ class ValidationError(QFieldCloudException):
     code = "validation_error"
     message = "Validation error"
     status_code = status.HTTP_400_BAD_REQUEST
+    log_as_error = False
 
 
 class MultipleProjectsError(QFieldCloudException):

--- a/docker-app/qfieldcloud/core/rest_utils.py
+++ b/docker-app/qfieldcloud/core/rest_utils.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.core import exceptions
 from qfieldcloud.core import exceptions as qfieldcloud_exceptions
 from rest_framework import exceptions as rest_exceptions
-from rest_framework import status
 from rest_framework.response import Response
 
 logger = logging.getLogger(__name__)
@@ -32,8 +31,8 @@ def exception_handler(exc, context):
             raise exc
         qfc_exc = qfieldcloud_exceptions.QFieldCloudException(detail=str(exc))
 
-    # Log level depends on the status code (5xx are logged as errors, 4xx are logged in info)
-    if not status.is_client_error(qfc_exc.status_code):
+    # Log level is defined by the exception
+    if qfc_exc.log_as_error:
         # log the original exception
         logging.exception(exc)
     else:

--- a/docker-app/qfieldcloud/core/rest_utils.py
+++ b/docker-app/qfieldcloud/core/rest_utils.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.core import exceptions
 from qfieldcloud.core import exceptions as qfieldcloud_exceptions
 from rest_framework import exceptions as rest_exceptions
+from rest_framework import status
 from rest_framework.response import Response
 
 logger = logging.getLogger(__name__)
@@ -11,7 +12,6 @@ logger = logging.getLogger(__name__)
 
 def exception_handler(exc, context):
     # Map exceptions to qfc exceptions
-    is_error = False
     if isinstance(exc, rest_exceptions.AuthenticationFailed):
         qfc_exc = qfieldcloud_exceptions.AuthenticationFailedError()
     elif isinstance(exc, rest_exceptions.NotAuthenticated):
@@ -23,19 +23,17 @@ def exception_handler(exc, context):
     elif isinstance(exc, exceptions.ValidationError):
         qfc_exc = qfieldcloud_exceptions.ValidationError(detail=str(exc))
     elif isinstance(exc, qfieldcloud_exceptions.QFieldCloudException):
-        is_error = True
         qfc_exc = exc
     elif isinstance(exc, rest_exceptions.APIException):
-        is_error = True
         qfc_exc = qfieldcloud_exceptions.APIError(exc.detail, exc.status_code)
     else:
         # Unexpected ! We rethrow original exception to make debugging tests easier
         if settings.IN_TEST_SUITE:
             raise exc
-        is_error = True
         qfc_exc = qfieldcloud_exceptions.QFieldCloudException(detail=str(exc))
 
-    if is_error:
+    # Log level depends on the status code (5xx are logged as errors, 4xx are logged in info)
+    if not status.is_client_error(qfc_exc.status_code):
         # log the original exception
         logging.exception(exc)
     else:


### PR DESCRIPTION
(we reuse the http code to determine if it's sever error or client error)