### PR TITLE
[sentry] Fix comparison between of a constance setting and "Content-Length" header

### DIFF
--- a/docker-app/qfieldcloud/core/middleware/requests.py
+++ b/docker-app/qfieldcloud/core/middleware/requests.py
@@ -17,15 +17,20 @@ def attach_keys(get_response):
     """
 
     def middleware(request):
+        try:
+            sentry_max_size = int(config.SENTRY_REQUEST_MAX_SIZE_TO_SEND)
+        except (ValueError, TypeError):
+            logger.error(
+                "Invalid SENTRY_REQUEST_MAX_SIZE_TO_SEND value. Defaulting to 0."
+            )
+            sentry_max_size = 0
+
         # add a copy of the request body to the request
         if (
             settings.SENTRY_DSN
             and request.method == "POST"
             and "Content-Length" in request.headers
-            and (
-                int(request.headers["Content-Length"])
-                < config.SENTRY_REQUEST_MAX_SIZE_TO_SEND
-            )
+            and (int(request.headers["Content-Length"]) < sentry_max_size)
         ):
             logger.info("Making a temporary copy for request body.")
 

--- a/docker-app/qfieldcloud/core/middleware/requests.py
+++ b/docker-app/qfieldcloud/core/middleware/requests.py
@@ -17,20 +17,15 @@ def attach_keys(get_response):
     """
 
     def middleware(request):
-        try:
-            sentry_max_size = int(config.SENTRY_REQUEST_MAX_SIZE_TO_SEND)
-        except (ValueError, TypeError):
-            logger.error(
-                "Invalid SENTRY_REQUEST_MAX_SIZE_TO_SEND value. Defaulting to 0."
-            )
-            sentry_max_size = 0
-
         # add a copy of the request body to the request
         if (
             settings.SENTRY_DSN
             and request.method == "POST"
             and "Content-Length" in request.headers
-            and (int(request.headers["Content-Length"]) < sentry_max_size)
+            and (
+                int(request.headers["Content-Length"])
+                < int(config.SENTRY_REQUEST_MAX_SIZE_TO_SEND)
+            )
         ):
             logger.info("Making a temporary copy for request body.")
 


### PR DESCRIPTION
This PR resolves a TypeError that raised in attach_keys middleware when comparing `request.headers["Content-Length"]` (integer type) with `config.SENTRY_REQUEST_MAX_SIZE_TO_SEND` (string).

**Changes Implemented**

- Cast config.SENTRY_REQUEST_MAX_SIZE_TO_SEND to an integer before performing the comparison.
- Added error handling via defaulting max size to zero, if the value is invalid.
