### PR TITLE
Add token filter and action

### DIFF
--- a/docker-app/qfieldcloud/authentication/admin.py
+++ b/docker-app/qfieldcloud/authentication/admin.py
@@ -23,7 +23,7 @@ class AuthTokenClientTypeFilter(admin.SimpleListFilter):
         appear in the URL query. The second element is the
         human-readable name for the option that will appear
         in the right sidebar.
-        Here it is just the several available AuthToken.ClientType
+        Here it is just the several available `AuthToken.ClientType`.
         """
         return AuthToken.ClientType.choices
 

--- a/docker-app/qfieldcloud/authentication/admin.py
+++ b/docker-app/qfieldcloud/authentication/admin.py
@@ -1,7 +1,47 @@
 from django.contrib import admin
 from django.contrib.admin import register
+from django.db.models import Q, QuerySet
 
 from .models import AuthToken
+
+
+class AuthTokenClientTypeFilter(admin.SimpleListFilter):
+    # Human-readable title which will be displayed in the
+    # admin page in the filter options
+    title = "Client type"
+
+    # Parameter for the filter that will be used in the URL query.
+    parameter_name = "client_type"
+
+    def lookups(self, request, model_admin):
+        """
+        Returns a list of tuples. The first element in each
+        tuple is the coded value for the option that will
+        appear in the URL query. The second element is the
+        human-readable name for the option that will appear
+        in the right sidebar.
+        Here it is just the several available AuthToken.ClientType
+        """
+        return AuthToken.ClientType.choices
+
+    def queryset(self, request, queryset) -> QuerySet:
+        """
+        Returns the filtered queryset based on the value
+        provided in the query string and retrievable via
+        `self.value()`.
+        """
+        value = self.value()
+
+        if value is None:
+            return queryset
+
+        accepted_values = [ct[0] for ct in AuthToken.ClientType.choices]
+        if value not in accepted_values:
+            raise NotImplementedError(
+                f"Unknown client type: {value} (was expecting: {','.join(accepted_values)})"
+            )
+
+        return queryset.filter(Q(client_type=value))
 
 
 @register(AuthToken)
@@ -15,6 +55,11 @@ class AuthTokenAdmin(admin.ModelAdmin):
         "client_type",
         "user_agent",
     )
-    list_filter = ("created_at", "last_used_at", "expires_at")
+    list_filter = (
+        "created_at",
+        "last_used_at",
+        "expires_at",
+        AuthTokenClientTypeFilter,
+    )
 
     search_fields = ("user__username__iexact", "client_type", "key__startswith")

--- a/docker-app/qfieldcloud/authentication/admin.py
+++ b/docker-app/qfieldcloud/authentication/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.contrib.admin import register
 from django.db.models import Q, QuerySet
+from django.http import HttpRequest
 from django.utils import timezone
 
 from .models import AuthToken
@@ -13,7 +14,9 @@ class AuthTokenClientTypeFilter(admin.SimpleListFilter):
     # Parameter for the filter that will be used in the URL query.
     parameter_name = "client_type"
 
-    def lookups(self, request, model_admin):
+    def lookups(
+        self, request: HttpRequest, model_admin: admin.ModelAdmin
+    ) -> list[tuple[str, str]]:
         """
         Returns a list of tuples. The first element in each
         tuple is the coded value for the option that will
@@ -24,7 +27,7 @@ class AuthTokenClientTypeFilter(admin.SimpleListFilter):
         """
         return AuthToken.ClientType.choices
 
-    def queryset(self, request, queryset) -> QuerySet:
+    def queryset(self, request: HttpRequest, queryset: QuerySet) -> QuerySet:
         """
         Returns the filtered queryset based on the value
         provided in the query string and retrievable via
@@ -66,7 +69,7 @@ class AuthTokenAdmin(admin.ModelAdmin):
 
     search_fields = ("user__username__iexact", "client_type", "key__startswith")
 
-    def expire_selected_tokens(self, request, queryset):
+    def expire_selected_tokens(self, request: HttpRequest, queryset: QuerySet) -> None:
         """
         Sets a set of tokens to expired
         by updating the expires_at date to now

--- a/docker-app/qfieldcloud/authentication/admin.py
+++ b/docker-app/qfieldcloud/authentication/admin.py
@@ -1,13 +1,13 @@
 from django.contrib import admin
 from django.contrib.admin import register
 from django.db.models import Q, QuerySet
+from django.utils import timezone
 
 from .models import AuthToken
 
 
 class AuthTokenClientTypeFilter(admin.SimpleListFilter):
-    # Human-readable title which will be displayed in the
-    # admin page in the filter options
+    # Human-readable title which will be displayed
     title = "Client type"
 
     # Parameter for the filter that will be used in the URL query.
@@ -62,4 +62,15 @@ class AuthTokenAdmin(admin.ModelAdmin):
         AuthTokenClientTypeFilter,
     )
 
+    actions = ("expire_selected_tokens",)
+
     search_fields = ("user__username__iexact", "client_type", "key__startswith")
+
+    def expire_selected_tokens(self, request, queryset):
+        """
+        Sets a set of tokens to expired
+        by updating the expires_at date to now
+        Expires only valid tokens
+        """
+        now = timezone.now()
+        queryset.filter(Q(expires_at__gt=now)).update(expires_at=now)

--- a/docker-app/qfieldcloud/authentication/admin.py
+++ b/docker-app/qfieldcloud/authentication/admin.py
@@ -71,9 +71,8 @@ class AuthTokenAdmin(admin.ModelAdmin):
 
     def expire_selected_tokens(self, request: HttpRequest, queryset: QuerySet) -> None:
         """
-        Sets a set of tokens to expired
-        by updating the expires_at date to now
-        Expires only valid tokens
+        Sets a set of tokens to expired by updating the `expires_at` date to now.
+        Expires only valid tokens.
         """
         now = timezone.now()
         queryset.filter(Q(expires_at__gt=now)).update(expires_at=now)


### PR DESCRIPTION
- add a token filter based on client type (e.g. `QField`, `QFieldSync`, `Browser`...)
- add a custom action to disable a token by setting it's expiration date to now