### PR TITLE
Simplify the teams endpoints removing unnecessary GET endpoints

### DIFF
--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -553,16 +553,25 @@ class LatestPackageSerializer(serializers.Serializer):
 class TeamSerializer(serializers.ModelSerializer):
     organization = serializers.StringRelatedField(source="team_organization")
     team = serializers.CharField(required=True, allow_blank=False, source="username")
+    members = serializers.SerializerMethodField()
 
     class Meta:
         model = Team
-        fields = ("team", "organization")
+        fields = ("team", "organization", "members")
 
     def to_representation(self, instance: Team) -> dict[str, Any]:
         representation = super().to_representation(instance)
         representation["team"] = instance.teamname
 
         return representation
+
+    def get_members(self, obj: Team) -> list[str]:
+        return [
+            m["member__username"]
+            for m in TeamMember.objects.filter(
+                team=obj,
+            ).values("member__username")
+        ]
 
 
 class TeamMemberSerializer(serializers.ModelSerializer):

--- a/docker-app/qfieldcloud/core/tests/test_team.py
+++ b/docker-app/qfieldcloud/core/tests/test_team.py
@@ -306,10 +306,12 @@ class QfcTestCase(APITestCase):
                 {
                     "team": self.t1.teamname,
                     "organization": self.o1.username,
+                    "members": [],
                 },
                 {
                     "team": self.t2.teamname,
                     "organization": self.o1.username,
+                    "members": [],
                 },
             ],
         )
@@ -329,6 +331,7 @@ class QfcTestCase(APITestCase):
             {
                 "team": self.t1.teamname,
                 "organization": self.o1.username,
+                "members": [],
             },
         )
 

--- a/docker-app/qfieldcloud/core/urls.py
+++ b/docker-app/qfieldcloud/core/urls.py
@@ -113,7 +113,7 @@ urlpatterns = [
     ),
     path(
         "organizations/<str:organization_name>/teams/<str:team_name>/members/<str:member_username>/",
-        teams_views.GetUpdateDestroyTeamMemberView.as_view(),
-        name="team_member_retrieve_update_destroy",
+        teams_views.DestroyTeamMemberView.as_view(),
+        name="team_member_destroy",
     ),
 ]

--- a/docker-app/qfieldcloud/core/views/teams_views.py
+++ b/docker-app/qfieldcloud/core/views/teams_views.py
@@ -178,7 +178,7 @@ class TeamListCreateView(generics.ListCreateAPIView):
     get=extend_schema(description="Retrieve, update, or delete a team member"),
     delete=extend_schema(description="Delete a team member"),
 )
-class GetUpdateDestroyTeamMemberView(generics.RetrieveDestroyAPIView):
+class DestroyTeamMemberView(generics.DestroyAPIView):
     """
     View to handle adding and listing team members. --> organizations/<str:organization_name>/team/<str:team_name>/members/"
     """
@@ -216,19 +216,6 @@ class GetUpdateDestroyTeamMemberView(generics.RetrieveDestroyAPIView):
         team_name = self.kwargs.get("team_name")
 
         return Team.format_team_name(organization_name, team_name)
-
-    def perform_update(self, serializer: TeamMemberSerializer) -> None:
-        """
-        Update logic for the team member.
-        """
-        team_member = self.get_object()
-        new_username = self.request.data.get("member")
-
-        user_member = team_member.member
-        user_member.username = new_username
-        user_member.save()
-
-        serializer.save()
 
 
 @extend_schema_view(


### PR DESCRIPTION
Basically we can kill theGET /organizations/<organizaztion>/teams/<team>/member   and GET /organizations/<organizaztion>/teams/<team>/member/<member>    . We add the new key members  to the TeamSerializer .


Follow up of #1031 