### PR TITLE
Add information in the admin when the project has been migrated

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -776,6 +776,7 @@ class ProjectAdmin(QFieldCloudModelAdmin):
         "description",
         "created_at",
         "updated_at",
+        "is_locked",
     )
     list_filter = (
         "is_public",
@@ -802,6 +803,9 @@ class ProjectAdmin(QFieldCloudModelAdmin):
         "data_last_updated_at",
         "data_last_packaged_at",
         "project_details__pre",
+        "is_locked",
+        "file_storage",
+        "file_storage_migrated_at",
         "project_files",
     )
     readonly_fields = (
@@ -814,6 +818,9 @@ class ProjectAdmin(QFieldCloudModelAdmin):
         "data_last_updated_at",
         "data_last_packaged_at",
         "project_details__pre",
+        "is_locked",
+        "file_storage",
+        "file_storage_migrated_at",
     )
     inlines = (
         ProjectSecretInline,

--- a/docker-app/qfieldcloud/core/migrations/0081_file_storage_project_and_more.py
+++ b/docker-app/qfieldcloud/core/migrations/0081_file_storage_project_and_more.py
@@ -31,6 +31,7 @@ class Migration(migrations.Migration):
             model_name="project",
             name="file_storage",
             field=models.CharField(
+                editable=False,
                 help_text="Which file storage provider should be used for the storing the project related files.",
                 max_length=100,
                 validators=[qfieldcloud.core.validators.file_storage_name_validator],
@@ -43,11 +44,22 @@ class Migration(migrations.Migration):
             model_name="project",
             name="file_storage",
             field=models.CharField(
+                editable=False,
                 help_text="Which file storage provider should be used for the storing the project related files.",
                 max_length=100,
                 validators=[qfieldcloud.core.validators.file_storage_name_validator],
                 verbose_name="File storage",
                 default=qfieldcloud.core.models.get_project_file_storage_default,
+            ),
+        ),
+        migrations.AddField(
+            model_name="project",
+            name="file_storage_migrated_at",
+            field=models.DateTimeField(
+                blank=True,
+                editable=False,
+                null=True,
+                verbose_name="File Storage Migrated At",
             ),
         ),
         migrations.RenameField(

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1201,6 +1201,14 @@ class Project(models.Model):
         max_length=100,
         validators=[validators.file_storage_name_validator],
         default=get_project_file_storage_default,
+        editable=False,
+    )
+
+    file_storage_migrated_at = models.DateTimeField(
+        _("File Storage Migrated At"),
+        blank=True,
+        null=True,
+        editable=False,
     )
 
     is_locked = models.BooleanField(

--- a/docker-app/qfieldcloud/filestorage/migrate_project_storage.py
+++ b/docker-app/qfieldcloud/filestorage/migrate_project_storage.py
@@ -60,6 +60,7 @@ def migrate_project_storage(
 
     from_storage_bucket = storages[from_storage].bucket  # type: ignore
     to_storage_bucket = storages[to_storage].bucket  # type: ignore
+    now = timezone.now()
 
     try:
         logger.info(f'Locking project "{project.name}" ({str(project.id)})...')
@@ -117,8 +118,6 @@ def migrate_project_storage(
                 raise Exception(
                     f'Cannot migrate project "{project.name}" ({str(project.id)}) to "{to_storage}", the path already exists in the bucket!!'
                 )
-
-        now = timezone.now()
 
         for project_file in project_files:
             for file_version in project_file.versions:
@@ -224,4 +223,12 @@ def migrate_project_storage(
         raise err
     finally:
         project.is_locked = False
-        project.save(update_fields=["is_locked", "file_storage", "thumbnail"])
+        project.file_storage_migrated_at = now
+        project.save(
+            update_fields=[
+                "is_locked",
+                "file_storage",
+                "file_storage_migrated_at",
+                "thumbnail",
+            ]
+        )


### PR DESCRIPTION
What storage is being used and whether it is locked.

Added to project admin:
![image](https://github.com/user-attachments/assets/0d407607-c738-404e-9c5b-57b5f6815ad2)
