### PR TITLE
Fix backwards compatibility with QField/QFieldSync for avatars

### DIFF
--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from django.urls import reverse_lazy
 from django.utils.translation import gettext as _
 from qfieldcloud.authentication.models import AuthToken
@@ -28,10 +29,14 @@ def get_avatar_url(user: User, request: Request | None = None) -> str | None:
     if not user.useraccount.avatar:
         return None
 
+    filename = user.useraccount.avatar.name
+    file_extension = Path(filename).suffix
+
     reversed_uri = reverse_lazy(
-        "filestorage_avatars",
+        "filestorage_named_avatars",
         kwargs={
             "username": user.username,
+            "filename": f"avatar.{file_extension}",
         },
     )
 

--- a/docker-app/qfieldcloud/filestorage/urls.py
+++ b/docker-app/qfieldcloud/filestorage/urls.py
@@ -28,4 +28,10 @@ urlpatterns = [
         AvatarFileReadView.as_view(),
         name="filestorage_avatars",
     ),
+    # NOTE The sole purpose of this URL is to keep backwards compatibility with QField/QFieldSync. They expect the URL path to end with filename with file extension.
+    path(
+        "files/avatars/<str:username>/<str:filename>/",
+        AvatarFileReadView.as_view(),
+        name="filestorage_named_avatars",
+    ),
 ]

--- a/docker-app/qfieldcloud/filestorage/views.py
+++ b/docker-app/qfieldcloud/filestorage/views.py
@@ -185,7 +185,20 @@ class ProjectMetaFileReadView(views.APIView):
 class AvatarFileReadView(views.APIView):
     permission_classes = []
 
-    def get(self, request: Request, username: str) -> HttpResponseBase:
+    def get(
+        self, request: Request, username: str, filename: str = ""
+    ) -> HttpResponseBase:
+        """Returns an internal redirect within nginx to serve the `avatar` file directly from the Object Storage.
+
+        NOTE the filename field is completely ignored and redundant, it exists only to satisfy backwards compatible expectations in QField/QFieldSync that avatars will have filename with file extension.
+        Args:
+            request: incoming request
+            username: the username we are serving avatar for
+            filename: the filename in the URL, but ignored in the function execution. Defaults to "".
+
+        Returns:
+            internal redirect to the Object Storage
+        """
         useraccount = get_object_or_404(UserAccount, user__username=username)
 
         return download_field_file(


### PR DESCRIPTION
They expect that the avatar URL returned via API is always ending with a file extension, e.g. `.png`, `.svg` etc.

Now we do match this expectation by adding a new URL path:
```/files/avatars/<username>/avatar.<extension>/```

The `avatar.<extension>` does nothing, it is used just for the
backwards compatibility.

This is only used in the serializers.