### PR TITLE
Fix pre-commit check on the CI that fails on commits merged to `master`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           python-version: '3.12'
       - name: Pre-commit
+        env:
+          # set the `no-commit-to-branch` to be skipped, otherwise the check fails when we merge to `master` branch
+          SKIP: no-commit-to-branch
         uses: pre-commit/action@v3.0.1
 
   test:


### PR DESCRIPTION
The `no-commit-to-branch` prevents from accidental commit to master locally. It is not needed to run on the CI. Whatismore, it has to be disabled, otherwise it causes merge commits to fail.