### PR TITLE
Add STORAGE_ACCESS_KEY_ID and STORAGE_SECRET_ACCESS_KEY to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,39 +1,7 @@
-####################
-# Debug settings
-####################
-
 # Whether the environment is in debug mode (e.g. Django debug)
 # VALUES: 0 - non debug mode; 1 - debug mode
 # DEFAULT: 1
 DEBUG=1
-
-# Debugpy port used for the `app` service
-# DEFAULT: 5678
-DEBUG_DEBUGPY_APP_PORT=5678
-
-# Debugpy port used for the `worker_wrapper` service
-# DEFAULT: 5679
-DEBUG_DEBUGPY_WORKER_WRAPPER_PORT=5679
-
-# The Django development port. Not used in production.
-# DEFAULT: 8011
-DJANGO_DEV_PORT=8011
-
-####################
-# Deployment settings
-####################
-
-# Prefix used by docker compose for each of the containers, e.g. app will be `qfieldcloud_app`
-# DEFAULT: qfieldcloud
-COMPOSE_PROJECT_NAME=qfieldcloud
-
-# List of docker compose files
-# DEFAULT: docker-compose.yml:docker-compose.override.local.yml
-COMPOSE_FILE=docker-compose.yml:docker-compose.override.local.yml:docker-compose.override.standalone.yml
-
-# Separator in `COMPOSE_FILE` between filenames. Required for making COMPOSE_FILE above cross-platform (do not change)
-# DEFAULT: :
-COMPOSE_PATH_SEPARATOR=:
 
 # Environment where QFieldCloud runs
 # VALUES: `development` - local development; `staging` - staging server; `test` - tests; `production` - production server
@@ -46,77 +14,7 @@ DJANGO_ALLOWED_HOSTS="localhost 127.0.0.1 0.0.0.0 app nginx"
 
 SECRET_KEY=change_me
 
-# Docker compose default network also used by the docker in docker workers
-# If empty value, a default name will be generated at build time, for example `qfieldcloud_default`.
-# QFIELDCLOUD_DEFAULT_NETWORK=""
-
-# Admin URI. Requires slash in the end. Please use something that is hard to guess.
-QFIELDCLOUD_ADMIN_URI=admin/
-
-# QFieldCloud URL used within the worker as configuration for qfieldcloud-sdk
-QFIELDCLOUD_WORKER_QFIELDCLOUD_URL=http://app:8000/api/v1/
-
-# number of parallel workers
-# DEFAULT: 1
-QFIELDCLOUD_WORKER_REPLICAS=1
-
-# QFieldCloud subscription model
-# DEFAULT: subscription.Subscription
-QFIELDCLOUD_SUBSCRIPTION_MODEL=subscription.Subscription
-
-# QFieldCloud auth token expiration hours. For example 720 hours (30 days).
-# DEFAULT: 720
-QFIELDCLOUD_AUTH_TOKEN_EXPIRATION_HOURS=720
-
-# Whether QFieldCloud should be translated in another language other than English.
-# NOTE if there is no full translation in given language, QFieldCloud will be shown in mixture of English and the given language. Also installed Django modules have their own translations that might not be complete.
-# VALUES: 0 - English only; 1 - enable other languages
-# DEFAULT: 1
-QFIELDCLOUD_USE_I18N=1
-
-# QFieldCloud default language that is displayed in the interface
-# DEFAULT: "en"
-QFIELDCLOUD_DEFAULT_LANGUAGE="en"
-
-# QFieldCloud default timezone that is used when account has no timezone
-# DEFAULT: "Europe/Zurich"
-QFIELDCLOUD_DEFAULT_TIME_ZONE="Europe/Zurich"
-
-# QFieldCloud QGIS image name to be used as worker by the `worker_wrapper`.
-# If empty value, a default name will be generated at build time, for example `qfieldcloud-qgis`.
-# DEFAULT: ""
-# QFIELDCLOUD_QGIS_IMAGE_NAME=""
-
-# QFieldCloud `libqfieldsync` volume path to be mounted by the `worker_wrapper` into `worker` containers.
-# If empty value or invalid value, the pip installed version defined in `requirements_libqfieldsync.txt` will be used.
-# DEFAULT: ""
-QFIELDCLOUD_LIBQFIELDSYNC_VOLUME_PATH=""
-
-# QFieldCloud SDK volume path to be mounted by the `worker_wrapper` into `worker` containers.
-# If empty value or invalid value, the pip installed version defined in `requirements_libqfieldsync.txt` will be used.
-# DEFAULT: ""
-QFIELDCLOUD_QFIELDCLOUD_SDK_VOLUME_PATH=""
-
-####################
-# Webserver settings
-####################
-
-WEB_HTTP_PORT=80
-WEB_HTTPS_PORT=443
-
-# Messages are logged at the specified level and all more severe levels. The nginx default is `error`. Read more on https://nginx.org/en/docs/ngx_core_module.html#error_log.
-# OPTIONS: debug, info, notice, warn, error, crit, alert, emerg
-# DEFAULT: error
-NGINX_ERROR_LOG_LEVEL=error
-
-GUNICORN_TIMEOUT_S=300
-GUNICORN_MAX_REQUESTS=300
-GUNICORN_WORKERS=3
-GUNICORN_THREADS=3
-
-####################
 # Certificates
