### PR TITLE
Move postgis docker image version to environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,6 +114,10 @@ WEB_HTTPS_PORT=443
 # DEFAULT: error
 NGINX_ERROR_LOG_LEVEL=error
 
+###################
+# Database settings
+###################
+
 POSTGRES_USER=qfieldcloud_db_admin
 POSTGRES_PASSWORD=3shJDd2r7Twwkehb
 POSTGRES_DB=qfieldcloud_db
@@ -122,6 +126,14 @@ POSTGRES_PORT=5432
 # "prefer" OR "require" most of the times
 POSTGRES_SSLMODE=prefer
 HOST_POSTGRES_PORT=5433
+
+# Docker image tag used for local/standalone database setup.
+# See https://hub.docker.com/r/postgis/postgis/tags.
+# When setting up a new local instance, do not hesitate to pick a recent version.
+# For migrating a local postgis to a more recent major version (risky operation),
+# see this gist: https://gist.github.com/gounux/2c0779fcb22e512cbdc613eb78200571 .
+# Migration to a newer database version is a risky operation to your data, so prepare and test the backup of the `postgres_data` volume.
+POSTGIS_IMAGE_VERSION=13-3.1-alpine
 
 GEODB_HOST=geodb
 GEODB_PORT=5432

--- a/README.md
+++ b/README.md
@@ -387,6 +387,19 @@ users. The template db has the following extensions installed:
 
 You can use either the integrated `minio` object storage, or use an external provider (e. g. S3) with versioning enabled. Check the corresponding `STORAGE_*` environment variables for more info.
 
+### Database
+
+QFieldCloud requires a PostgreSQL/PostGIS database persisting it's own data.
+The recommended and only supported way is to use an external to the docker-compose stack PostgreSQL/PostGIS database.
+Check the corresponding `POSTGRES_*` environment variables for more info.
+
+> [!CAUTION]
+> For local development and testing you can use the `db` service in `docker-compose.standalone.yml`.
+
+If a local PostGIS is running and hosting QFieldCloud's data, check the `POSTGIS_IMAGE_VERSION` for controlling the version of the PostgreSQL/PostGIS backend.
+[These commands](https://gist.github.com/gounux/2c0779fcb22e512cbdc613eb78200571) can help in order to migrate the local PG service from a major version to another one.
+Migration to a newer database version is a risky operation to your data, so prepare and test the backup of the `postgres_data` volume.
+
 ## Collaboration
 
 Contributions welcome!

--- a/docker-compose.override.staging.yml
+++ b/docker-compose.override.staging.yml
@@ -6,7 +6,7 @@ services:
         DEBUG_BUILD: ${DEBUG}
 
   geodb:
-    image: postgis/postgis:12-3.0
+    image: postgis/postgis:${POSTGIS_IMAGE_VERSION}
     restart: unless-stopped
     volumes:
       - geodb_data:/var/lib/postgresql

--- a/docker-compose.override.standalone.yml
+++ b/docker-compose.override.standalone.yml
@@ -1,7 +1,7 @@
 services:
 
   db:
-    image: postgis/postgis:13-3.1-alpine
+    image: postgis/postgis:${POSTGIS_IMAGE_VERSION}
     restart: unless-stopped
     environment:
       POSTGRES_DB: ${POSTGRES_DB}
@@ -14,7 +14,7 @@ services:
     command: ["postgres", "-c", "log_statement=all", "-c", "log_destination=stderr"]
 
   geodb:
-    image: postgis/postgis:12-3.0
+    image: postgis/postgis:${POSTGIS_IMAGE_VERSION}
     restart: unless-stopped
     volumes:
       - geodb_data:/var/lib/postgresql


### PR DESCRIPTION
This PR makes the postgis docker version configurable in the environment file.

Reason behind this simplicity for bumping repository to new versions later, as well as more flexibility for local and standalone instances.