### PR TITLE
Sign-up via invitation link process results in a broken `/accounts/profile` redirect

### DIFF
--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -310,6 +310,7 @@ EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 SITE_ID = 1
 
 LOGIN_URL = "account_login"
+LOGIN_REDIRECT_URL = "index"
 
 # Sentry configuration
 SENTRY_DSN = os.environ.get("SENTRY_DSN", "")


### PR DESCRIPTION
Fixes #1124