-####################
 
 # TLS certificate filename from within the `nginx` container.
 # For usage with Let's Encrypt certificate, use as:
@@ -201,9 +99,13 @@ MINIO_API_PORT=8009
 # DEFAULT: 8010
 MINIO_BROWSER_PORT=8010
 
-####################
-# Database settings
-####################
+WEB_HTTP_PORT=80
+WEB_HTTPS_PORT=443
+
+# Messages are logged at the specified level and all more severe levels. The nginx default is `error`. Read more on https://nginx.org/en/docs/ngx_core_module.html#error_log.
+# OPTIONS: debug, info, notice, warn, error, crit, alert, emerg
+# DEFAULT: error
+NGINX_ERROR_LOG_LEVEL=error
 
 POSTGRES_USER=qfieldcloud_db_admin
 POSTGRES_PASSWORD=3shJDd2r7Twwkehb
@@ -220,10 +122,6 @@ GEODB_USER=postgres
 GEODB_PASSWORD="KUAa7h!G&wQEmkS3"
 GEODB_DB=postgres
 HOST_GEODB_PORT=5434
-
-####################
-# Logging settings
-####################
 
 # Sentry DSN. Missing value disables Sentry logging. Can be found on https://opengisch.sentry.io/settings/projects/qfieldcloud/keys/ .
 # DEFAULT: <NO VALUE>
@@ -244,10 +142,6 @@ MEMCACHED_PORT=11211
 LOG_DIRECTORY=/tmp
 TMP_DIRECTORY=/tmp
 
-####################
-# Mail settings
-####################
-
 ACCOUNT_EMAIL_VERIFICATION=optional
 EMAIL_HOST=smtp4dev
 EMAIL_USE_TLS=False
@@ -256,6 +150,66 @@ EMAIL_PORT=25
 EMAIL_HOST_USER=user
 EMAIL_HOST_PASSWORD=password
 DEFAULT_FROM_EMAIL="webmaster@localhost"
