### PR TITLE
Remove useless django 4.2.16 dependency

### DIFF
--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -1,7 +1,6 @@
 boto3-stubs==1.35.90
 boto3==1.35.90
 deprecated==1.2.15
-django==4.2.16
 django-allauth==65.3.1
 django-auditlog==3.0.0
 django-axes==7.0.1


### PR DESCRIPTION
Removes `django` v4.2.16 dependency that was introduced by accident [in this commit](https://github.com/opengisch/QFieldCloud/commit/93e1935cf73e8ab39bf9510092cfb63d66cce8db).

Was introducing some `pipcompile` errors since targeted `django` version is 4.2.17, at the end of the file.