### PR TITLE
Fix potential assertion error when resending a confirmation email

### DIFF
--- a/docker-app/qfieldcloud/core/views/accounts_views.py
+++ b/docker-app/qfieldcloud/core/views/accounts_views.py
@@ -35,7 +35,9 @@ def resend_confirmation_email(request: HttpRequest) -> HttpResponse:
     if request.method != "POST":
         return redirect_to_referer_or_view(request, "account_login")
 
-    assert "account_verified_email" in request.session
+    if "account_verified_email" not in request.session:
+        messages.error(request, _("No email found."))
+        return redirect_to_referer_or_view(request, "account_login")
 
     email_address = request.session["account_verified_email"]
 


### PR DESCRIPTION
This PR fixes a potential assertion error raised when resending a confirmation email, in case the mail key is missing from the session.