### PR TITLE
[tests] Rename `TeamsTestCase` to `QfcTestCase` as all the tests on QFieldCloud

### DIFF
--- a/docker-app/qfieldcloud/core/tests/test_team.py
+++ b/docker-app/qfieldcloud/core/tests/test_team.py
@@ -15,7 +15,7 @@ from .utils import setup_subscription_plans
 logging.disable(logging.CRITICAL)
 
 
-class TeamsTestCase(APITestCase):
+class QfcTestCase(APITestCase):
     def setUp(self):
         setup_subscription_plans()
 


### PR DESCRIPTION
We name everything with the same name to make our life much easier when running tests via the CLI.