### PR TITLE
Bump `django-axes` to v7.0.1 and `django-allauth` to 65.3.1 

### DIFF
--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -372,10 +372,10 @@ ACCOUNT_LOGOUT_ON_GET = True
 ###########################
 # The integer number of login attempts allowed before a record is created for the failed logins. Default: 3
 AXES_FAILURE_LIMIT = 5
-# If True, only lock based on username, and never lock based on IP if attempts exceed the limit. Otherwise utilize the existing IP and user locking logic. Default: False
-AXES_ONLY_USER_FAILURES = True
+# Configures the limiter to handle username only (see https://github.com/jazzband/django-axes/blob/4e89d72b92db044ff3f6b23ea2ab2e681211c98e/docs/2_installation.rst#version-6-breaking-changes-and-upgrading-from-django-axes-version-5)
+AXES_LOCKOUT_PARAMETERS = ["username"]
 # If set, defines a period of inactivity after which old failed login attempts will be cleared. If an integer, will be interpreted as a number of hours. Default: None
-AXES_COOLOFF_TIME = timedelta(minutes=30)
+AXES_COOLOFF_TIME = lambda request: timedelta(minutes=30)  # noqa: E731
 # If True, a successful login will reset the number of failed logins. Default: False
 AXES_RESET_ON_SUCCESS = True
 

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -375,7 +375,7 @@ AXES_FAILURE_LIMIT = 5
 # Configures the limiter to handle username only (see https://django-axes.readthedocs.io/en/latest/2_installation.html#version-7-breaking-changes-and-upgrading-from-django-axes-version-6)
 AXES_LOCKOUT_PARAMETERS = ["username"]
 # If set, defines a period of inactivity after which old failed login attempts will be cleared. If an integer, will be interpreted as a number of hours. Default: None
-AXES_COOLOFF_TIME = lambda request: timedelta(minutes=30)  # noqa: E731
+AXES_COOLOFF_TIME = lambda _request: timedelta(minutes=30)  # noqa: E731
 # If True, a successful login will reset the number of failed logins. Default: False
 AXES_RESET_ON_SUCCESS = True
 

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -372,7 +372,7 @@ ACCOUNT_LOGOUT_ON_GET = True
 ###########################
 # The integer number of login attempts allowed before a record is created for the failed logins. Default: 3
 AXES_FAILURE_LIMIT = 5
-# Configures the limiter to handle username only (see https://github.com/jazzband/django-axes/blob/4e89d72b92db044ff3f6b23ea2ab2e681211c98e/docs/2_installation.rst#version-6-breaking-changes-and-upgrading-from-django-axes-version-5)
+# Configures the limiter to handle username only (see https://django-axes.readthedocs.io/en/latest/2_installation.html#version-7-breaking-changes-and-upgrading-from-django-axes-version-6)
 AXES_LOCKOUT_PARAMETERS = ["username"]
 # If set, defines a period of inactivity after which old failed login attempts will be cleared. If an integer, will be interpreted as a number of hours. Default: None
 AXES_COOLOFF_TIME = lambda request: timedelta(minutes=30)  # noqa: E731

--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -3,7 +3,7 @@ boto3==1.35.90
 deprecated==1.2.15
 django-allauth==0.44.0
 django-auditlog==3.0.0
-django-axes==5.40.1
+django-axes==7.0.1
 django-bootstrap4==24.4
 django-classy-tags==4.1.0
 django-common-helpers==0.9.2

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -77,7 +77,7 @@ django-appconf==1.0.6
     # via django-cryptography
 django-auditlog==3.0.0
     # via -r /requirements/requirements.in
-django-axes==5.40.1
+django-axes==7.0.1
     # via -r /requirements/requirements.in
 django-bootstrap4==24.4
     # via -r /requirements/requirements.in

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -7,6 +7,7 @@
 asgiref==3.8.1
     # via
     #   django
+    #   django-axes
     #   django-countries
 attrs==24.2.0
     # via
@@ -103,8 +104,6 @@ django-filter==24.3
     # via -r /requirements/requirements.in
 django-invitations==2.1.0
     # via -r /requirements/requirements.in
-django-ipware==7.0.1
-    # via django-axes
 django-jazzmin==3.0.1
     # via -r /requirements/requirements.in
 django-log-request-id==2.1.0
@@ -171,8 +170,6 @@ python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   django-auditlog
-python-ipware==3.0.0
-    # via django-ipware
 python3-openid==3.2.0
     # via django-allauth
 pytz==2024.1
@@ -229,6 +226,3 @@ urllib3==1.26.20
     #   sentry-sdk
 wrapt==1.16.0
     # via deprecated
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools


### PR DESCRIPTION
This PR bumps the dependency to its newest version.

`axes`'s changelog: https://github.com/jazzband/django-axes/blob/master/CHANGES.rst#701-2024-12-02

Notable breaking changes: https://django-axes.readthedocs.io/en/latest/2_installation.html#version-7-breaking-changes-and-upgrading-from-django-axes-version-6

To be tested :

- try 6 unsuccessful logins with a correct username and a fake password -> custom QFC lockout page should appear, displaying username :

![image](https://github.com/user-attachments/assets/5f4a8a75-078a-4a17-9d54-76e9acc66d87)

- try 6 unsuccessful logins with previous user's email address and a fake password -> custom QFC lockout page should appear, displaying email address:

![image](https://github.com/user-attachments/assets/d9a8a687-00df-4ecf-86fc-1fbcc60b1d71)

- delete the access attempts in the admin page (or wait for 30min), then:
  - try again a login with username and correct password -> should be logged in
  - log out and try again a login with email address and correct password -> should be logged in