### PR TITLE
Add `.env` file CI step before generating Django strings for Transifex

### DIFF
--- a/.github/workflows/sync_translations.yml
+++ b/.github/workflows/sync_translations.yml
@@ -27,6 +27,15 @@ jobs:
             curl -OL https://github.com/transifex/cli/releases/download/v1.6.17/tx-linux-amd64.tar.gz
             tar -xvzf tx-linux-amd64.tar.gz
 
+      - name: Copy .env file
+        run: |
+          cp .env.example .env
+
+      - name: Perform docker pre operations
+        run: |
+            docker compose pull
+            docker compose build
+
       - name: Generate Django translation po files
         run: |
             docker compose run --user root app python manage.py makemessages -l es
@@ -35,7 +44,7 @@ jobs:
         run: ./tx push --source
 
       - name: Pull from Transifex
-        run: ./tx pull --all ---minimum-perc 0 --force
+        run: ./tx pull --all --minimum-perc 0 --force
 
       - name: Add and commit new translations
         uses: EndBug/add-and-commit@v9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,3 +50,5 @@ repos:
         additional_dependencies: [types-pytz, types-Deprecated, types-PyYAML, types-requests, types-tabulate, types-jsonschema, django-stubs, django-stubs-ext, djangorestframework-stubs]
         pass_filenames: false
         entry: bash -c 'mypy -p docker-app -p docker-qgis "$@"' --
+
+exclude: 'docker-app/qfieldcloud/locale/.*'


### PR DESCRIPTION
This PR is intended to fix the Transifex synchronization CI GitHub workflow for QFieldCloud Django strings.

Check this successful manually triggered Transifex sync Action : https://github.com/opengisch/QFieldCloud/actions/runs/13183139676.