### PR TITLE
Update minio createbuckets

### DIFF
--- a/docker-createbuckets/Dockerfile
+++ b/docker-createbuckets/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:noble
 
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y \
     curl \
-    python3 \
-    && rm -rf /var/lib/apt/lists/*
+    python3
 
 RUN curl https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2025-02-18T16-25-55Z.fips -o /usr/bin/mc
 RUN chmod +x /usr/bin/mc

--- a/docker-createbuckets/Dockerfile
+++ b/docker-createbuckets/Dockerfile
@@ -1,12 +1,12 @@
-FROM ubuntu:noble-20241015
+FROM ubuntu:latest
 
 RUN apt-get update \
-    && apt-get upgrade -y \
     && apt-get install -y \
     curl \
-    python3
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN curl https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2024-11-17T19-35-25Z.fips -o /usr/bin/mc
+RUN curl https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2025-02-18T16-25-55Z.fips -o /usr/bin/mc
 RUN chmod +x /usr/bin/mc
 
 COPY ./createbuckets.py /createbuckets.py

--- a/docker-createbuckets/Dockerfile
+++ b/docker-createbuckets/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:noble
 
 RUN apt-get update \
     && apt-get install -y \

--- a/docker-createbuckets/Dockerfile
+++ b/docker-createbuckets/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
     curl \
     python3
 
-RUN curl https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2025-02-18T16-25-55Z.fips -o /usr/bin/mc
+RUN curl https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2025-03-12T17-29-24Z -o /usr/bin/mc
 RUN chmod +x /usr/bin/mc
 
 COPY ./createbuckets.py /createbuckets.py


### PR DESCRIPTION
When upgrading my QFieldCloud instance, I noticed, that minio wasn't updated in the whole project. 

It is not an issue, but it is better to use the same version, I think.

But I think it would be great to update the base image.

Here are different things possible:

1. use python as base image
2. use python as base image and use minio library to get rid of the mc subprocesses
3. stay at ubuntu as is

Further, I noticed that there is also a newer version of minio, which I cloud also update. 

Please let me know which of the possibilities you would prefer and I can implement it.

Thanks for your great work :)
