### PR TITLE
Ignore `AuthenticationViaTokenFailedError` in sentry reports

### DIFF
--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -339,6 +339,7 @@ if SENTRY_DSN:
             ProjectAlreadyExistsError,
             ValidationError,
         )
+        from qfieldcloud.core.exceptions import AuthenticationViaTokenFailedError
         from qfieldcloud.subscription.exceptions import (
             InactiveSubscriptionError,
             PlanInsufficientError,
@@ -358,6 +359,8 @@ if SENTRY_DSN:
             UnsupportedMediaType,
             # Purely a client error
             MethodNotAllowed,
+            # the client sent invalid authentication token, the user should fix his token
+            AuthenticationViaTokenFailedError,
         )
 
         if "exc_info" in hint:


### PR DESCRIPTION
The client sent invalid authentication token, the user should fix his token.