### PR TITLE
Add an assert when resending confirmation email

### DIFF
--- a/docker-app/qfieldcloud/core/views/accounts_views.py
+++ b/docker-app/qfieldcloud/core/views/accounts_views.py
@@ -35,6 +35,7 @@ def resend_confirmation_email(request: HttpRequest) -> HttpResponse:
     if request.method != "POST":
         return redirect_to_referer_or_view(request, "account_login")
 
+    assert "account_verified_email" in request.session
     email_address = request.session.get("account_verified_email")
 
     if email_address:


### PR DESCRIPTION
This PR makes sure there is a `account_verified_email` key in the resend confirmation email view.