### PR TITLE
Reorder Organization admin tabs: members and teams should be neighbors

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -815,7 +815,10 @@ class ProjectAdmin(QFieldCloudModelAdmin):
         "data_last_packaged_at",
         "project_details__pre",
     )
-    inlines = (ProjectCollaboratorInline, ProjectSecretInline)
+    inlines = (
+        ProjectSecretInline,
+        ProjectCollaboratorInline,
+    )
     search_fields = (
         "id",
         "name__icontains",

--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -1316,8 +1316,8 @@ class OrganizationAdmin(QFieldCloudModelAdmin):
     inlines = (
         UserAccountInline,
         GeodbInline,
-        OrganizationMemberInline,
         ProjectInline,
+        OrganizationMemberInline,
         TeamInline,
     )
     fields = (


### PR DESCRIPTION
I believe the Organization members and Teams are very related and makes sense to be next to each other.

|before|after|
|-|-|
| ![image](https://github.com/user-attachments/assets/cf688766-1ffd-4afb-b95a-8aa2b2d751ea) | ![image](https://github.com/user-attachments/assets/972f5bdc-cd75-4e3b-8275-e11b4fd27302) |

|before|after|
|-|-|
| ![image](https://github.com/user-attachments/assets/1f138915-7fba-4d71-916c-9ed9aa7a4842) | ![image](https://github.com/user-attachments/assets/6f956dfb-86d5-4bcc-8673-3080ac033463) |