### PR TITLE
[CI] Fix CI docker image build tagging on tag event

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -67,8 +67,8 @@ jobs:
           tags: |
             type=ref,enable=true,priority=600,prefix=pr-,suffix=,event=pr
             type=sha,format=short,prefix=commit-,event=pr
-            type=semver,pattern={{version}},event=release
-            type=edge,branch=main
+            type=match,pattern=v(.*),group=1
+            type=edge,branch=master
 
       -
         name: Login to GitHub Container Repository (ghcr.io)


### PR DESCRIPTION
Since the new QFieldCloud versioning has been setup, the build image are not tagged correctly using the version number, since those versions are not [semver](https://semver.org/) compliant.

Spotted in [this action run](https://github.com/opengisch/QFieldCloud/actions/runs/14118362595): ` Warning: v25.5 is not a valid semver. More info: https://semver.org/`.

It is possible to see the tagged version on dockerhub:

- before versioning change -> 0.32.5: present -> https://hub.docker.com/r/opengisch/qfieldcloud-app/tags?name=0.32.5
- now -> 25.5: empty -> https://hub.docker.com/r/opengisch/qfieldcloud-app/tags?name=25.5

The output of the [`docker-metadata` action](https://github.com/docker/metadata-action) needs to be fixed.

It is not possible to use [metadata's `type=semver`](https://github.com/docker/metadata-action?tab=readme-ov-file#typesemver) anymore. Proposed solution is to tag and push the build images on the GitHub `tag` event, using metadata's `type=ref` combined with `event=tag`, which should give us an image tagged with `v25.6`, [according to docker-metadata's documentation](https://github.com/docker/metadata-action?tab=readme-ov-file#typeref).

Open to discussions regarding this approach.