### PR TITLE
Add the possibility to migrate file storage by exact username and support version ids that are not UUIDs

### DIFF
--- a/docker-app/qfieldcloud/filestorage/management/commands/migratefilestorage.py
+++ b/docker-app/qfieldcloud/filestorage/management/commands/migratefilestorage.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 class Command(BaseCommand):
     """
-    Recalculate projects storage size
+    Migrate project from one legacy storage to another storage.
     """
 
     def add_arguments(self, parser):

--- a/docker-app/qfieldcloud/filestorage/management/commands/migrateprojectstorage.py
+++ b/docker-app/qfieldcloud/filestorage/management/commands/migrateprojectstorage.py
@@ -23,6 +23,7 @@ class Command(BaseCommand):
         group.add_argument("--project-id", type=uuid.UUID, nargs="?")
         group.add_argument("--all", action="store_true", default=None)
         group.add_argument("--owner-username-startswith", type=str)
+        group.add_argument("--owner-username-matches", type=str)
 
     def handle(self, *args, **options):
         projects: Sized = []
@@ -33,10 +34,12 @@ class Command(BaseCommand):
         project_id = options.get("project_id")
         all = options.get("all")
         owner_username_startswith = options.get("owner_username_startswith")
+        owner_username_matches = options.get("owner_username_matches")
 
         if all is not None:
             assert project_id is None
             assert owner_username_startswith is None
+            assert owner_username_matches is None
 
             self.stderr.write(
                 "You are going to migrate all files on this installation."
@@ -55,18 +58,28 @@ class Command(BaseCommand):
         elif project_id is not None:
             assert all is None
             assert owner_username_startswith is None
+            assert owner_username_matches is None
 
             projects = [Project.objects.get(pk=project_id)]
         elif owner_username_startswith is not None:
             assert all is None
             assert project_id is None
+            assert owner_username_matches is None
 
             projects = Project.objects.filter(
-                owner__username__startswith=owner_username_startswith
+                owner__username__startswith=owner_username_startswith,
+            )
+        elif owner_username_matches is not None:
+            assert all is None
+            assert project_id is None
+            assert owner_username_startswith is None
+
+            projects = Project.objects.filter(
+                owner__username=owner_username_matches,
             )
         else:
             self.stderr.write(
-                "You must pass exactly one of filter arguments: --project-id, --all, or --owner-username-startswith!"
+                "You must pass exactly one of filter arguments: --project-id, --all, --owner-username-startswith, or --owner-username-matches!"
             )
 
             exit(1)

--- a/docker-app/qfieldcloud/filestorage/migrate_project_storage.py
+++ b/docker-app/qfieldcloud/filestorage/migrate_project_storage.py
@@ -144,7 +144,7 @@ def migrate_project_storage(
                     uploaded_at=file_version.last_modified,
                     uploaded_by=project.owner,
                     created_at=now,
-                    version_id=file_version.id,
+                    legacy_version_id=file_version.id,
                 )
 
         package_files = get_project_package_files(

--- a/docker-app/qfieldcloud/filestorage/migrations/0001_initial.py
+++ b/docker-app/qfieldcloud/filestorage/migrations/0001_initial.py
@@ -141,6 +141,10 @@ class Migration(migrations.Migration):
                         editable=False,
                     ),
                 ),
+                (
+                    "legacy_id",
+                    models.TextField(max_length=255, editable=False, null=True),
+                ),
             ],
             options={"ordering": ("file", "-uploaded_at")},
         ),

--- a/docker-app/qfieldcloud/filestorage/utils.py
+++ b/docker-app/qfieldcloud/filestorage/utils.py
@@ -1,4 +1,6 @@
+from typing import Any
 import hashlib
+import uuid
 
 from pathlib import Path, PurePath
 
@@ -144,3 +146,14 @@ def calc_etag(file: ContentFile, part_size: int = 8 * 1024 * 1024) -> str:
         final_md5sum = hashlib.md5(b"".join(md5sums))
 
         return "{}-{}".format(final_md5sum.hexdigest(), len(md5sums))
+
+
+def to_uuid(value: Any) -> uuid.UUID | None:
+    """Converts a given value to a UUID object, or if not possible, returns None."""
+    if not value:
+        return None
+
+    try:
+        return uuid.UUID(value)
+    except ValueError:
+        return None


### PR DESCRIPTION
Basically the title, it seems besides minio version id that is a UUID , there are other providers that use other strings to represent version ids.