### PR TITLE
Fix case sensitivity issue in username handling

### DIFF
--- a/docker-app/qfieldcloud/authentication/tests/test_authentication.py
+++ b/docker-app/qfieldcloud/authentication/tests/test_authentication.py
@@ -97,17 +97,7 @@ class QfcTestCase(APITransactionTestCase):
         self.assertTokenMatch(tokens[0], response.json())
         self.assertGreater(tokens[0].expires_at, now())
 
-    def test_prevent_duplicate_case_insensitive_registration(self):
-        with self.assertRaises(django.db.utils.IntegrityError):
-            Person.objects.create_user(username="USER1", password="abc123")
-
-        with self.assertRaises(django.db.utils.IntegrityError):
-            Person.objects.create_user(username="uSeR1", password="abc123")
-
-        users = Person.objects.filter(username__iexact="user1")
-        self.assertEqual(users.count(), 1)
-
-    def test_case_sensitive_user_login_with_session(self):
+    def test_login_with_session_case_insensitive(self):
         self.login_url = reverse("account_login")
 
         response = self.client.post(
@@ -192,6 +182,16 @@ class QfcTestCase(APITransactionTestCase):
         self.assertNotEqual(tokens[0], tokens[1])
         self.assertGreater(tokens[0].expires_at, now())
         self.assertGreater(tokens[1].expires_at, now())
+
+    def test_case_insensitive_username_uniqueness(self):
+        with self.assertRaises(django.db.utils.IntegrityError):
+            Person.objects.create_user(username="USER1", password="abc123")
+
+        with self.assertRaises(django.db.utils.IntegrityError):
+            Person.objects.create_user(username="uSeR1", password="abc123")
+
+        users = Person.objects.filter(username__iexact="user1")
+        self.assertEqual(users.count(), 1)
 
     def test_client_type(self):
         # QFIELDSYNC login

--- a/docker-app/qfieldcloud/authentication/tests/test_authentication.py
+++ b/docker-app/qfieldcloud/authentication/tests/test_authentication.py
@@ -97,45 +97,6 @@ class QfcTestCase(APITransactionTestCase):
         self.assertTokenMatch(tokens[0], response.json())
         self.assertGreater(tokens[0].expires_at, now())
 
-    def test_login_with_session_case_insensitive(self):
-        self.login_url = reverse("account_login")
-
-        response = self.client.post(
-            self.login_url, {"login": "user1", "password": "i_am_wrong"}, follow=True
-        )
-        # As we use a TemplateResponse we cannot check status_code 302 redirect,
-        # because it renders a template instead of returning an HTTP redirect response.
-        self.assertEqual(response.status_code, 200)
-        self.assertNotIn("_auth_user_id", self.client.session)
-        # Check if the response content contains the error message displayed in the UI after an unsuccessful login
-        self.assertContains(
-            response, "The username and/or password you specified are not correct."
-        )
-
-        response = self.client.post(
-            self.login_url,
-            {
-                "login": "user1",
-                "password": "abc123",
-            },
-            follow=True,
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(self.client.session["_auth_user_id"], str(self.user1.id))
-
-        response = self.client.post(
-            self.login_url,
-            {
-                "login": "USER1",
-                "password": "abc123",
-            },
-            follow=True,
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(self.client.session["_auth_user_id"], str(self.user1.id))
-
     def test_login_with_avatar(self):
         u2 = Person.objects.create_user(username="u2", password="u2")
         u2.useraccount.avatar = ContentFile("<svg />", "avatar.svg")
@@ -182,6 +143,45 @@ class QfcTestCase(APITransactionTestCase):
         self.assertNotEqual(tokens[0], tokens[1])
         self.assertGreater(tokens[0].expires_at, now())
         self.assertGreater(tokens[1].expires_at, now())
+
+    def test_login_with_session_case_insensitive(self):
+        self.login_url = reverse("account_login")
+
+        response = self.client.post(
+            self.login_url, {"login": "user1", "password": "i_am_wrong"}, follow=True
+        )
+        # As we use a TemplateResponse we cannot check status_code 302 redirect,
+        # because it renders a template instead of returning an HTTP redirect response.
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("_auth_user_id", self.client.session)
+        # Check if the response content contains the error message displayed in the UI after an unsuccessful login
+        self.assertContains(
+            response, "The username and/or password you specified are not correct."
+        )
+
+        response = self.client.post(
+            self.login_url,
+            {
+                "login": "user1",
+                "password": "abc123",
+            },
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.client.session["_auth_user_id"], str(self.user1.id))
+
+        response = self.client.post(
+            self.login_url,
+            {
+                "login": "USER1",
+                "password": "abc123",
+            },
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.client.session["_auth_user_id"], str(self.user1.id))
 
     def test_case_insensitive_username_uniqueness(self):
         with self.assertRaises(django.db.utils.IntegrityError):

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -394,6 +394,11 @@ ACCOUNT_RATE_LIMITS = False
 # Choose one of "mandatory", "optional", or "none".
 # For local development and test use "optional" or "none"
 ACCOUNT_EMAIL_VERIFICATION = os.environ.get("ACCOUNT_EMAIL_VERIFICATION")
+
+# This setting determines whether the username is stored in lowercase (False) or whether its casing is to be preserved (True).
+# Note that when casing is preserved, potentially expensive __iexact lookups are performed when filter on username.
+# For now, the default is set to True to maintain backwards compatibility.
+# See https://docs.allauth.org/en/dev/account/configuration.html
 ACCOUNT_PRESERVE_USERNAME_CASING = True
 ACCOUNT_USERNAME_REQUIRED = True
 ACCOUNT_ADAPTER = "qfieldcloud.core.adapters.AccountAdapter"

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -394,7 +394,7 @@ ACCOUNT_RATE_LIMITS = False
 # Choose one of "mandatory", "optional", or "none".
 # For local development and test use "optional" or "none"
 ACCOUNT_EMAIL_VERIFICATION = os.environ.get("ACCOUNT_EMAIL_VERIFICATION")
-ACCOUNT_PRESERVE_USERNAME_CASING = False
+ACCOUNT_PRESERVE_USERNAME_CASING = True
 ACCOUNT_USERNAME_REQUIRED = True
 ACCOUNT_ADAPTER = "qfieldcloud.core.adapters.AccountAdapter"
 ACCOUNT_LOGOUT_ON_GET = True


### PR DESCRIPTION
This PR resolves an issue where Django Allauth was treating all usernames as lowercase during authentication, preventing users with capital letters in their usernames from logging in.

**The problem**
Usernames were correctly stored in the database with their original case (e.g., Bob), but authentication failed if users entered their names with uppercase letters.

**Solution**
Updated `ACCOUNT_PRESERVE_USERNAME_CASING` to `True` so to ensure usernames are not altered during authentication and are matched exactly as stored in the database.

**Impact**
- Users can now login using the their, exact case, username as stored in the db.
- No impact on existing stored usernames as only the authentication behavior has been adjusted.

**Test new functionality (Manual tests)**
- Tested logging in with usernames having uppercase letters 
- Ensured that new users can sign up and log in as expected.
- Verified password reset still works with case-sensitive usernames