+
+# Docker compose default network also used by the docker in docker workers
+# If empty value, a default name will be generated at build time, for example `qfieldcloud_default`.
+# QFIELDCLOUD_DEFAULT_NETWORK=""
+
+# Admin URI. Requires slash in the end. Please use something that is hard to guess.
+QFIELDCLOUD_ADMIN_URI=admin/
+
+# QFieldCloud URL used within the worker as configuration for qfieldcloud-sdk
+QFIELDCLOUD_WORKER_QFIELDCLOUD_URL=http://app:8000/api/v1/
+
+# number of parallel workers
+# DEFAULT: 1
+QFIELDCLOUD_WORKER_REPLICAS=1
+
+# QFieldCloud subscription model
+# DEFAULT: subscription.Subscription
+QFIELDCLOUD_SUBSCRIPTION_MODEL=subscription.Subscription
+
+# QFieldCloud auth token expiration hours. For example 720 hours (30 days).
+# DEFAULT: 720
+QFIELDCLOUD_AUTH_TOKEN_EXPIRATION_HOURS=720
+
+# Whether QFieldCloud should be translated in another language other than English.
+# NOTE if there is no full translation in given language, QFieldCloud will be shown in mixture of English and the given language. Also installed Django modules have their own translations that might not be complete.
+# VALUES: 0 - English only; 1 - enable other languages
+# DEFAULT: 1
+QFIELDCLOUD_USE_I18N=1
+
+# QFieldCloud default language that is displayed in the interface
+# DEFAULT: "en"
+QFIELDCLOUD_DEFAULT_LANGUAGE="en"
+
+# QFieldCloud default timezone that is used when account has no timezone
+# DEFAULT: "Europe/Zurich"
+QFIELDCLOUD_DEFAULT_TIME_ZONE="Europe/Zurich"
+
+# QFieldCloud QGIS image name to be used as worker by the `worker_wrapper`.
+# If empty value, a default name will be generated at build time, for example `qfieldcloud-qgis`.
+# DEFAULT: ""
+# QFIELDCLOUD_QGIS_IMAGE_NAME=""
+
+# QFieldCloud `libqfieldsync` volume path to be mounted by the `worker_wrapper` into `worker` containers.
+# If empty value or invalid value, the pip installed version defined in `requirements_libqfieldsync.txt` will be used.
+# DEFAULT: ""
+QFIELDCLOUD_LIBQFIELDSYNC_VOLUME_PATH=""
+
+# QFieldCloud SDK volume path to be mounted by the `worker_wrapper` into `worker` containers.
+# If empty value or invalid value, the pip installed version defined in `requirements_libqfieldsync.txt` will be used.
+# DEFAULT: ""
+QFIELDCLOUD_QFIELDCLOUD_SDK_VOLUME_PATH=""
+
+# The Django development port. Not used in production.
+# DEFAULT: 8011
+DJANGO_DEV_PORT=8011
+
+GUNICORN_TIMEOUT_S=300
+GUNICORN_MAX_REQUESTS=300
+GUNICORN_WORKERS=3
+GUNICORN_THREADS=3
 
 # Not used in production.
 # DEFAULT: 8012
@@ -268,3 +222,23 @@ SMTP4DEV_SMTP_PORT=25
 # Not used in production.
 # DEFAULT: 143
 SMTP4DEV_IMAP_PORT=143
+
+# Prefix used by docker compose for each of the containers, e.g. app will be `qfieldcloud_app`
+# DEFAULT: qfieldcloud
+COMPOSE_PROJECT_NAME=qfieldcloud
+
+# List of docker compose files
+# DEFAULT: docker-compose.yml:docker-compose.override.local.yml
+COMPOSE_FILE=docker-compose.yml:docker-compose.override.local.yml:docker-compose.override.standalone.yml
+
+# Separator in `COMPOSE_FILE` between filenames. Required for making COMPOSE_FILE above cross-platform (do not change)
+# DEFAULT: :
+COMPOSE_PATH_SEPARATOR=:
+
+# Debugpy port used for the `app` service
+# DEFAULT: 5678
+DEBUG_DEBUGPY_APP_PORT=5678
+
+# Debugpy port used for the `worker_wrapper` service
+# DEFAULT: 5679
+DEBUG_DEBUGPY_WORKER_WRAPPER_PORT=5679

--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,7 @@ LETSENCRYPT_RSA_KEY_SIZE=4096
 # Set to 1 if you're testing your setup to avoid hitting request limits
 LETSENCRYPT_STAGING=1
 
+# Storage
 
 # Used to define storages in QFieldCloud. Note the contents of this variable is a superset of Django's `STORAGES` setting.
 # NOTE: Note if the `STORAGES` is not available, QFieldCloud will still work with `STORAGE_ACCESS_KEY_ID`, `STORAGE_SECRET_KEY_ID`, `STORAGE_BUCKET_NAME` and `STORAGE_REGION_NAME` from previous QFC versions.
@@ -75,6 +76,10 @@ STORAGES='{
 # NOTE: The value must be a key of the `STORAGES` setting.
 # DEFAULT: ""
 # STORAGES_PROJECT_DEFAULT_STORAGE=
