### PR TITLE
[breaking] Bump `django-constance` from 2.9.1 to 4.3.1

### DIFF
--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -115,7 +115,6 @@ INSTALLED_APPS = [
     "axes",
     "migrate_sql",
     "constance",
-    "constance.backends.database",
     "django_extensions",
 ]
 

--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -7,7 +7,7 @@ django-axes==7.0.1
 django-bootstrap4==24.4
 django-classy-tags==4.1.0
 django-common-helpers==0.9.2
-django-constance[database]==2.9.1
+django-constance[database]==4.3.1
 django-countries==7.6.1
 django-cron==0.6.0
 django-cryptography==1.1

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -61,7 +61,6 @@ django==4.2.17
     #   django-nonrelated-inlines
     #   django-notifications-hq
     #   django-phonenumber-field
-    #   django-picklefield
     #   django-sri
     #   django-storages
     #   django-tables2
@@ -83,7 +82,7 @@ django-classy-tags==4.1.0
     # via -r /requirements/requirements.in
 django-common-helpers==0.9.2
     # via -r /requirements/requirements.in
-django-constance[database]==2.9.1
+django-constance[database]==4.3.1
     # via -r /requirements/requirements.in
 django-countries==7.6.1
     # via -r /requirements/requirements.in
@@ -117,8 +116,6 @@ django-notifications-hq==1.8.3
     # via -r /requirements/requirements.in
 django-phonenumber-field==8.0.0
     # via -r /requirements/requirements.in
-django-picklefield==3.2
-    # via django-constance
 django-sri==0.7.0
     # via -r /requirements/requirements.in
 django-storages==1.14.4


### PR DESCRIPTION
Diff: https://github.com/jazzband/django-constance/compare/2.9.1...4.3.1

Old versions changelog: https://django-constance.readthedocs.io/en/latest/changes.html

New versions changelog: https://github.com/jazzband/django-constance/releases

4 django migrations have to be applied FYI

Note: the migrations introduced by dependency bumping are not reversible ([the 0003 one](https://github.com/jazzband/django-constance/compare/2.9.1...4.3.1#diff-a3c5f342d52fbe646e30d291705158eb3e3e8c8a3bf0c3019c58be94934f7787), using the new `constance` app instead of `database` before). Please take this information into consideration.

```
django.db.migrations.exceptions.IrreversibleError: Operation <RunPython <function migrate_pickled_data at 0x7f744f80d2d0>> in constance.0003_drop_pickle is not reversible
```