### PR TITLE
[refactor] Add error message for the `FileNotFoundError` instead of just showing the filename

### DIFF
--- a/docker-qgis/qfc_worker/utils.py
+++ b/docker-qgis/qfc_worker/utils.py
@@ -229,7 +229,7 @@ def open_qgis_project(
     logging.info(f'Loading QGIS project "{project_filename}"…')
 
     if not Path(project_filename).exists():
-        raise FileNotFoundError(project_filename)
+        raise FileNotFoundError(f"File not found: {project_filename}")
 
     project = QgsProject.instance()
 


### PR DESCRIPTION
This is only visible in the `Job.feedback_json`, but makes much more sense to the user and the developer when debugging.