### PR TITLE
Fixing github Build-and-push so that it actually pushes

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -96,6 +96,7 @@ jobs:
         with:
           file: ${{ matrix.services.dockerfile }}
           context: ${{ matrix.services.docker_context }}
+          push: ${{ matrix.services.enable_dockerhub && (github.event_name == 'release' || github.ref_name == 'master') }}
           target: ${{ matrix.services.docker_target }}
           tags: ${{ steps.docker_metadata.outputs.tags }}
           cache-from: type=registry,ref=ghcr.io/opengisch/qfieldcloud-${{ matrix.services.service_name }}:buildcache


### PR DESCRIPTION
Build and push was missing the `push:` entry, so it was not pushing over its build.