### PR TITLE
Store and display jobs' qgis app version

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -943,6 +943,7 @@ class JobAdmin(QFieldCloudModelAdmin):
         "status",
         "error_type",
         "type",
+        "qgis_version",
         "created_at",
         "updated_at",
         "started_at",

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1764,6 +1764,30 @@ class Job(models.Model):
                 "The job ended in unknown state. Please verify the project is configured properly, try again and contact QFieldCloud support for more information."
             )
 
+    @property
+    def qgis_version(self) -> str | None:
+        """Returns QGIS app version used for the job.
+
+        The QGIS version is the one coming from the instanciated worker QGIS app.
+        The version number would be in `Major.Minor.Patch-NAME` format, e.g. 3.40.2-Bratislava
+
+        Returns:
+            str | None: QGIS version if found else None.
+        """
+        if not self.feedback:
+            return None
+
+        feedback_step_data = self.get_feedback_step_data("start_qgis_app")
+
+        if not feedback_step_data:
+            return None
+
+        if "qgis_version" in feedback_step_data["returns"]:
+            qgis_version = feedback_step_data["returns"]["qgis_version"]
+            return qgis_version
+
+        return None
+
     def check_can_be_created(self):
         from qfieldcloud.core.permissions_utils import (
             check_supported_regarding_owner_account,

--- a/docker-qgis/entrypoint.py
+++ b/docker-qgis/entrypoint.py
@@ -172,6 +172,7 @@ def cmd_package_project(args: argparse.Namespace):
                 id="start_qgis_app",
                 name="Start QGIS Application",
                 method=qfc_worker.utils.start_app,
+                return_names=["qgis_version"],
             ),
             Step(
                 id="download_project_directory",
@@ -250,6 +251,7 @@ def cmd_apply_deltas(args: argparse.Namespace):
                 id="start_qgis_app",
                 name="Start QGIS Application",
                 method=qfc_worker.utils.start_app,
+                return_names=["qgis_version"],
             ),
             Step(
                 id="download_project_directory",
@@ -308,6 +310,7 @@ def cmd_process_projectfile(args: argparse.Namespace):
                 id="start_qgis_app",
                 name="Start QGIS Application",
                 method=qfc_worker.utils.start_app,
+                return_names=["qgis_version"],
             ),
             Step(
                 id="download_project_directory",

--- a/docker-qgis/qfc_worker/utils.py
+++ b/docker-qgis/qfc_worker/utils.py
@@ -146,7 +146,7 @@ def _write_log_message(message, tag, level):
 QGISAPP: QgsApplication = None
 
 
-def start_app():
+def start_app() -> str:
     """
     Will start a QgsApplication and call all initialization code like
     registering the providers and other infrastructure. It will not load
@@ -158,9 +158,7 @@ def start_app():
 
         Returns
         -------
-        QgsApplication
-
-        A QgsApplication singleton
+        str: QGIS app version that was started.
     """
     global QGISAPP
 
@@ -192,7 +190,7 @@ def start_app():
     # we set the `bad_layer_handler` and assume we always have only one single `QgsProject` instance within the job's life
     QgsProject.instance().setBadLayerHandler(bad_layer_handler)
 
-    return QGISAPP
+    return Qgis.version()
 
 
 def stop_app():


### PR DESCRIPTION
This PR makes QFieldCloud store and display the QGIS app version used by Jobs

- [x] store the QGIS app version in a job's feedback
- [x] display the Job's QGIS version in admin

![image](https://github.com/user-attachments/assets/1870699d-5049-41af-956b-1627821b4150)

**Note** : since the QGIS app version is stored in job's feedback, it will not be possible to get and display "old" jobs this way. Extracting it from Job's `Output pre` with a bit of regexp could be considered, if old job's QGIS version must be fetched anyway :

![image](https://github.com/user-attachments/assets/fdbd984e-9704-405d-9adf-56095b5fa30e)

