### PR TITLE
Remove trailing slash for avatars for backwards compatibility for QFieldSync

### DIFF
--- a/docker-app/qfieldcloud/filestorage/urls.py
+++ b/docker-app/qfieldcloud/filestorage/urls.py
@@ -30,7 +30,7 @@ urlpatterns = [
     ),
     # NOTE The sole purpose of this URL is to keep backwards compatibility with QField/QFieldSync. They expect the URL path to end with filename with file extension.
     path(
-        "files/avatars/<str:username>/<str:filename>/",
+        "files/avatars/<str:username>/<str:filename>",
         AvatarFileReadView.as_view(),
         name="filestorage_named_avatars",
     ),


### PR DESCRIPTION
Fix the fix in #1161 .

The error we target with this PR is:
![image](https://github.com/user-attachments/assets/cd8f75ca-89ca-42cc-8dfb-7a45ba0815b3)
