### PR TITLE
Customize auth providers buttons by overriding allauth's template

### DIFF
--- a/docker-app/qfieldcloud/core/staticfiles/css/sso.css
+++ b/docker-app/qfieldcloud/core/staticfiles/css/sso.css
@@ -1,0 +1,23 @@
+/* SSO providers buttons */
+.provider-button-parent {
+    list-style: none;
+    margin: 0 1em 1em 0;
+    padding: 0;
+  }
+
+  .provider-button {
+    border-radius: .25rem;
+    padding: .5rem;
+  }
+
+  .provider-button img {
+    margin-right: 1em;
+    width: 50px;
+    height: 50px;
+  }
+
+  .provider-button span {
+    font-size: larger;
+    margin-bottom: 0;
+  }
+  /* /SSO providers buttons */

--- a/docker-app/qfieldcloud/core/templates/allauth/elements/provider.html
+++ b/docker-app/qfieldcloud/core/templates/allauth/elements/provider.html
@@ -1,0 +1,13 @@
+<li class="provider-button-parent">
+
+    <a title="{{ attrs.name }}" href="{{ attrs.href }}">
+        <div class="provider-button" style="border: 1px solid {{ attrs.styles.light.color_stroke|default:"grey" }}; background-color: {{ attrs.styles.light.color_fill|default:"white" }}">
+
+            <img src="{{ attrs.styles.light.logo }}" alt="{{ attrs.name }}">
+            <span>
+                <strong style="color: {{ attrs.styles.light.color_text|default:"black" }}">{{ attrs.name }}</strong>
+            </span>
+
+        </div>
+    </a>
+</li>

--- a/docker-app/qfieldcloud/core/templates/socialaccount/snippets/provider_list.html
+++ b/docker-app/qfieldcloud/core/templates/socialaccount/snippets/provider_list.html
@@ -1,5 +1,9 @@
 {% load allauth socialaccount %}
 {% get_providers as socialaccount_providers %}
+
+{% load static %}
+<link rel="stylesheet" type="text/css" href="{% static 'css/sso.css' %}">
+
 {% if socialaccount_providers %}
     {% element provider_list %}
         {% for provider in socialaccount_providers %}


### PR DESCRIPTION
This PR customizes the display of the SSO providers buttons, in the login page.

![image](https://github.com/user-attachments/assets/a040049e-182d-41a9-bf80-6a8ea6d6cfe1)

Logic consists of overriding allauth's `provider.html` template, with style being configured in the `QFIELDCLOUD_SSO_PROVIDER_STYLES` settings variable (fill, stroke, text color + svg icon).

Since the QFieldCloud jazzmin UI is light, the `light` styles are being used at the moment.

Approach is to use a css file for non-dynamic style properties.