### PR TITLE
[refactor] Make functions in `utils2.storages` us the `Project` instance, not only the `project_id`

### DIFF
--- a/docker-app/qfieldcloud/core/cron.py
+++ b/docker-app/qfieldcloud/core/cron.py
@@ -128,4 +128,4 @@ class DeleteObsoleteProjectPackagesJob(CronJobBase):
                 if package_id in job_ids:
                     continue
 
-                storage.delete_stored_package(project_id, package_id)
+                storage.delete_stored_package(project, package_id)

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1417,7 +1417,7 @@ class Project(models.Model):
         logger.debug(f"Saving project {self}...")
 
         if recompute_storage:
-            self.file_storage_bytes = storage.get_project_file_storage_in_bytes(self.id)
+            self.file_storage_bytes = storage.get_project_file_storage_in_bytes(self)
 
         # Ensure that the Project's storage_keep_versions is at least 1, and reflects the plan's default storage_keep_versions value.
         if not self.storage_keep_versions:

--- a/docker-app/qfieldcloud/core/tests/test_packages.py
+++ b/docker-app/qfieldcloud/core/tests/test_packages.py
@@ -665,7 +665,7 @@ class QfcTestCase(APITransactionTestCase):
         old_package = PackageJob.objects.filter(project=self.project1).latest(
             "created_at"
         )
-        stored_package_ids = get_stored_package_ids(self.project1.id)
+        stored_package_ids = get_stored_package_ids(self.project1)
         self.assertIn(str(old_package.id), stored_package_ids)
         self.assertEqual(len(stored_package_ids), 1)
 
@@ -683,7 +683,7 @@ class QfcTestCase(APITransactionTestCase):
             "created_at"
         )
 
-        stored_package_ids = get_stored_package_ids(self.project1.id)
+        stored_package_ids = get_stored_package_ids(self.project1)
 
         self.assertNotEqual(old_package.id, new_package.id)
         self.assertNotIn(str(old_package.id), stored_package_ids)

--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -408,8 +408,7 @@ class PackageJobRun(JobRun):
         )
 
         try:
-            project_id = str(self.job.project.id)
-            package_ids = storage.get_stored_package_ids(project_id)
+            package_ids = storage.get_stored_package_ids(self.job.project)
             job_ids = [
                 str(job["id"])
                 for job in Job.objects.filter(
@@ -431,7 +430,7 @@ class PackageJobRun(JobRun):
                 if package_id in job_ids:
                     continue
 
-                storage.delete_stored_package(project_id, package_id)
+                storage.delete_stored_package(self.job.project, package_id)
         except Exception as err:
             logger.error(
                 "Failed to delete dangling packages, will be deleted via CRON later.",


### PR DESCRIPTION
This simplifies some of the future code that is coming in QF-2760.