### PR TITLE
Fix: Do not require useraccount for teams during autocomplete

### DIFF
--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -26,7 +26,10 @@ from typing import Any
 
 
 def get_avatar_url(user: User, request: Request | None = None) -> str | None:
-    if not user.useraccount.avatar:
+    if user.type == user.Type.TEAM:
+        return None
+
+    if not hasattr(user, "useraccount") or not user.useraccount.avatar:
         return None
 
     filename = user.useraccount.avatar.name

--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -29,7 +29,7 @@ def get_avatar_url(user: User, request: Request | None = None) -> str | None:
     if user.type == user.Type.TEAM:
         return None
 
-    if not hasattr(user, "useraccount") or not user.useraccount.avatar:
+    if not user.useraccount.avatar:
         return None
 
     filename = user.useraccount.avatar.name


### PR DESCRIPTION
This PR fixes the error encountered during autocomplete when adding teams as collaborators. The error “Team has no useraccount” occurred because the `get_avatar_url` method was attempting to access a non-existent `useraccount` attribute on team objects. The autocomplete endpoint (`/api/v1/users/?q=<search>&project=<project-id>`) returns both regular users and teams. Since teams do not have a useraccount, accessing it in the avatar URL helper was causing errors. This update ensures teams are correctly handled by simply returning `None` for their avatar URL.

Error Message: "Team has no useraccount."

**Changes**

- Added a type check to return `None` for avatar URLs when the object is a team (`user.type == user.Type.TEAM`), ensuring that teams no longer trigger an error by trying to access a `useraccount`.
- The fix only adjusts the behavior in the serialization process, maintaining existing API logic and endpoints (no breaking changes).

**After the change**
![image](https://github.com/user-attachments/assets/2ed76557-8709-49a5-9eac-1fc19aa194b9)

