### PR TITLE
Fix incorrect key usage in kwargs.pop() for filename extraction

### DIFF
--- a/docker-app/qfieldcloud/filestorage/views.py
+++ b/docker-app/qfieldcloud/filestorage/views.py
@@ -295,7 +295,7 @@ def compatibility_project_meta_file_read_view(
         # rename the `project_id` to previously used `projectid`, so we don't change anything in the legacy code
         kwargs["projectid"] = kwargs.pop("project_id")
         # hardcode the thumbnail file name
-        kwargs["filename"] = kwargs.pop("thumbnail.png")
+        kwargs["filename"] = "thumbnail.png"
 
         logger.debug(
             f"Project {project_id=} will be using the legacy file management for meta files."


### PR DESCRIPTION
This PR addresses a bug where `kwargs.pop("thumbnail.png")` was mistakenly using a literal string as a key in projects where `legacy_storage` is used.

**Impact** 
Using the wrong key caused the function to raise a KeyError, breaking the thumbnail processing logic. This fix ensures the correct file is handled.