### PR TITLE
Fix GitHub warning that variables should be defined before their use

### DIFF
--- a/docker-qgis/Dockerfile
+++ b/docker-qgis/Dockerfile
@@ -60,7 +60,7 @@ ENV LIBC_FATAL_STDERR_=1
 ENV LANG=C.UTF-8
 ENV XDG_RUNTIME_DIR=/root
 # allow local development for `libqfieldsync`, requires `/libqfieldsync` to be a mounted host directory
-ENV PYTHONPATH=/libqfieldsync:${PYTHONPATH}
+ENV PYTHONPATH=/libqfieldsync
 ENV PYTHONPATH=/qfieldcloud-sdk-python:${PYTHONPATH}
 
 # Install regular dependencies that rarely change


### PR DESCRIPTION
I was using `$PYTHONPATH` in a context where I cannot expect it to exist.

![image](https://github.com/user-attachments/assets/d19fde4e-a05a-4129-b786-dac2b999dd43)
