### PR TITLE
Delete previous thumbnails versions on s3 when updating project thumbnail

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -16,7 +16,6 @@ from django.contrib.auth.models import AbstractUser
 from django.contrib.auth.models import UserManager as DjangoUserManager
 from django.contrib.gis.db import models
 from django.core.exceptions import ValidationError
-from django.core.files.storage import storages
 from django.core.validators import (
     FileExtensionValidator,
     MaxValueValidator,
@@ -1582,16 +1581,6 @@ class Project(models.Model):
             self.storage_keep_versions >= 1
         ), "If 0, storage_keep_versions mean that all file versions are deleted!"
 
-        # check if thumbnail has changed, delete previous versions if so.
-        if not self.uses_legacy_storage and self.pk:
-            try:
-                old_instance = Project.objects.get(pk=self.pk)
-                if old_instance.thumbnail and old_instance.thumbnail != self.thumbnail:
-                    self.delete_previous_thumbnails_versions()
-            except Project.DoesNotExist:
-                # Project does not exist yet
-                pass
-
         super().save(*args, **kwargs)
 
     def get_file(self, filename: str) -> File:
@@ -1601,36 +1590,6 @@ class Project(models.Model):
         files = filter(lambda f: f.latest.name == filename, self.legacy_files)
 
         return next(files)
-
-    def delete_previous_thumbnails_versions(self, keep_last: bool = True) -> None:
-        """
-        Deletes previous thumbnails versions of a project on S3.
-        """
-
-        s3_storage = storages[self.file_storage]
-        s3_bucket = s3_storage.bucket  # type: ignore[attr-defined]
-        s3_client = s3_bucket.meta.client
-        thumbnail_key = get_project_thumbnail_upload_to(self, self.thumbnail.name)
-
-        # get all stored versions of this key
-        versions = s3_client.list_object_versions(
-            Bucket=s3_bucket.name, Prefix=thumbnail_key
-        )
-
-        if "Versions" in versions:
-            version_sorted = sorted(
-                versions["Versions"], key=lambda v: v["LastModified"]
-            )
-
-            if len(version_sorted) > 0 and keep_last:
-                version_sorted = version_sorted[:-1]
-
-            for version in version_sorted:
-                s3_client.delete_object(
-                    Bucket=s3_bucket.name,
-                    Key=thumbnail_key,
-                    VersionId=version["VersionId"],
-                )
 
 
 class ProjectCollaboratorQueryset(models.QuerySet):

--- a/docker-app/qfieldcloud/core/utils2/storage.py
+++ b/docker-app/qfieldcloud/core/utils2/storage.py
@@ -15,6 +15,7 @@ from typing import IO
 
 from django.conf import settings
 from django.core.files.base import ContentFile
+from django.core.files.storage import storages
 from django.db import transaction
 from django.http import FileResponse, HttpRequest
 from django.http.response import HttpResponse, HttpResponseBase
@@ -443,6 +444,59 @@ def delete_project_thumbnail(
         raise RuntimeError(f"Suspicious S3 deletion of project thumbnail image {key=}")
 
     _delete_by_key_permanently(key)
+
+
+def purge_previous_thumbnails_versions(
+    project: qfieldcloud.core.models.Project,
+) -> None:
+    bucket = storages[project.file_storage].bucket  # type: ignore
+    prefix = project.thumbnail.name
+
+    if not prefix:
+        return
+
+    thumbnail_files = list(
+        qfieldcloud.core.utils.list_files_with_versions(bucket, prefix)
+    )
+
+    if len(thumbnail_files) == 0:
+        logger.info(f'No thumbnail found to delete for project "{project.id}"!')
+        return
+
+    assert len(thumbnail_files) == 1
+
+    thumbnail_file = thumbnail_files[0]
+
+    # we only keep 1 version of the thumbnail file.
+    # otherwise we hit the limit of 1000.
+    keep_count = 1
+
+    old_versions_to_purge = sorted(
+        thumbnail_file.versions, key=lambda v: v.last_modified, reverse=True
+    )[keep_count:]
+
+    # Remove the N oldest
+    for old_version in old_versions_to_purge:
+        logger.info(
+            f'Purging {old_version.key=} {old_version.id=} as old version for "{thumbnail_file.latest.name}"...'
+        )
+
+        if old_version.is_latest:
+            # This is not supposed to happen, as versions were sorted above,
+            # but leaving it here as a security measure in case version
+            # ordering changes for some reason.
+            raise Exception("Trying to delete latest version")
+
+        if not old_version.key or not re.match(
+            r"^projects/[\w]{8}(-[\w]{4}){3}-[\w]{12}/meta/thumbnail.png$",
+            old_version.key,
+        ):
+            raise RuntimeError(
+                f"Suspicious S3 file version deletion {old_version.key=} {old_version.id=}"
+            )
+        # TODO: any way to batch those ? will probaby get slow on production
+        delete_version_permanently(old_version)
+        # TODO: audit ? take implementation from files_views.py:211
 
 
 @legacy_only

--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -625,6 +625,10 @@ class ProcessProjectfileJobRun(JobRun):
             )
         )
 
+        # for non-legacy storage, keep only one thumbnail version if so.
+        if not project.uses_legacy_storage and project.thumbnail:
+            storage.purge_previous_thumbnails_versions(project)
+
     def after_docker_exception(self) -> None:
         project = self.job.project
 


### PR DESCRIPTION
This PR makes QFC delete previous thumbnails versions of a project, when updating the project's thumbnail.

Thus avoiding multiple and important amount of s3 file versions for thumbnails, when versioning is enabled on a s3 storage.