### PR TITLE
Bump `boto3`, `boto3-stubs` and `mypy-boto3-s3` from 1.35.90 to 1.37.0 and `minio` to `RELEASE.2025-02-18T16-25-55Z`

### DIFF
--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -1,5 +1,5 @@
-boto3-stubs==1.35.90
-boto3==1.35.90
+boto3-stubs==1.37.0
+boto3==1.37.0
 deprecated==1.2.18
 django-allauth==65.4.1
 django-auditlog==3.0.0
@@ -31,7 +31,7 @@ django==4.2.19
 djangorestframework==3.15.2
 drf-spectacular==0.28.0
 json-log-formatter==1.1
-mypy-boto3-s3==1.35.81
+mypy-boto3-s3==1.37.0
 phonenumbers==8.13.55
 psycopg2==2.9.10
 pymemcache==4.0.0

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -16,11 +16,11 @@ attrs==24.2.0
     #   referencing
 beautifulsoup4==4.12.3
     # via django-bootstrap4
-boto3==1.35.90
+boto3==1.37.0
     # via -r /requirements/requirements.in
-boto3-stubs==1.35.90
+boto3-stubs==1.37.0
     # via -r /requirements/requirements.in
-botocore==1.35.90
+botocore==1.37.0
     # via
     #   boto3
     #   s3transfer
@@ -146,7 +146,7 @@ jsonschema==4.23.0
     # via drf-spectacular
 jsonschema-specifications==2023.12.1
     # via jsonschema
-mypy-boto3-s3==1.35.81
+mypy-boto3-s3==1.37.0
     # via -r /requirements/requirements.in
 phonenumbers==8.13.55
     # via -r /requirements/requirements.in
@@ -174,7 +174,7 @@ rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.10.2
+s3transfer==0.11.2
     # via boto3
 sentry-sdk==1.24.0
     # via -r /requirements/requirements.in

--- a/docker-compose.override.standalone.yml
+++ b/docker-compose.override.standalone.yml
@@ -42,7 +42,7 @@ services:
       - ServerOptions__HostName=smtp4dev
 
   minio:
-    image: minio/minio:RELEASE.2023-04-07T05-28-58Z
+    image: minio/minio:RELEASE.2025-02-18T16-25-55Z
     restart: unless-stopped
     volumes:
       - minio_data1:/data1


### PR DESCRIPTION
Changelog:

https://github.com/boto/boto3/blob/develop/CHANGELOG.rst