### PR TITLE
Bump `django-auditlog` to 3.0.0+

### DIFF
--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -616,6 +616,17 @@ AUDITLOG_INCLUDE_TRACKING_MODELS = [
     },
 ]
 
+
+# Django auditlog version 3.0.0 migrates the `changes` from `text` to `jsonb` datatype.
+# Since QFieldCloud has millions of audits, the migration will lock the database for hours.
+# This problem was recognized by the developers and they added two step migration: there are two fields to store the `changes`, the old text based one and the new json based new one.
+# TODO remove the `AUDITLOG_TWO_STEP_MIGRATION` and `AUDITLOG_USE_TEXT_CHANGES_IF_JSON_IS_NOT_PRESENT` settings in the future, after `manage.py auditlogmigratejson` has been called.
+# TODO THe `auditlog_logentry.changes_text` shall be removed manually after that.
+# Read more: https://django-auditlog.readthedocs.io/en/latest/upgrade.html
+AUDITLOG_TWO_STEP_MIGRATION = True
+AUDITLOG_USE_TEXT_CHANGES_IF_JSON_IS_NOT_PRESENT = True
+
+
 SPECTACULAR_SETTINGS = {
     "TITLE": "QFieldCloud JSON API",
     "DESCRIPTION": "QFieldCloud JSON API",

--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -3,7 +3,7 @@ boto3-stubs==1.35.20
 deprecated==1.2.14
 django==4.2.16
 django-allauth==0.44.0
-django-auditlog==2.3.0
+django-auditlog==3.0.0
 django-axes==5.40.1
 django-bootstrap4==24.3
 django-classy-tags==4.1.0

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -74,7 +74,7 @@ django-allauth==0.44.0
     # via -r /requirements/requirements.in
 django-appconf==1.0.6
     # via django-cryptography
-django-auditlog==2.3.0
+django-auditlog==3.0.0
     # via -r /requirements/requirements.in
 django-axes==5.40.1
     # via -r /requirements/requirements.in


### PR DESCRIPTION
Django auditlog version 3.0.0 migrates the `changes` from `text` to `jsonb` datatype. Since QFieldCloud has millions of audits, the migration will lock the database for hours. This problem was recognized by the developers and they added two step migration: there are two fields to store the `changes`, the old text based one and the new json based new one. Read more: https://django-auditlog.readthedocs.io/en/latest/upgrade.html

We have to remove the `AUDITLOG_TWO_STEP_MIGRATION` and `AUDITLOG_USE_TEXT_CHANGES_IF_JSON_IS_NOT_PRESENT` settings in the future after `manage.py auditlogmigratejson` has been called. THe `auditlog_logentry.changes_text` shall be removed manually after that.