### PR TITLE
Delete the `FileField` files when a model entity is deleted

### DIFF
--- a/docker-app/qfieldcloud/core/tests/test_admin.py
+++ b/docker-app/qfieldcloud/core/tests/test_admin.py
@@ -71,34 +71,35 @@ class QfcTestCase(TransactionTestCase):
 
             url = "/" + "".join(url_item)
 
-            # skip if the URL pattern contains placeholders, e.g. /admin/app/model/<object_id>/edit
-            if "<" in url:
-                continue
-
-            if url in settings.QFIELDCLOUD_TEST_SKIP_VIEW_ADMIN_URLS:
-                continue
-
-            # get page without any sorting
-            resp = self.client.get(f"{url}?o=")
-            self.assertEqual(
-                resp.status_code,
-                200,
-                f'Failed to open "{url}", got HTTP {resp.status_code}.',
-            )
-
-            # check all different sort columns
-            soup = BeautifulSoup(resp.content, "html.parser")
-
-            for anchor in soup.select("th.sortable a"):
-                sort_url = f"{url}{anchor.get('href')}"
-
-                # TODO make tests pass for these sortable URLs
-                if sort_url in settings.QFIELDCLOUD_TEST_SKIP_SORT_ADMIN_URLS:
+            with self.subTest(f"Test {url} opens..."):
+                # skip if the URL pattern contains placeholders, e.g. /admin/app/model/<object_id>/edit
+                if "<" in url:
                     continue
 
-                resp = self.client.get(sort_url)
+                if url in settings.QFIELDCLOUD_TEST_SKIP_VIEW_ADMIN_URLS:
+                    continue
+
+                # get page without any sorting
+                resp = self.client.get(f"{url}?o=")
                 self.assertEqual(
                     resp.status_code,
                     200,
-                    f'Failed to sort "{sort_url}", got HTTP {resp.status_code}.',
+                    f'Failed to open "{url}", got HTTP {resp.status_code}.',
                 )
+
+                # check all different sort columns
+                soup = BeautifulSoup(resp.content, "html.parser")
+
+                for anchor in soup.select("th.sortable a"):
+                    sort_url = f"{url}{anchor.get('href')}"
+
+                    # TODO make tests pass for these sortable URLs
+                    if sort_url in settings.QFIELDCLOUD_TEST_SKIP_SORT_ADMIN_URLS:
+                        continue
+
+                    resp = self.client.get(sort_url)
+                    self.assertEqual(
+                        resp.status_code,
+                        200,
+                        f'Failed to sort "{sort_url}", got HTTP {resp.status_code}.',
+                    )

--- a/docker-app/qfieldcloud/filestorage/models.py
+++ b/docker-app/qfieldcloud/filestorage/models.py
@@ -325,7 +325,10 @@ class FileVersion(models.Model):
         super().delete(*args, **kwargs)
 
     def __repr__(self) -> str:
-        return f'FileVersion({self.id}) in "{self.file.project_id}" "{self.file.name}" "{self.display}"'  # type: ignore
+        if hasattr(self, "file"):
+            return f'FileVersion({self.id}) in "{self.file.project_id}" "{self.file.name}" "{self.display}"'  # type: ignore
+        else:
+            return f'FileVersion({self.id}) in "UNKNOWN_PROJECT_ID" "UNKNOWN_FILENAME" "{self.display}"'  # type: ignore
 
     def __str__(self) -> str:
         return self.__repr__()

--- a/docker-app/qfieldcloud/filestorage/tests/test_files_api.py
+++ b/docker-app/qfieldcloud/filestorage/tests/test_files_api.py
@@ -156,6 +156,8 @@ class QfcTestCase(APITransactionTestCase):
     ) -> HttpResponse | Response:
         if params and params.get("version"):
             file_version = FileVersion.objects.get(id=params["version"])
+        elif headers and headers.get("x-file-version"):
+            file_version = FileVersion.objects.get(id=headers["x-file-version"])
         else:
             file_version = File.objects.get(name=filename).latest_version
 

--- a/docker-app/qfieldcloud/filestorage/tests/test_files_api.py
+++ b/docker-app/qfieldcloud/filestorage/tests/test_files_api.py
@@ -24,6 +24,8 @@ from rest_framework.test import APITransactionTestCase
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 from django.conf import settings
+from django.core.files.base import ContentFile
+from django.core.files.storage import storages
 from django.contrib.contenttypes.models import ContentType
 from auditlog.models import LogEntry
 