+
+# Configuration for minio access. Needs to be the same as in the STORAGES setting in standalone config.
+STORAGE_ACCESS_KEY_ID=minioadmin
+STORAGE_SECRET_ACCESS_KEY=minioadmin
 
 # Public port to the minio API endpoint. It must match the configured port in `STORAGE_ENDPOINT_URL`.
 # NOTE: active only when minio is the configured as storage endpoint. Mostly for local development.

--- a/.env.example
+++ b/.env.example
@@ -77,10 +77,11 @@ STORAGES='{
 # DEFAULT: ""
 # STORAGES_PROJECT_DEFAULT_STORAGE=
 
-# Local configuration for minio storage and standalone instances. Uncomment if necessary.
-# Needs to be the same as in the STORAGES setting in standalone config.
-# STORAGE_ACCESS_KEY_ID=minioadmin
-# STORAGE_SECRET_ACCESS_KEY=minioadmin
+# Local admin credentials configuration for minio storage and standalone instances. Uncomment if necessary.
+# NOTE: Needs to be the same as in the `STORAGES` setting in standalone config.
+# DEFAULT: MINIO_ROOT_USER=minioadmin, MINIO_ROOT_PASSWORD=minioadmin
+# MINIO_ROOT_USER=minioadmin
+# MINIO_ROOT_PASSWORD=minioadmin
 
 # Public port to the minio API endpoint. It must match the configured port in `STORAGE_ENDPOINT_URL`.
 # NOTE: active only when minio is the configured as storage endpoint. Mostly for local development.

--- a/.env.example
+++ b/.env.example
@@ -77,9 +77,10 @@ STORAGES='{
 # DEFAULT: ""
 # STORAGES_PROJECT_DEFAULT_STORAGE=
 
-# Configuration for minio access. Needs to be the same as in the STORAGES setting in standalone config.
-STORAGE_ACCESS_KEY_ID=minioadmin
-STORAGE_SECRET_ACCESS_KEY=minioadmin
+# Local configuration for minio storage and standalone instances. Uncomment if necessary.
+# Needs to be the same as in the STORAGES setting in standalone config.
+# STORAGE_ACCESS_KEY_ID=minioadmin
+# STORAGE_SECRET_ACCESS_KEY=minioadmin
 
 # Public port to the minio API endpoint. It must match the configured port in `STORAGE_ENDPOINT_URL`.
 # NOTE: active only when minio is the configured as storage endpoint. Mostly for local development.

--- a/.env.example
+++ b/.env.example
@@ -79,10 +79,14 @@ STORAGES='{
 # DEFAULT: ""
 # STORAGES_PROJECT_DEFAULT_STORAGE=
 
-# Local admin credentials configuration for minio storage and standalone instances. Uncomment if necessary.
+# Local admin username configuration for minio storage in local and standalone instances. Uncomment if necessary.
 # NOTE: Needs to be the same as in the `STORAGES` setting in standalone config.
-# DEFAULT: MINIO_ROOT_USER=minioadmin, MINIO_ROOT_PASSWORD=minioadmin
+# DEFAULT: MINIO_ROOT_USER=minioadmin
 # MINIO_ROOT_USER=minioadmin
+
+# Local admin password configuration for minio storage in local and standalone instances. Uncomment if necessary.
+# NOTE: Needs to be the same as in the `STORAGES` setting in standalone config.
+# DEFAULT: MINIO_ROOT_PASSWORD=minioadmin
 # MINIO_ROOT_PASSWORD=minioadmin
 
 # Public port to the minio API endpoint. It must match the configured port in `STORAGE_ENDPOINT_URL`.

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,39 @@
+####################
+# Debug settings
+####################
+
 # Whether the environment is in debug mode (e.g. Django debug)
 # VALUES: 0 - non debug mode; 1 - debug mode
 # DEFAULT: 1
 DEBUG=1
