### PR TITLE
Make it easy to change the default storage by changing `STORAGES_PROJECT_DEFAULT_STORAGE`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
           }'
           EOF
 
-          echo "TEST_SUITE_PROJECT_DEFAULT_STORAGE=${{ matrix.storage }}" >> .env
+          echo "STORAGES_PROJECT_DEFAULT_STORAGE=${{ matrix.storage }}" >> .env
 
       - name: Pull docker containers
         run: docker compose pull

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1029,29 +1029,10 @@ class ProjectQueryset(models.QuerySet):
 def get_project_file_storage_default() -> str:
     """Get the default file storage for the newly created project
 
-    Raises:
-        ConfigValidationError: when `TEST_SUITE_PROJECT_DEFAULT_STORAGE` value is not available as a key in the `STORAGES`
-
     Returns:
         str: the name of the storage
-
-    Todo:
-        * Delete with QF-4963 Drop support for legacy storage
     """
-    if settings.IN_TEST_SUITE:
-        import os
-        from qfieldcloud.settings_utils import ConfigValidationError
-
-        storage = os.environ["TEST_SUITE_PROJECT_DEFAULT_STORAGE"]
-
-        if storage not in settings.STORAGES:
-            raise ConfigValidationError(
-                f"Missing {storage=} from the `STORAGES` configuration, available storages: {settings.STORAGES.keys()}"
-            )
-
-        return storage
-
-    return "default"
+    return settings.STORAGES_PROJECT_DEFAULT_STORAGE
 
 
 def get_project_thumbnail_upload_to(instance: "Project", _filename: str) -> str:

--- a/docker-app/qfieldcloud/core/tests/utils.py
+++ b/docker-app/qfieldcloud/core/tests/utils.py
@@ -127,6 +127,11 @@ def wait_for_project_ok_status(project: Project, wait_s: int = 30):
         fail(f"Still pending jobs after waiting for {wait_s} seconds")
 
     for _ in range(wait_s):
+        try:
+            del project.status  # type: ignore
+        except AttributeError:
+            pass
+
         project.refresh_from_db()
 
         if project.status == Project.Status.OK:

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -17,7 +17,7 @@ import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
 
-from .settings_utils import get_storages_config
+from .settings_utils import get_storages_config, ConfigValidationError
 
 
 # QFieldCloud specific configuration
@@ -290,6 +290,14 @@ STORAGES_FILENAME_VALIDATION_REGEX = (
     r"(?<![\s\.])$"
 )
 
+STORAGES_PROJECT_DEFAULT_STORAGE = (
+    os.environ.get("STORAGES_PROJECT_DEFAULT_STORAGE") or "default"
+)
+
+if STORAGES_PROJECT_DEFAULT_STORAGE not in STORAGES:
+    raise ConfigValidationError(
+        f"Missing {STORAGES_PROJECT_DEFAULT_STORAGE=} from the `STORAGES` configuration, available storages: {STORAGES.keys()}"
+    )
 
 AUTH_USER_MODEL = "core.User"
 

--- a/docker-compose.override.test.yml
+++ b/docker-compose.override.test.yml
@@ -8,13 +8,14 @@ services:
       # we must use the same db for test and runserver
       POSTGRES_DB: test_${POSTGRES_DB}
       POSTGRES_DB_TEST: test_${POSTGRES_DB}
-      TEST_SUITE_PROJECT_DEFAULT_STORAGE: ${TEST_SUITE_PROJECT_DEFAULT_STORAGE:-default}
+      STORAGES_PROJECT_DEFAULT_STORAGE: ${STORAGES_PROJECT_DEFAULT_STORAGE:-}
 
   worker_wrapper:
     environment:
       # we must use the same db for test and runserver
       POSTGRES_DB: test_${POSTGRES_DB}
       POSTGRES_DB_TEST: test_${POSTGRES_DB}
+      STORAGES_PROJECT_DEFAULT_STORAGE: ${STORAGES_PROJECT_DEFAULT_STORAGE:-}
     scale: ${QFIELDCLOUD_WORKER_REPLICAS}
 
   db:


### PR DESCRIPTION


Previously changing the default storage was only possible by modifying the STORAGES or during tests execution. Now one can change this also for regular web server execution via a envvar.

Also removed the deprecation of this feature being deleted with QF-4963.