### PR TITLE
Fix an error from `drf-spectacular` that returns 500 on GET /swagger.yml

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1337,7 +1337,7 @@ class Project(models.Model):
         return problems
 
     @property
-    def status(self) -> Status:
+    def status(self) -> "Project.Status":
         # NOTE the status is NOT stored in the db, because it might be outdated
         if (
             self.jobs.filter(status__in=[Job.Status.QUEUED, Job.Status.STARTED])  # type: ignore


### PR DESCRIPTION
The error was due to reference within a class for a class member without namespacing with the  class itself, or reference with `Status` instead of `Project.Status`.