### PR TITLE
Fix missing timezones

### DIFF
--- a/docker-app/Dockerfile
+++ b/docker-app/Dockerfile
@@ -49,7 +49,9 @@ RUN apt-get update && apt-get install -y \
 # needed for Django's `manage.py makemessages`
     gettext \
 # for development purposes only (optional dependency for `django-extensions`)
-    graphviz
+    graphviz \
+# timezone data used by python to determine the user's timezone
+    tzdata
 
 # copy the dependencies
 COPY --from=build /usr/local/lib/python3.10/site-packages/ /usr/local/lib/python3.10/site-packages/

--- a/docker-app/qfieldcloud/core/middleware/timezone.py
+++ b/docker-app/qfieldcloud/core/middleware/timezone.py
@@ -1,4 +1,4 @@
-import pytz
+import zoneinfo
 from django.conf import settings
 from django.utils import timezone
 
@@ -13,7 +13,7 @@ class TimezoneMiddleware:
         ):
             user_tz = request.user.useraccount.timezone
         elif settings.TIME_ZONE:
-            user_tz = pytz.timezone(settings.TIME_ZONE)
+            user_tz = zoneinfo.ZoneInfo(settings.TIME_ZONE)
         else:
             user_tz = None
 


### PR DESCRIPTION
Basically we need to install all of them with `zoneinfo` package on
Ubuntu. It is also present as pip package, but I believe the Debian guys
are better at handling this.