### PR TITLE
Add `djangorestframework-stubs` for better typing

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -9,3 +9,6 @@ ignore_errors: True
 # Turn off mypy for unit tests
 [mypy-*.tests.*]
 ignore_errors: True
+
+plugins =
+    mypy_drf_plugin.main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,6 @@ repos:
     rev: v1.13.0
     hooks:
       - id: mypy
-        additional_dependencies: [types-pytz, types-Deprecated, types-PyYAML, types-requests, types-tabulate, types-jsonschema, django-stubs, django-stubs-ext]
+        additional_dependencies: [types-pytz, types-Deprecated, types-PyYAML, types-requests, types-tabulate, types-jsonschema, django-stubs, django-stubs-ext, djangorestframework-stubs]
         pass_filenames: false
         entry: bash -c 'mypy -p docker-app -p docker-qgis "$@"' --

--- a/docker-app/qfieldcloud/core/drf_utils.py
+++ b/docker-app/qfieldcloud/core/drf_utils.py
@@ -1,6 +1,7 @@
 from django.db.models import QuerySet
-from django.http import HttpRequest
-from rest_framework import filters, viewsets
+from rest_framework import filters, views
+from rest_framework.request import Request
+from typing import Iterable
 
 
 class QfcOrderingFilter(filters.OrderingFilter):
@@ -15,7 +16,7 @@ class QfcOrderingFilter(filters.OrderingFilter):
     TOKENS_LIST_SEPARATOR = ","
     TOKENS_VALUE_SEPARATOR = "="
 
-    def _get_query_field(self, fields: list[str], term: str) -> str | None:
+    def _get_query_field(self, fields: Iterable[str], term: str) -> str | None:
         """Searches a term in a query field list.
 
         The field list elements may start with "-".
@@ -74,9 +75,9 @@ class QfcOrderingFilter(filters.OrderingFilter):
     def remove_invalid_fields(
         self,
         queryset: QuerySet,
-        fields: list[str],
-        view: viewsets.ModelViewSet,
-        request: HttpRequest,
+        fields: Iterable[str],
+        view: views.APIView,
+        request: Request,
     ) -> list[str]:
         """Process ordering fields by parsing custom field expression.
 
@@ -86,8 +87,8 @@ class QfcOrderingFilter(filters.OrderingFilter):
 
         Args:
             queryset (QuerySet): Django's ORM queryset of the same model as the one used in view of the `ModelViewSet`
-            fields (list[str]): ordering fields passed to the HTTP querystring
-            view (ModelViewSet): DRF view instance
+            fields (Iterable[str]): ordering fields passed to the HTTP querystring
+            view (APIView): DRF view instance
             request (HttpRequest): DRF request instance
         Returns :
             list[str]: parsed ordering fields where aliases have been replaced

--- a/docker-app/qfieldcloud/core/exceptions.py
+++ b/docker-app/qfieldcloud/core/exceptions.py
@@ -21,7 +21,7 @@ class QFieldCloudException(Exception):
 
     code = "unknown_error"
     message = "QFieldcloud Unknown Error"
-    status_code = None
+    status_code: int | None = None
     log_as_error = True
 
     def __init__(self, detail="", status_code=None):

--- a/docker-app/qfieldcloud/core/pagination.py
+++ b/docker-app/qfieldcloud/core/pagination.py
@@ -32,14 +32,15 @@ class QfcLimitOffsetPagination(pagination.LimitOffsetPagination):
         Set new header fields to carry pagination controls.
         """
         headers = {
-            "X-Total-Count": self.count,
+            "X-Total-Count": str(self.count),
         }
 
-        next_link = self.get_next_link()
+        next_link: str | None = self.get_next_link()
+
         if next_link:
             headers["X-Next-Page"] = next_link
 
-        previous_link = self.get_previous_link()
+        previous_link: str | None = self.get_previous_link()
         if previous_link:
             headers["X-Previous-Page"] = previous_link
 
@@ -49,7 +50,11 @@ class QfcLimitOffsetPagination(pagination.LimitOffsetPagination):
         """
         Paginate results injecting pagination controls and counter into response headers.
         """
-        if self.request.GET.get("offset") and not self.request.GET.get("limit"):
+        if (
+            self.request is not None
+            and self.request.GET.get("offset")
+            and not self.request.GET.get("limit")
+        ):
             # slice serialized data to enforce the application wide limit
             data = islice(data, settings.QFIELDCLOUD_API_DEFAULT_PAGE_LIMIT)
 

--- a/docker-app/qfieldcloud/core/views/teams_views.py
+++ b/docker-app/qfieldcloud/core/views/teams_views.py
@@ -14,15 +14,15 @@ from qfieldcloud.core.serializers import (
     TeamSerializer,
 )
 
-from rest_framework import generics, permissions
+from rest_framework import generics, permissions, exceptions
 from rest_framework.request import Request
-from rest_framework.views import View
+from rest_framework.views import APIView
 
 from django.shortcuts import get_object_or_404
 
 
 class TeamMemberDeleteViewPermissions(permissions.BasePermission):
-    def has_permission(self, request: Request, view: View) -> bool:
+    def has_permission(self, request: Request, view: APIView) -> bool:
         user = request.user
         organization_name = permissions_utils.get_param_from_request(
             request, "organization"
@@ -44,7 +44,7 @@ class TeamMemberPermission(permissions.BasePermission):
     Permission class to handle CRUD operations for team members.
     """
 
-    def has_permission(self, request: Request, view: View) -> bool:
+    def has_permission(self, request: Request, view: APIView) -> bool:
         organization_name = view.kwargs.get("organization_name")
         team_name = view.kwargs.get("team_name")
         team_username = Team.format_team_name(organization_name, team_name)
@@ -78,7 +78,7 @@ class TeamPermission(permissions.BasePermission):
     Permission class to handle CRUD operations for teams.
     """
 
-    def has_permission(self, request: Request, view: View) -> bool:
+    def has_permission(self, request: Request, view: APIView) -> bool:
         organization_name = view.kwargs.get("organization_name")
 
         try:
@@ -138,7 +138,7 @@ class GetUpdateDestroyTeamDetailView(generics.RetrieveUpdateDestroyAPIView):
             team_organization=serializer.instance.team_organization,
             username=full_team_name,
         ).exists():
-            raise permissions.ValidationError(
+            raise exceptions.ValidationError(
                 {"error": "A team with this name already exists."}
             )
 


### PR DESCRIPTION
This PR introduces the following updates to enhance type checking in our project:

- [x] Integrate mypy by adding `mypy_drf_plugin` to **mypy.ini** for better Django REST Framework type-checking.
- [x] Integrate pre-commit by updating **.pre-commit-config.yaml** to ensure `mypy` runs with `pre-commit` using the new plugin and settings.
- [x] Add djangorestframework-stubs to the **requirements.in** file in order to regenerate the appropriate **requirements.txt** 
- [x] Fix various typing issues such as type mismatches in exception, and incorrect annonations

Examples of issues:

1. `from rest_framework.views import View` --> The mypy-drf-plugin is strict about ensuring attributes or classes explicitly exported by a module. In simply words, mypy complains because it’s not officially listed in the __all__ attribute of the rest_framework.views module.