### PR TITLE
Fixed wrong query in dequeue script leading to the same jobs being picked by multiple worker wrappers

### DIFF
--- a/docker-app/qfieldcloud/core/management/commands/dequeue.py
+++ b/docker-app/qfieldcloud/core/management/commands/dequeue.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand
 from django.db import connection, transaction
+from django.db.models import Q
 from qfieldcloud.core.models import Job
 from worker_wrapper.wrapper import (
     DeltaApplyJobRun,
@@ -75,9 +76,9 @@ class Command(BaseCommand):
                     Job.objects.select_for_update(skip_locked=True)
                     .filter(status=Job.Status.PENDING)
                     .exclude(
-                        project_id__in=busy_projects_ids_qs,
+                        Q(project_id__in=busy_projects_ids_qs)
                         # skip all projects that are currently locked, most probably because of file transfer
-                        project__is_locked=True,
+                        | Q(project__is_locked=True),
                     )
                     .order_by("created_at")
                 )


### PR DESCRIPTION

The observed error looks like this:
```
worker_wrapper-10  | {"ts":"12:26:43.487080","level":"INFO","name":"root","message":"Dequeued job de71eaa9-37c5-419c-a763-093b96904485, run!","filename":"dequeue.py","lineno":90,"thread":139638455768896,"source":"worker_wrapper"}
worker_wrapper-10  | {"ts":"12:26:43.500372","level":"WARNING","name":"worker_wrapper.wrapper","message":"Concurrent jobs occured for job ProcessProjectfileJob object (de71eaa9-37c5-419c-a763-093b96904485).","filename":"wrapper.py","lineno":136,"thread":139638455768896,"source":"worker_wrapper"}
worker_wrapper-1   | {"ts":"12:26:42.523750","level":"INFO","name":"root","message":"Dequeued job de71eaa9-37c5-419c-a763-093b96904485, run!","filename":"dequeue.py","lineno":90,"thread":140571515266880,"source":"worker_wrapper"}
worker_wrapper-1   | {"ts":"12:26:42.538148","level":"WARNING","name":"worker_wrapper.wrapper","message":"Concurrent jobs occured for job ProcessProjectfileJob object (de71eaa9-37c5-419c-a763-093b96904485).","filename":"wrapper.py","lineno":136,"thread":140571515266880,"source":"worker_wrapper"}
```

A very good protection and detection mechanism, which does not allow the two parallel runs to happen, which causes the WARNING log above.

The error was introduced when `Project.is_locked` was introduced and filtered out from the dequeue. Unfortunately it was overlooked AND condition while it had to be OR.