@@ -141,6 +143,35 @@ class QfcTestCase(APITransactionTestCase):
         self.assertEqual(file.versions.count(), min((versions_count + 1), max_versions))
         self.assertEqual(file.latest_version, file.versions.all()[0])
         self.assertNotEqual(file.latest_version, latest_version)
+
+        return response
+
+    def assertFileDeleted(
+        self,
+        user: User,
+        project: Project,
+        filename: str,
+        params: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> HttpResponse | Response:
+        if params and params.get("version"):
+            file_version = FileVersion.objects.get(id=params["version"])
+        else:
+            file_version = File.objects.get(name=filename).latest_version
+
+            # make typing happy that `file_version` is not `None`
+            assert file_version
+
+        storage_filename = file_version.content.name
+
+        self.assertTrue(storages[project.file_storage].exists(storage_filename))
+
+        response = self._delete_file(user, project, filename, params, headers)
+
+        project.refresh_from_db()
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(storages[project.file_storage].exists(storage_filename))
 
         return response
 
@@ -564,7 +595,7 @@ class QfcTestCase(APITransactionTestCase):
         self.p1.refresh_from_db()
         self.assertEqual(self.p1.file_storage_bytes, 14)
 
-        response = self._delete_file(
+        self.assertFileDeleted(
             self.u1,
             self.p1,
             "file.name",
@@ -572,15 +603,8 @@ class QfcTestCase(APITransactionTestCase):
                 "version": self.p1.get_file("file.name").latest_version.id,
             },
         )
-
-        self.p1.refresh_from_db()
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(self.p1.file_storage_bytes, 7)
-
-        response = self._delete_file(self.u1, self.p1, "file.name")
-
-        self.p1.refresh_from_db()
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFileDeleted(self.u1, self.p1, "file.name")
         self.assertEqual(self.p1.file_storage_bytes, 0)
 
     # def test_upload_non_attachment_file_starts_a_new_job(self):
@@ -679,10 +703,7 @@ class QfcTestCase(APITransactionTestCase):
 
     def test_delete_existing_file_succeeds(self):
         self.assertFileUploaded(self.u1, self.p1, "file.name", StringIO("Hello1!"))
-
-        response = self._delete_file(self.u1, self.p1, "file.name")
-
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFileDeleted(self.u1, self.p1, "file.name")
         self.assertEqual(self.p1.files.count(), 0)
 
     def test_delete_non_existing_file_fails(self):
@@ -698,7 +719,7 @@ class QfcTestCase(APITransactionTestCase):
         old_newer_version = old_versions_qs[0]
         old_older_version = old_versions_qs[1]
 
-        response = self._delete_file(
+        self.assertFileDeleted(
             self.u1,
             self.p1,
             "file.name",
@@ -706,8 +727,6 @@ class QfcTestCase(APITransactionTestCase):
                 "version": str(old_older_version.id),
             },
         )
-
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(self.p1.files.count(), 1)
 
         new_versions_qs = self.p1.get_file("file.name").versions.all()
@@ -725,7 +744,7 @@ class QfcTestCase(APITransactionTestCase):
         old_newer_version = old_versions_qs[0]
         old_older_version = old_versions_qs[1]
 
-        response = self._delete_file(
+        self.assertFileDeleted(
             self.u1,
             self.p1,
             "file.name",
@@ -733,8 +752,6 @@ class QfcTestCase(APITransactionTestCase):
                 "x-file-version": str(old_older_version.id),
             },
         )
-
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(self.p1.files.count(), 1)
 
         new_versions_qs = self.p1.get_file("file.name").versions.all()
@@ -773,11 +790,7 @@ class QfcTestCase(APITransactionTestCase):
 
         self.assertEqual(self.p1.the_qgis_file_name, "project1.qgs")
 
-        response = self._delete_file(self.u1, self.p1, "project1.qgs")
-
-        self.p1.refresh_from_db()
-
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFileDeleted(self.u1, self.p1, "project1.qgs")
         self.assertEqual(self.p1.files.count(), 0)
         self.assertIsNone(self.p1.the_qgis_file_name)
 
@@ -803,7 +816,7 @@ class QfcTestCase(APITransactionTestCase):
 
         versions_qs = self.p1.get_file("project1.qgs").versions.all()
 
-        response = self._delete_file(
+        self.assertFileDeleted(
             self.u1,
             self.p1,
             "project1.qgs",
@@ -811,10 +824,6 @@ class QfcTestCase(APITransactionTestCase):
                 "version": str(versions_qs[0].id),
             },
         )
-
-        self.p1.refresh_from_db()
-
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(self.p1.files.count(), 1)
         # project file still set to the recently uploaded file as there is one more version
         self.assertEqual(self.p1.the_qgis_file_name, "project1.qgs")
@@ -898,9 +907,7 @@ class QfcTestCase(APITransactionTestCase):
             project=self.p1, collaborator=u2, role=ProjectCollaborator.Roles.EDITOR
         )
 
