### PR TITLE
Bump `django-sri` from `0.7.0` to `0.8.0`

### DIFF
--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -23,7 +23,7 @@ django-model-utils==5.0.0
 django-nonrelated-inlines==0.2
 django-notifications-hq==1.8.3
 django-phonenumber-field==8.0.0
-django-sri==0.7.0
+django-sri==0.8.0
 django-storages==1.14.5
 django-tables2==2.7.5
 django-timezone-field==7.1

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -116,7 +116,7 @@ django-notifications-hq==1.8.3
     # via -r /requirements/requirements.in
 django-phonenumber-field==8.0.0
     # via -r /requirements/requirements.in
-django-sri==0.7.0
+django-sri==0.8.0
     # via -r /requirements/requirements.in
 django-storages==1.14.5
     # via -r /requirements/requirements.in


### PR DESCRIPTION
Changelog: https://github.com/RealOrangeOne/django-sri/releases/tag/0.8.0
Diff: https://github.com/RealOrangeOne/django-sri/compare/0.7.0...0.8.0