### PR TITLE
Do not raise when subscription overlap in the admin

### DIFF
--- a/docker-app/qfieldcloud/subscription/admin.py
+++ b/docker-app/qfieldcloud/subscription/admin.py
@@ -9,7 +9,6 @@ from django.utils.translation import gettext as _
 from qfieldcloud.core.admin import QFieldCloudModelAdmin, model_admin_url
 
 from .models import PackageType, Plan, Subscription
-from django.core.exceptions import ValidationError
 
 
 class PlanAdmin(admin.ModelAdmin):
@@ -224,14 +223,7 @@ class SubscriptionAdmin(QFieldCloudModelAdmin):
         if not change:
             obj.created_by_id = obj.created_by_id or request.user.id
 
-        try:
-            super().save_model(request, obj, form, change)
-        except ValidationError as e:
-            self.message_user(
-                request,
-                e.messages[0],
-                level="error",
-            )
+        super().save_model(request, obj, form, change)
 
 
 admin.site.register(Plan, PlanAdmin)

--- a/docker-app/qfieldcloud/subscription/admin.py
+++ b/docker-app/qfieldcloud/subscription/admin.py
@@ -223,7 +223,7 @@ class SubscriptionAdmin(QFieldCloudModelAdmin):
         if not change:
             obj.created_by_id = obj.created_by_id or request.user.id
 
-        super().save_model(request, obj, form, change)
+        return super().save_model(request, obj, form, change)
 
 
 admin.site.register(Plan, PlanAdmin)

--- a/docker-app/qfieldcloud/subscription/admin.py
+++ b/docker-app/qfieldcloud/subscription/admin.py
@@ -9,7 +9,6 @@ from django.utils.translation import gettext as _
 from qfieldcloud.core.admin import QFieldCloudModelAdmin, model_admin_url
 
 from .models import PackageType, Plan, Subscription
-from django.db.models import Q
 from django.core.exceptions import ValidationError
 
 
@@ -222,27 +221,17 @@ class SubscriptionAdmin(QFieldCloudModelAdmin):
         return instance.account.user.email
 
     def save_model(self, request, obj, form, change):
-        conflicting_subscriptions = (
-            Subscription.objects.filter(
-                account=obj.account,
-                status__in=["active_paid", "active_past_due", "trialing"],
-            )
-            .filter(
-                Q(active_since__lte=obj.active_since)
-                & (Q(active_until__isnull=True) | Q(active_until__gte=obj.active_since))
-            )
-            .exclude(id=obj.id)
-        )
-
-        if conflicting_subscriptions.exists():
-            raise ValidationError(
-                "This account already has an active subscription. Please cancel it before adding a new one."
-            )
-
         if not change:
             obj.created_by_id = obj.created_by_id or request.user.id
 
-        return super().save_model(request, obj, form, change)
+        try:
+            super().save_model(request, obj, form, change)
+        except ValidationError as e:
+            self.message_user(
+                request,
+                e.messages[0],
+                level="error",
+            )
 
 
 admin.site.register(Plan, PlanAdmin)

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -898,7 +898,7 @@ class AbstractSubscription(models.Model):
         if not self.active_since:
             return
 
-        conflicts = (
+        conflicting_subscriptions_qs = (
             self.__class__.objects.filter(
                 account=self.account,
             )
@@ -909,10 +909,12 @@ class AbstractSubscription(models.Model):
             )
         )
 