-        response = self._delete_file(u2, self.p1, "file.name")
-
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFileDeleted(u2, self.p1, "file.name")
         self.assertEqual(self.p1.files.count(), 0)
 
     def test_latest_version_attribute_is_updated(self):
@@ -930,7 +937,7 @@ class QfcTestCase(APITransactionTestCase):
         self.assertEqual(self.p1.get_file("file.name").latest_version_id, version3.pk)
 
         # delete the 2nd version
-        response = self._delete_file(
+        self.assertFileDeleted(
             self.u1,
             self.p1,
             "file.name",
@@ -938,14 +945,12 @@ class QfcTestCase(APITransactionTestCase):
                 "version": str(version2.id),
             },
         )
-
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(self.p1.files.count(), 1)
         self.assertEqual(self.p1.get_file("file.name").versions.count(), 2)
         self.assertEqual(self.p1.get_file("file.name").latest_version_id, version3.pk)
 
         # delete the 3rd (latest) version
-        response = self._delete_file(
+        self.assertFileDeleted(
             self.u1,
             self.p1,
             "file.name",
@@ -953,8 +958,6 @@ class QfcTestCase(APITransactionTestCase):
                 "version": str(version3.id),
             },
         )
-
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(self.p1.files.count(), 1)
         self.assertEqual(self.p1.get_file("file.name").versions.count(), 1)
         self.assertEqual(self.p1.get_file("file.name").latest_version_id, version1.pk)
@@ -1035,7 +1038,7 @@ class QfcTestCase(APITransactionTestCase):
         (v4, v3, v2, v1) = self.p1.files.all()[0].versions.all()
 
         # deleting the oldest version should create only one new `FileVersion` DELETE audit
-        response = self._delete_file(
+        self.assertFileDeleted(
             self.u1,
             self.p1,
             "file.name",
@@ -1043,14 +1046,12 @@ class QfcTestCase(APITransactionTestCase):
                 "version": str(v1.id),
             },
         )
-
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(file_delete_audit_qs.count(), 0)
         self.assertEqual(file_update_audit_qs.count(), 3)
         self.assertEqual(version_delete_log_qs.count(), 1)
 
         # deleting the latest version should create two new audits: `FileVersion` DELETE audit and `File` UPDATE audit
-        response = self._delete_file(
+        self.assertFileDeleted(
             self.u1,
             self.p1,
             "file.name",
@@ -1058,16 +1059,12 @@ class QfcTestCase(APITransactionTestCase):
                 "version": str(v4.id),
             },
         )
-
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(file_delete_audit_qs.count(), 0)
         self.assertEqual(file_update_audit_qs.count(), 4)
         self.assertEqual(version_delete_log_qs.count(), 2)
 
         # deleting the file should create three new audits: two `FileVersion` DELETE audits and `File` DELETE audit
-        response = self._delete_file(self.u1, self.p1, "file.name")
-
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFileDeleted(self.u1, self.p1, "file.name")
         self.assertEqual(file_delete_audit_qs.count(), 1)
         self.assertEqual(file_update_audit_qs.count(), 4)
         self.assertEqual(version_delete_log_qs.count(), 4)
@@ -1140,3 +1137,25 @@ class QfcTestCase(APITransactionTestCase):
             "0c9a42b3d065a64063eca67e98c932fa2e9a077bc7973a421a964a11304c998c",
         )
         self.assertEqual(len(payload[0].get("versions", [])), 1)