+
+# Debugpy port used for the `app` service
+# DEFAULT: 5678
+DEBUG_DEBUGPY_APP_PORT=5678
+
+# Debugpy port used for the `worker_wrapper` service
+# DEFAULT: 5679
+DEBUG_DEBUGPY_WORKER_WRAPPER_PORT=5679
+
+# The Django development port. Not used in production.
+# DEFAULT: 8011
+DJANGO_DEV_PORT=8011
+
+####################
+# Deployment settings
+####################
+
+# Prefix used by docker compose for each of the containers, e.g. app will be `qfieldcloud_app`
+# DEFAULT: qfieldcloud
+COMPOSE_PROJECT_NAME=qfieldcloud
+
+# List of docker compose files
+# DEFAULT: docker-compose.yml:docker-compose.override.local.yml
+COMPOSE_FILE=docker-compose.yml:docker-compose.override.local.yml:docker-compose.override.standalone.yml
+
+# Separator in `COMPOSE_FILE` between filenames. Required for making COMPOSE_FILE above cross-platform (do not change)
+# DEFAULT: :
+COMPOSE_PATH_SEPARATOR=:
 
 # Environment where QFieldCloud runs
 # VALUES: `development` - local development; `staging` - staging server; `test` - tests; `production` - production server
@@ -14,7 +46,77 @@ DJANGO_ALLOWED_HOSTS="localhost 127.0.0.1 0.0.0.0 app nginx"
 
 SECRET_KEY=change_me
 
+# Docker compose default network also used by the docker in docker workers
+# If empty value, a default name will be generated at build time, for example `qfieldcloud_default`.
+# QFIELDCLOUD_DEFAULT_NETWORK=""
+
+# Admin URI. Requires slash in the end. Please use something that is hard to guess.
+QFIELDCLOUD_ADMIN_URI=admin/
+
+# QFieldCloud URL used within the worker as configuration for qfieldcloud-sdk
+QFIELDCLOUD_WORKER_QFIELDCLOUD_URL=http://app:8000/api/v1/
+
+# number of parallel workers
+# DEFAULT: 1
+QFIELDCLOUD_WORKER_REPLICAS=1
+
+# QFieldCloud subscription model
+# DEFAULT: subscription.Subscription
+QFIELDCLOUD_SUBSCRIPTION_MODEL=subscription.Subscription
+
+# QFieldCloud auth token expiration hours. For example 720 hours (30 days).
+# DEFAULT: 720
+QFIELDCLOUD_AUTH_TOKEN_EXPIRATION_HOURS=720
+
+# Whether QFieldCloud should be translated in another language other than English.
+# NOTE if there is no full translation in given language, QFieldCloud will be shown in mixture of English and the given language. Also installed Django modules have their own translations that might not be complete.
+# VALUES: 0 - English only; 1 - enable other languages
+# DEFAULT: 1
+QFIELDCLOUD_USE_I18N=1
+
+# QFieldCloud default language that is displayed in the interface
+# DEFAULT: "en"
+QFIELDCLOUD_DEFAULT_LANGUAGE="en"
+
+# QFieldCloud default timezone that is used when account has no timezone
+# DEFAULT: "Europe/Zurich"
+QFIELDCLOUD_DEFAULT_TIME_ZONE="Europe/Zurich"
+
+# QFieldCloud QGIS image name to be used as worker by the `worker_wrapper`.
+# If empty value, a default name will be generated at build time, for example `qfieldcloud-qgis`.
+# DEFAULT: ""
+# QFIELDCLOUD_QGIS_IMAGE_NAME=""
+
+# QFieldCloud `libqfieldsync` volume path to be mounted by the `worker_wrapper` into `worker` containers.
+# If empty value or invalid value, the pip installed version defined in `requirements_libqfieldsync.txt` will be used.
+# DEFAULT: ""
+QFIELDCLOUD_LIBQFIELDSYNC_VOLUME_PATH=""
+
+# QFieldCloud SDK volume path to be mounted by the `worker_wrapper` into `worker` containers.
+# If empty value or invalid value, the pip installed version defined in `requirements_libqfieldsync.txt` will be used.
+# DEFAULT: ""
+QFIELDCLOUD_QFIELDCLOUD_SDK_VOLUME_PATH=""
+
+####################
+# Webserver settings
+####################
+
+WEB_HTTP_PORT=80
+WEB_HTTPS_PORT=443
+
+# Messages are logged at the specified level and all more severe levels. The nginx default is `error`. Read more on https://nginx.org/en/docs/ngx_core_module.html#error_log.
+# OPTIONS: debug, info, notice, warn, error, crit, alert, emerg
+# DEFAULT: error
+NGINX_ERROR_LOG_LEVEL=error
+
+GUNICORN_TIMEOUT_S=300
+GUNICORN_MAX_REQUESTS=300
+GUNICORN_WORKERS=3
+GUNICORN_THREADS=3
+
+####################
 # Certificates