-        if conflicts.exists():
+        if conflicting_subscriptions_qs.exists():
             raise ValidationError(
                 {
-                    "active_since": "This account already has an active subscription that overlaps with this period. Please cancel the existing subscription or choose a different date range."
+                    "active_since": _(
+                        "This account already has an active subscription that overlaps with this period. Please cancel the existing subscription or choose a different time range."
+                    )
                 }
             )
 

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -894,7 +894,7 @@ class AbstractSubscription(models.Model):
         Validates that the subscription's active period does not overlap with
         any other active subscriptions for the same account.
         """
-        # If there is no active_since, nothing to check.
+        # If there is no `active_since`, nothing to check.
         if not self.active_since:
             return
 

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -911,8 +911,9 @@ class AbstractSubscription(models.Model):
 
         if conflicts.exists():
             raise ValidationError(
-                "This account already has an active subscription that overlaps with "
-                "this period. Please cancel the existing subscription or choose a different date range."
+                {
+                    "active_since": "This account already has an active subscription that overlaps with this period. Please cancel the existing subscription or choose a different date range."
+                }
             )
 
     def save(self, *args, **kwargs):

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -889,11 +889,15 @@ class AbstractSubscription(models.Model):
 
         return trial_subscription_obj, regular_subscription_obj
 
-    def check_overlaps(self):
+    def clean(self):
         """
         Validates that the subscription's active period does not overlap with
         any other active subscriptions for the same account.
         """
+        # If there is no active_since, nothing to check.
+        if not self.active_since:
+            return
+
         conflicts = (
             self.__class__.objects.filter(
                 account=self.account,
@@ -912,7 +916,7 @@ class AbstractSubscription(models.Model):
             )
 
     def save(self, *args, **kwargs):
-        self.check_overlaps()
+        self.clean()
         super().save(*args, **kwargs)
 
     def __str__(self):

--- a/docker-app/qfieldcloud/subscription/tests/test_subscription.py
+++ b/docker-app/qfieldcloud/subscription/tests/test_subscription.py
@@ -37,7 +37,7 @@ class QfcTestCase(APITransactionTestCase):
         u1 = Person.objects.create(username="u1")
         subscription = u1.useraccount.current_subscription
 
-        with self.assertRaises(django.db.utils.IntegrityError):
+        with self.assertRaises(django.core.exceptions.ValidationError):
             Subscription.objects.create(
                 plan=Plan.get_or_create_default(),
                 account=u1.useraccount,
@@ -785,20 +785,3 @@ class QfcTestCase(APITransactionTestCase):
         count = Project.objects.for_user(u1).count()
 
         self.assertEqual(count, 1)
-
-    def test_validation_error_for_overlapping_subscriptions(self):
-        u1 = Person.objects.create(username="u1")
-
-        existing_subscription = u1.useraccount.current_subscription
-
-        # Attempt to create an overlapping subscription, expecting ValidationError
-        overlapping_subscription = Subscription(
-            plan=Plan.get_or_create_default(),
-            account=u1.useraccount,
-            created_by=u1,
-            status=Subscription.Status.ACTIVE_PAID,
-            active_since=existing_subscription.active_since + timedelta(hours=1),
-        )
-
-        with self.assertRaises(django.core.exceptions.ValidationError):
-            overlapping_subscription.clean()


### PR DESCRIPTION
This PR handles the issue raised when the admin creates an overlaping subscription. 

**Before**
Previously, the system allowed admin users to create subscriptions without checking for overlaps. This resulted in conflicting active subscriptions, leading to IntegrityErrors due to PostgreSQL's exclusion constraint (subscription_subscription_prevent_overlaps).

**After**
This PR introduces strict validation to prevent overlapping subscriptions before saving them in the admin panel. It prevents overlapping subscriptions by checking:

- If the new subscription’s active_since falls between an existing subscription’s active_since and active_until.
- if active_until is NULL (meaning the subscription is still ongoing), the new subscription cannot start.
- ~~Ensures only ACTIVE_PAID, ACTIVE_PAST_DUE, TRIALING subscriptions are checked for conflicts.~~
- Raises a clear ValidationError in the admin panel instead of causing an IntegrityError and prevents object to be saved. 
 
Please see the attached screenshots demonstrating the behavior when overlapping subscriptions are attempted: 
 
 **Approach 1:**
![image](https://github.com/user-attachments/assets/edf3347b-0a3d-40c8-ab91-a5e27ee9f59b)

**Approach 2:**
![image](https://github.com/user-attachments/assets/fe787c1a-54e9-46b7-83ee-d58f1ed4f21b)
