### PR TITLE
When reversing a URL, we need to pass it as `kwargs`, not just a dict

### DIFF
--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -29,7 +29,7 @@ def get_avatar_url(user: User) -> str | None:
 
     return reverse_lazy(
         "filestorage_avatars",
-        {
+        kwargs={
             "username": user.username,
         },
     )


### PR DESCRIPTION
Causing a weird error:
```
TypeError: unhashable type: 'dict'
```

Follow-up of #1065 