+####################
 
 # TLS certificate filename from within the `nginx` container.
 # For usage with Let's Encrypt certificate, use as:
@@ -99,13 +201,9 @@ MINIO_API_PORT=8009
 # DEFAULT: 8010
 MINIO_BROWSER_PORT=8010
 
-WEB_HTTP_PORT=80
-WEB_HTTPS_PORT=443
-
-# Messages are logged at the specified level and all more severe levels. The nginx default is `error`. Read more on https://nginx.org/en/docs/ngx_core_module.html#error_log.
-# OPTIONS: debug, info, notice, warn, error, crit, alert, emerg
-# DEFAULT: error
-NGINX_ERROR_LOG_LEVEL=error
+####################
+# Database settings
+####################
 
 POSTGRES_USER=qfieldcloud_db_admin
 POSTGRES_PASSWORD=3shJDd2r7Twwkehb
@@ -122,6 +220,10 @@ GEODB_USER=postgres
 GEODB_PASSWORD="KUAa7h!G&wQEmkS3"
 GEODB_DB=postgres
 HOST_GEODB_PORT=5434
+
+####################
+# Logging settings
+####################
 
 # Sentry DSN. Missing value disables Sentry logging. Can be found on https://opengisch.sentry.io/settings/projects/qfieldcloud/keys/ .
 # DEFAULT: <NO VALUE>
@@ -142,6 +244,10 @@ MEMCACHED_PORT=11211
 LOG_DIRECTORY=/tmp
 TMP_DIRECTORY=/tmp
 
+####################
+# Mail settings
+####################
+
 ACCOUNT_EMAIL_VERIFICATION=optional
 EMAIL_HOST=smtp4dev
 EMAIL_USE_TLS=False
@@ -150,66 +256,6 @@ EMAIL_PORT=25
 EMAIL_HOST_USER=user
 EMAIL_HOST_PASSWORD=password
 DEFAULT_FROM_EMAIL="webmaster@localhost"
-
-# Docker compose default network also used by the docker in docker workers
-# If empty value, a default name will be generated at build time, for example `qfieldcloud_default`.
-# QFIELDCLOUD_DEFAULT_NETWORK=""
-
-# Admin URI. Requires slash in the end. Please use something that is hard to guess.
-QFIELDCLOUD_ADMIN_URI=admin/
-
-# QFieldCloud URL used within the worker as configuration for qfieldcloud-sdk
-QFIELDCLOUD_WORKER_QFIELDCLOUD_URL=http://app:8000/api/v1/
-
-# number of parallel workers
-# DEFAULT: 1
-QFIELDCLOUD_WORKER_REPLICAS=1
-
-# QFieldCloud subscription model
-# DEFAULT: subscription.Subscription
-QFIELDCLOUD_SUBSCRIPTION_MODEL=subscription.Subscription
-
-# QFieldCloud auth token expiration hours. For example 720 hours (30 days).
-# DEFAULT: 720
-QFIELDCLOUD_AUTH_TOKEN_EXPIRATION_HOURS=720
-
-# Whether QFieldCloud should be translated in another language other than English.
-# NOTE if there is no full translation in given language, QFieldCloud will be shown in mixture of English and the given language. Also installed Django modules have their own translations that might not be complete.
-# VALUES: 0 - English only; 1 - enable other languages
-# DEFAULT: 1
-QFIELDCLOUD_USE_I18N=1
-
-# QFieldCloud default language that is displayed in the interface
-# DEFAULT: "en"
-QFIELDCLOUD_DEFAULT_LANGUAGE="en"
-
-# QFieldCloud default timezone that is used when account has no timezone
-# DEFAULT: "Europe/Zurich"
-QFIELDCLOUD_DEFAULT_TIME_ZONE="Europe/Zurich"
-
-# QFieldCloud QGIS image name to be used as worker by the `worker_wrapper`.
-# If empty value, a default name will be generated at build time, for example `qfieldcloud-qgis`.
-# DEFAULT: ""
-# QFIELDCLOUD_QGIS_IMAGE_NAME=""
-
-# QFieldCloud `libqfieldsync` volume path to be mounted by the `worker_wrapper` into `worker` containers.
-# If empty value or invalid value, the pip installed version defined in `requirements_libqfieldsync.txt` will be used.
-# DEFAULT: ""
-QFIELDCLOUD_LIBQFIELDSYNC_VOLUME_PATH=""
-
-# QFieldCloud SDK volume path to be mounted by the `worker_wrapper` into `worker` containers.
-# If empty value or invalid value, the pip installed version defined in `requirements_libqfieldsync.txt` will be used.
-# DEFAULT: ""
-QFIELDCLOUD_QFIELDCLOUD_SDK_VOLUME_PATH=""
-
-# The Django development port. Not used in production.
-# DEFAULT: 8011
-DJANGO_DEV_PORT=8011
-
-GUNICORN_TIMEOUT_S=300
-GUNICORN_MAX_REQUESTS=300
-GUNICORN_WORKERS=3
-GUNICORN_THREADS=3
 
 # Not used in production.
 # DEFAULT: 8012
