### PR TITLE
Build and push createbuckets docker image

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -45,6 +45,12 @@ jobs:
             docker_context: docker-nginx
             enable_dockerhub: true
 
+          -
+            service_name: createbuckets
+            dockerfile: docker-createbuckets/Dockerfile
+            docker_context: docker-createbuckets
+            enable_dockerhub: true
+
     steps:
       -
         name: Checkout


### PR DESCRIPTION
Since the recent storage changes, the docker image used to create the buckets for local instances is not the `minio/mc` anymore, but a specific one that is built using a Dockerfile in the `docker-createbuckets` folder of the QFieldCloud repository.

This PR sets up the CI to build and push a `qfieldcloud-createbuckets` image to the hub, using the same way as the other built images (app, nginx, worker_wrapper, qgis).