### PR TITLE
Bump django-allauth to 65.3.1

### DIFF
--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -136,6 +136,7 @@ MIDDLEWARE = [
     "qfieldcloud.core.middleware.timezone.TimezoneMiddleware",
     "qfieldcloud.core.middleware.test.TestMiddleware",
     "axes.middleware.AxesMiddleware",
+    "allauth.account.middleware.AccountMiddleware",
 ]
 
 CRON_CLASSES = [
@@ -358,6 +359,10 @@ ACCOUNT_AUTHENTICATION_METHOD = "username_email"
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS = 3
 ACCOUNT_EMAIL_SUBJECT_PREFIX = ""
+
+# Django allauth's RateLimiter configuration
+# https://docs.allauth.org/en/latest/account/rate_limits.html
+ACCOUNT_RATE_LIMITS = False
 
 # Choose one of "mandatory", "optional", or "none".
 # For local development and test use "optional" or "none"

--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -1,7 +1,8 @@
 boto3-stubs==1.35.90
 boto3==1.35.90
 deprecated==1.2.15
-django-allauth==0.44.0
+django==4.2.16
+django-allauth==65.3.1
 django-auditlog==3.0.0
 django-axes==7.0.1
 django-bootstrap4==24.4

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -7,6 +7,7 @@
 asgiref==3.8.1
     # via
     #   django
+    #   django-allauth
     #   django-axes
     #   django-countries
 attrs==24.2.0
@@ -34,11 +35,7 @@ cffi==1.17.0
 charset-normalizer==3.3.2
     # via requests
 cryptography==44.0.0
-    # via
-    #   django-cryptography
-    #   pyjwt
-defusedxml==0.7.1
-    # via python3-openid
+    # via django-cryptography
 deprecated==1.2.15
     # via -r /requirements/requirements.in
 django==4.2.17
@@ -72,7 +69,7 @@ django==4.2.17
     #   djangorestframework
     #   drf-spectacular
     #   jsonfield
-django-allauth==0.44.0
+django-allauth==65.3.1
     # via -r /requirements/requirements.in
 django-appconf==1.0.6
     # via django-cryptography
@@ -154,24 +151,18 @@ jsonschema-specifications==2023.12.1
     # via jsonschema
 mypy-boto3-s3==1.35.81
     # via -r /requirements/requirements.in
-oauthlib==3.2.2
-    # via requests-oauthlib
 phonenumbers==8.13.52
     # via -r /requirements/requirements.in
 psycopg2==2.9.10
     # via -r /requirements/requirements.in
 pycparser==2.22
     # via cffi
-pyjwt[crypto]==2.9.0
-    # via django-allauth
 pymemcache==4.0.0
     # via -r /requirements/requirements.in
 python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   django-auditlog
-python3-openid==3.2.0
-    # via django-allauth
 pytz==2024.1
     # via django-notifications-hq
 pyyaml==6.0.2
@@ -181,12 +172,7 @@ referencing==0.35.1
     #   jsonschema
     #   jsonschema-specifications
 requests==2.32.3
-    # via
-    #   django-allauth
-    #   requests-oauthlib
-    #   stripe
-requests-oauthlib==2.0.0
-    # via django-allauth
+    # via stripe
 rpds-py==0.20.0
     # via
     #   jsonschema


### PR DESCRIPTION
This PR upgrades `django-allauth` dependency version to a newer one :

- [x] bumps `django-allauth` to `65.3.1` in requirements
- [x] adds `allauth.account.middleware.AccountMiddleware` to settings' `MIDDLEWARE` (see [Quickstart guide](https://docs.allauth.org/en/dev/installation/quickstart.html))
- [ ] ~removes `django-axes` from the requirements~ (edit : choice has been made to keep the `django-axes` rate limiter for the moment, since it provides a convenient way to re-enable a locked-out user, in the admin interface)
- [x] does not add any regression (check `authentication` module tests as well)