### PR TITLE
Retire the outdated `django-migrate-sql-deux` and use `django-migrate-sql-3`

### DIFF
--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -18,7 +18,7 @@ django-extensions==3.2.3
 django-filter==24.3
 django-invitations==2.1.0
 django-jazzmin==3.0.0
-django-migrate-sql-deux==0.5.0
+django-migrate-sql-3==3.0.2
 django-model-utils==5.0.0
 django-nonrelated-inlines==0.2
 django-notifications-hq==1.8.3

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -108,7 +108,7 @@ django-jazzmin==3.0.0
     # via -r /requirements/requirements.in
 django-log-request-id==2.1.0
     # via -r /requirements/requirements.in
-django-migrate-sql-deux==0.5.0
+django-migrate-sql-3==3.0.2
     # via -r /requirements/requirements.in
 django-model-utils==5.0.0
     # via


### PR DESCRIPTION
The old module does not support Django 4+