### PR TITLE
Fix getting the list of available teams per organization

### DIFF
--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -187,10 +187,13 @@ class OrganizationSerializer(serializers.ModelSerializer):
 
     def get_teams(self, obj: Organization) -> list[str]:
         """Implementation of `SerializerMethodField` for `teams`. Returns list of team names."""
-        return [
-            t.teamname
-            for t in Team.objects.filter(team_organization=obj).values("username")
-        ]
+        team_qs = (
+            Team.objects.filter(team_organization=obj)
+            .select_related("team_organization")
+            .only("username", "team_organization__username")
+        )
+
+        return [t.teamname for t in team_qs]
 
     def get_avatar_url(self, obj):
         return get_avatar_url(obj)


### PR DESCRIPTION
The problem comes from the fact that `teamname` is a runtime property of the `Team` class and not an actual database  field. In addition we were using `Team.object.values()` which returns an `Iterable[dict]`, instead of `Iterable[Team]`. So even if it returned the right type, it would have been terribly slow, due to N+1 situation.

This problem made the `/user/<username>/organization` return an error, therefore prevented QFieldSync from selecting the available organizations for the team.