### PR TITLE
Docker: Add memcached restart: unless-stopped policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,6 +187,7 @@ services:
 
   memcached:
     image: memcached:1
+    restart: unless-stopped
     expose:
       - "11211:11211"
 


### PR DESCRIPTION
@suricactus seems when rebooting the server i.e. restarting docker daemon the memcached does not come up automatically on our infra and then the worker_wrapper hangs in restart loop

! This seems to help in our case at least but I let it up to you to check necessity for QFC classic