@@ -222,23 +268,3 @@ SMTP4DEV_SMTP_PORT=25
 # Not used in production.
 # DEFAULT: 143
 SMTP4DEV_IMAP_PORT=143
-
-# Prefix used by docker compose for each of the containers, e.g. app will be `qfieldcloud_app`
-# DEFAULT: qfieldcloud
-COMPOSE_PROJECT_NAME=qfieldcloud
-
-# List of docker compose files
-# DEFAULT: docker-compose.yml:docker-compose.override.local.yml
-COMPOSE_FILE=docker-compose.yml:docker-compose.override.local.yml:docker-compose.override.standalone.yml
-
-# Separator in `COMPOSE_FILE` between filenames. Required for making COMPOSE_FILE above cross-platform (do not change)
-# DEFAULT: :
-COMPOSE_PATH_SEPARATOR=:
-
-# Debugpy port used for the `app` service
-# DEFAULT: 5678
-DEBUG_DEBUGPY_APP_PORT=5678
-
-# Debugpy port used for the `worker_wrapper` service
-# DEFAULT: 5679
-DEBUG_DEBUGPY_WORKER_WRAPPER_PORT=5679

--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,9 @@ LETSENCRYPT_RSA_KEY_SIZE=4096
 # Set to 1 if you're testing your setup to avoid hitting request limits
 LETSENCRYPT_STAGING=1
 
-# Storage
+####################
+# Storage settings
+####################
 
 # Used to define storages in QFieldCloud. Note the contents of this variable is a superset of Django's `STORAGES` setting.
 # NOTE: Note if the `STORAGES` is not available, QFieldCloud will still work with `STORAGE_ACCESS_KEY_ID`, `STORAGE_SECRET_KEY_ID`, `STORAGE_BUCKET_NAME` and `STORAGE_REGION_NAME` from previous QFC versions.

--- a/docker-compose.override.standalone.yml
+++ b/docker-compose.override.standalone.yml
@@ -50,8 +50,8 @@ services:
       - minio_data3:/data3
       - minio_data4:/data4
     environment:
-      MINIO_ROOT_USER: ${STORAGE_ACCESS_KEY_ID}
-      MINIO_ROOT_PASSWORD: ${STORAGE_SECRET_ACCESS_KEY}
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
       MINIO_BROWSER_REDIRECT_URL: http://${QFIELDCLOUD_HOST}:${MINIO_BROWSER_PORT}
     command: server /data{1...4} --console-address :9001
     healthcheck:


### PR DESCRIPTION
When upgrading my QFieldCloud instance I noticed, that `STORAGE_ACCESS_KEY_ID` and `STORAGE_SECRET_ACCESS_KEY` has been removed from `.env.example`. As this is fine for development it is required for the standalone config and should also stay in the config to be able to change the credentials.

It is not perfect, that the credentials are now redundant and also used in `STORAGES` but I don't see a solution for that. 

Thanks for your great work :)