### PR TITLE
Add mail confirmation and resend django logic

### DIFF
--- a/docker-app/qfieldcloud/core/adapters.py
+++ b/docker-app/qfieldcloud/core/adapters.py
@@ -3,6 +3,8 @@ from allauth.account.adapter import DefaultAccountAdapter
 from django.core.exceptions import ValidationError
 from invitations.adapters import BaseInvitationsAdapter
 from qfieldcloud.core.models import Person
+from allauth.account.models import EmailConfirmationHMAC
+from django.http import HttpRequest
 
 
 class AccountAdapter(DefaultAccountAdapter, BaseInvitationsAdapter):
@@ -50,3 +52,20 @@ class AccountAdapter(DefaultAccountAdapter, BaseInvitationsAdapter):
                 )
 
         return result
+
+    def send_confirmation_mail(
+        self,
+        request: HttpRequest,
+        email_confirmation: EmailConfirmationHMAC,
+        signup: bool,
+    ) -> None:
+        """
+        Overrides allauth's default method for sending a confirmation email.
+        Adds the email provided by the future user in the session.
+        """
+        if request and email_confirmation:
+            request.session["account_verified_email"] = (
+                email_confirmation.email_address.email
+            )
+
+        super().send_confirmation_mail(request, email_confirmation, signup)

--- a/docker-app/qfieldcloud/core/urls.py
+++ b/docker-app/qfieldcloud/core/urls.py
@@ -11,6 +11,7 @@ from qfieldcloud.core.views import (
     teams_views,
 )
 from qfieldcloud.filestorage.urls import urlpatterns as filestorage_urlpatterns
+from qfieldcloud.core.views.accounts_views import resend_confirmation_email
 from rest_framework.routers import DefaultRouter
 
 router = DefaultRouter()
@@ -101,4 +102,5 @@ urlpatterns = [
         teams_views.DestroyTeamMemberView.as_view(),
         name="team_member_destroy",
     ),
+    path("resend-confirmation/", resend_confirmation_email, name="resend_confirmation"),
 ]

--- a/docker-app/qfieldcloud/core/views/accounts_views.py
+++ b/docker-app/qfieldcloud/core/views/accounts_views.py
@@ -1,0 +1,59 @@
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.contrib import messages
+from django.utils.translation import gettext as _
+from allauth.account.models import EmailAddress
+from django.utils.http import url_has_allowed_host_and_scheme
+
+
+def redirect_to_referer_or_view(
+    request: HttpRequest, view_name: str, *view_args, **view_kwargs
+) -> HttpResponseRedirect:
+    """
+    Redirects a request to a referer provided by a client.
+    If no referer provided or the referer is not safe,
+    this will create a redirection to a default view.
+
+    Args:
+        request (HttpRequest): incoming client request.
+        view_name (str): name of the view to redirect to.
+
+    Returns:
+        HttpResponseRedirect: client redirect http response.
+    """
+    referer = request.headers.get("referer", "")
+    if url_has_allowed_host_and_scheme(referer, allowed_hosts=settings.ALLOWED_HOSTS):
+        return HttpResponseRedirect(referer)
+    else:
+        return HttpResponseRedirect(view_name)
+
+
+def resend_confirmation_email(request: HttpRequest) -> HttpResponse:
+    """
+    Resends a confirmation email to a new unverified user.
+    """
+    if request.method != "POST":
+        return redirect_to_referer_or_view(request, "account_login")
+
+    email_address = request.session.get("account_verified_email")
+
+    if email_address:
+        try:
+            email_obj = EmailAddress.objects.get(email=email_address)
+            email_obj.send_confirmation(request)
+            messages.success(
+                request,
+                _("A new verification email has been sent to {}!").format(
+                    email_address
+                ),
+            )
+        except EmailAddress.DoesNotExist:
+            messages.error(
+                request,
+                _("Email {} not found. Please register again.").format(email_address),
+            )
+
+    else:
+        messages.error(request, _("No email found."))
+
+    return redirect_to_referer_or_view(request, "account_login")


### PR DESCRIPTION
This PR adds the email confirmation and resend logic to QFieldCloud, with a new url, a new view as well as overriding django allauth's `DefaultAccountAdapter`.