### PR TITLE
Make `Project.status` a cached property to drastically reduce the number of DB queries

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1487,7 +1487,7 @@ class Project(models.Model):
 
         return problems
 
-    @property
+    @cached_property
     def status(self) -> "Project.Status":
         # NOTE the status is NOT stored in the db, because it might be outdated
         if (

--- a/docker-app/qfieldcloud/core/tests/utils.py
+++ b/docker-app/qfieldcloud/core/tests/utils.py
@@ -127,6 +127,11 @@ def wait_for_project_ok_status(project: Project, wait_s: int = 30):
         fail(f"Still pending jobs after waiting for {wait_s} seconds")
 
     for _ in range(wait_s):
+        try:
+            del project.status  # type: ignore
+        except AttributeError:
+            pass
+
         project.refresh_from_db()
 
         if project.status == Project.Status.OK:


### PR DESCRIPTION
From 324 to 196 queries on the projects home screen.