### PR TITLE
Move smtp4dev from standalone to local

### DIFF
--- a/docker-compose.override.local.yml
+++ b/docker-compose.override.local.yml
@@ -47,6 +47,22 @@ services:
     ports:
       - "${MEMCACHED_PORT}:11211"
 
+  smtp4dev:
+    image: rnwood/smtp4dev:v3
+    restart: always
+    ports:
+      # Web interface
+      - ${SMTP4DEV_WEB_PORT}:80
+      # SMTP server
+      - ${SMTP4DEV_SMTP_PORT}:25
+      # IMAP
+      - ${SMTP4DEV_IMAP_PORT}:143
+    volumes:
+        - smtp4dev_data:/smtp4dev
+    environment:
+      # Specifies the server hostname. Used in auto-generated TLS certificate if enabled.
+      - ServerOptions__HostName=smtp4dev
+
   qgis:
     volumes:
       # allow local development for `docker-qgis`
@@ -56,3 +72,6 @@ services:
       - ./docker-qgis/libqfieldsync:/libqfieldsync:ro
       # allow local development for `qfieldcloud-sdk-python` if host directory present; requires `PYTHONPATH=/qfieldcloud-sdk-python:${PYTHONPATH}`
       - ./docker-qgis/qfieldcloud-sdk-python:/qfieldcloud-sdk-python:ro
+
+volumes:
+  smtp4dev_data:

--- a/docker-compose.override.standalone.yml
+++ b/docker-compose.override.standalone.yml
@@ -25,22 +25,6 @@ services:
     ports:
       - ${HOST_GEODB_PORT}:5432
 
-  smtp4dev:
-    image: rnwood/smtp4dev:v3
-    restart: always
-    ports:
-      # Web interface
-      - ${SMTP4DEV_WEB_PORT}:80
-      # SMTP server
-      - ${SMTP4DEV_SMTP_PORT}:25
-      # IMAP
-      - ${SMTP4DEV_IMAP_PORT}:143
-    volumes:
-        - smtp4dev_data:/smtp4dev
-    environment:
-      # Specifies the server hostname. Used in auto-generated TLS certificate if enabled.
-      - ServerOptions__HostName=smtp4dev
-
   minio:
     image: minio/minio:RELEASE.2025-02-18T16-25-55Z
     restart: unless-stopped
@@ -82,7 +66,6 @@ services:
 volumes:
   postgres_data:
   geodb_data:
-  smtp4dev_data:
   minio_data1:
   minio_data2:
   minio_data3:


### PR DESCRIPTION
Hi everyone, working on qfieldcloud. 

I want to propose to move the smtp4dev configuration in the overrides from "standalone" to "local".

I my mind, the standalone override is for self-hosted standalone instances, where there is no requirement for smtp4dev.

smtp4dev is required for development, when the local override should be used for. 

I'm unsure if smtp4dev is used in any tests. 

If the change is fine, i would also add some more documentation for self-hosted instances.


