### PR TITLE
Fix a misleading comment that the envvar is called `DYNAMIC_STORAGES`, but it we settled on `STORAGES` only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,7 @@ LETSENCRYPT_STAGING=1
 
 
 # Used to define storages in QFieldCloud. Note the contents of this variable is a superset of Django's `STORAGES` setting.
-# NOTE: Note if the DYNAMIC_STORAGES is not available, QFieldCloud will still work with `STORAGE_ACCESS_KEY_ID`, `STORAGE_SECRET_KEY_ID`, `STORAGE_BUCKET_NAME` and `STORAGE_REGION_NAME` from previous QFC versions.
+# NOTE: Note if the `STORAGES` is not available, QFieldCloud will still work with `STORAGE_ACCESS_KEY_ID`, `STORAGE_SECRET_KEY_ID`, `STORAGE_BUCKET_NAME` and `STORAGE_REGION_NAME` from previous QFC versions.
 # NOTE: The custom property `QFC_IS_LEGACY` is temporary available to allow migration from the old to the new way of handling files. This option will soon be removed, so you are highly encouraged to migrate all the projects to the new way of handling files.
 # NOTE: The `endpoint_url` must be a URL reachable from within docker and the host, the default value `172.17.0.1` for `minio` is the docker network `bridge`. On windows/mac, change the value to "http://host.docker.internal:8009".
 # DEFAULT:


### PR DESCRIPTION
Pretty much the title.