+
+    def test_delete_project_deletes_thumbnail_and_all_project_files(self):
+        p2 = Project.objects.create(
+            owner=self.u1,
+            name="p2",
+            file_storage="default",
+        )
+
+        p2.thumbnail = ContentFile("<svg />", "thumbnail.svg")
+        p2.save()
+
+        self.assertFileUploaded(self.u1, p2, "file.name", StringIO("Hello world!"))
+
+        latest_version: FileVersion = p2.files.first().latest_version  # type: ignore
+
+        self.assertTrue(storages[p2.file_storage].exists(p2.thumbnail.name))
+        self.assertTrue(storages[p2.file_storage].exists(latest_version.content.name))
+
+        p2.delete()
+
+        self.assertFalse(storages[p2.file_storage].exists(p2.thumbnail.name))
+        self.assertFalse(storages[p2.file_storage].exists(latest_version.content.name))

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -127,6 +127,7 @@ INSTALLED_APPS = [
     "migrate_sql",
     "constance",
     "django_extensions",
+    "django_cleanup.apps.CleanupConfig",
 ]
 
 MIDDLEWARE = [

--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -6,6 +6,7 @@ django-auditlog==3.0.0
 django-axes==7.0.2
 django-bootstrap4==24.4
 django-classy-tags==4.1.0
+django-cleanup==9.0.0
 django-common-helpers==0.9.2
 django-constance[database]==4.3.2
 django-countries==7.6.1

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -80,6 +80,8 @@ django-bootstrap4==24.4
     # via -r /requirements/requirements.in
 django-classy-tags==4.1.0
     # via -r /requirements/requirements.in
+django-cleanup==9.0.0
+    # via -r /requirements/requirements.in
 django-common-helpers==0.9.2
     # via -r /requirements/requirements.in
 django-constance[database]==4.3.2


### PR DESCRIPTION
Copy-paste from the docs https://github.com/un1t/django-cleanup:

> The django-cleanup app automatically deletes files for FileField, ImageField and subclasses. When a FileField's value is changed and the model is saved, the old file is deleted. When a model that has a FileField is deleted, the file is also deleted. A file that is set as the FileField's default value will not be deleted.

and

> In order to track changes of a FileField and facilitate file deletions, django-cleanup connects post_init, pre_save, post_save and post_delete signals to signal handlers for each INSTALLED_APPS model that has a FileField. In order to tell whether or not a FileField's value has changed a local cache of original values is kept on the model instance. If a condition is detected that should result in a file deletion, a function to delete the file is setup and inserted into the commit phase of the current transaction.

EDIT: The initial commit failed the CI, so we had to do the following change in https://github.com/opengisch/QFieldCloud/pull/1166/commits/7e953d02fdb1214b0d70554c9df43112c9013740

Fix loading the Django admin for `FileVersion` model admin

If the model is not saved yet, there is a chance that it was instantiated without values
for the foreign keys.
In some models, e.g. `filestorage.FileVersion`, calling `_get_file_storage_name`
requires a foreign key value. Therefore we return the `default` storage for those cases.

The situation arises because `django_cleanup` module implements the `FieldFile`:
https://github.com/un1t/django-cleanup/blob/master/src/django_cleanup/cache.py#L84

It uses it to compare new and old file values for a model and whether it is needed to delete the old file from the file storage, see https://github.com/un1t/django-cleanup/blob/master/src/django_cleanup/handlers.py#L47-L49

Fixes the following error:
```
  File "/usr/local/lib/python3.10/site-packages/django/contrib/admin/options.py", line 1814, in _changeform_view
    form = ModelForm(initial=initial)
  File "/usr/local/lib/python3.10/site-packages/django/forms/models.py", line 353, in __init__
    self.instance = opts.model()
  File "/usr/local/lib/python3.10/site-packages/django/db/models/base.py", line 572, in __init__
    post_init.send(sender=cls, instance=self)
  File "/usr/local/lib/python3.10/site-packages/django/dispatch/dispatcher.py", line 176, in send
    return [
  File "/usr/local/lib/python3.10/site-packages/django/dispatch/dispatcher.py", line 177, in <listcomp>
    (receiver, receiver(signal=self, sender=sender, **named))
  File "/usr/local/lib/python3.10/site-packages/django_cleanup/handlers.py", line 22, in cache_original_post_init
    cache.make_cleanup_cache(instance)
  File "/usr/local/lib/python3.10/site-packages/django_cleanup/cache.py", line 160, in make_cleanup_cache
    setattr(instance, CACHE_NAME, dict(
  File "/usr/local/lib/python3.10/site-packages/django_cleanup/cache.py", line 84, in fields_for_model_instance
    fieldfile = getattr(instance, field_name)
  File "/usr/local/lib/python3.10/site-packages/django/db/models/fields/files.py", line 192, in __get__
    attr = self.field.attr_class(instance, self.field, file)
  File "/usr/src/app/qfieldcloud/core/fields.py", line 52, in __init__
    storage_name = instance._get_file_storage_name()
  File "/usr/src/app/qfieldcloud/filestorage/models.py", line 247, in _get_file_storage_name
    return self.file.project.file_storage
  File "/usr/local/lib/python3.10/site-packages/django/db/models/fields/related_descriptors.py", line 246, in __get__
    raise self.RelatedObjectDoesNotExist(
qfieldcloud.filestorage.models.FileVersion.file.RelatedObjectDoesNotExist: FileVersion has no file.

```