### PR TITLE
Fix manual write to audit, usually about file changes, that is a string

### DIFF
--- a/docker-app/qfieldcloud/core/utils2/audit.py
+++ b/docker-app/qfieldcloud/core/utils2/audit.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 
 from auditlog.models import LogEntry
@@ -10,18 +9,10 @@ def audit(
     instance,
     action: LogEntry.Action,
     changes: dict[str, Any] | list[Any] | str | None = None,
-    actor: User = None,
-    remote_addr: str = None,
-    additional_data: Any = None,
+    actor: User | None = None,
+    remote_addr: str | None = None,
+    additional_data: Any | None = None,
 ):
-    changes_json = None
-
-    try:
-        if changes is not None:
-            changes_json = json.dumps(changes)
-    except Exception:
-        changes_json = json.dumps(str(changes))
-
     if actor is None:
         actor = get_current_authenticated_user()
     elif isinstance(actor, AnonymousUser):
@@ -32,7 +23,7 @@ def audit(
     return LogEntry.objects.log_create(
         instance,
         action=action,
-        changes=changes_json,
+        changes=changes,
         actor_id=actor_id,
         remote_addr=remote_addr,
         additional_data=additional_data,


### PR DESCRIPTION
In older version of audit, the value must be a string. This is no longer the case and we have to push the value native type, usually a dict.

A manual patch of the database is needed, please run something like this:
```
update auditlog_logentry set changes = replace(replace(rtrim(ltrim(changes::text,'"'),'"'), '\"', '"'), '\\"', '')::jsonb where jsonb_typeof(changes) = 'string';
```

See https://app.clickup.com/t/2192114/QF-5019