### PR TITLE
Add some extra default settings to the cache configuration

### DIFF
--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -73,6 +73,12 @@ CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
         "LOCATION": "memcached:11211",
+        "OPTIONS": {
+            "no_delay": True,
+            "ignore_exc": True,
+            "max_pool_size": 10,
+            "use_pooling": True,
+        },
     }
 }
 


### PR DESCRIPTION
Hopefully should fix all the `KeyError` and `OSError` exceptions.

This is the recommended setting from Django, with some inflated value for the number of pool members.
See: https://docs.djangoproject.com/en/5.1/topics/cache/#cache-arguments