### PR TITLE
Customize reset password from key page

### DIFF
--- a/docker-app/qfieldcloud/core/templates/account/password_reset_from_key.html
+++ b/docker-app/qfieldcloud/core/templates/account/password_reset_from_key.html
@@ -22,17 +22,18 @@
 
         <p class="card-text">
           {% url 'account_reset_password' as passwd_reset_url %}
-          {% blocktrans %}The password reset link was invalid, possibly because it has already been used. Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}
+          {% blocktrans %}
+            The password reset link was invalid, possibly because it has already been used. Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.
+          {% endblocktrans %}
         </p>
-
       {% else %}
-
         {% if form %}
-
           <p class="card-text">
             {% url 'account_login' as login_url %}
-            {% blocktrans with login_url=login_url %}Please enter the newly chosen secure password in the form below.<br>
-            If you happened to remember the old password, please go back to the <a href="{{ login_url }}">sign-in form</a>.{% endblocktrans %}
+            {% blocktrans with login_url=login_url %}
+              Please enter the newly chosen secure password in the form below.<br />
+              If you happened to remember the old password, please go back to the <a href="{{ login_url }}">sign-in form</a>.
+            {% endblocktrans %}
           </p>
           <form method="POST" action="{{ action_url }}">
             {% csrf_token %}

--- a/docker-app/qfieldcloud/core/templates/account/password_reset_from_key.html
+++ b/docker-app/qfieldcloud/core/templates/account/password_reset_from_key.html
@@ -1,0 +1,54 @@
+{% extends 'admin/base_site.html' %}
+{% load i18n static %}
+{% load bootstrap4 %}
+
+{% block title %}
+  {% trans 'Change Password' %}
+{% endblock %}
+
+{% block content %}
+  <div class="card">
+    <div class="card-body">
+
+      <h5 class="card-title mb-3">
+        {% if token_fail %}
+          {% trans 'Bad Token' %}
+        {% else %}
+          {% trans 'Change Password' %}
+        {% endif %}
+      </h5>
+
+      {% if token_fail %}
+
+        <p class="card-text">
+          {% url 'account_reset_password' as passwd_reset_url %}
+          {% blocktrans %}The password reset link was invalid, possibly because it has already been used. Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}
+        </p>
+
+      {% else %}
+
+        {% if form %}
+
+          <p class="card-text">
+            {% url 'account_login' as login_url %}
+            {% blocktrans with login_url=login_url %}Please enter the newly chosen secure password in the form below.<br>
+            If you happened to remember the old password, please go back to the <a href="{{ login_url }}">sign-in form</a>.{% endblocktrans %}
+          </p>
+          <form method="POST" action="{{ action_url }}">
+            {% csrf_token %}
+
+            {% bootstrap_form form %}
+
+            <button class="btn btn-primary" type="submit" name="action">{% trans 'Change password' %}</button>
+          </form>
+
+        {% else %}
+          <p>
+            {% trans 'Your password is now changed.' %}
+          </p>
+        {% endif %}
+
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}

--- a/docker-app/qfieldcloud/core/templates/account/password_reset_from_key_done.html
+++ b/docker-app/qfieldcloud/core/templates/account/password_reset_from_key_done.html
@@ -1,0 +1,18 @@
+{% extends 'admin/base_site.html' %}
+{% load i18n static %}
+
+{% block title %}
+  {% trans 'Change Password Complete' %}
+{% endblock %}
+
+{% block content %}
+  <div class="card">
+    <div class="card-body">
+      <h5 class="card-title mb-3">{% trans 'Change Password' %}</h5>
+      <p class="card-text">
+        {% url 'account_login' as login_url %}
+        {% blocktrans with login_url=login_url %}The password is now changed. Use the password on the <a href="{{ login_url }}">sign-in form</a>.{% endblocktrans %}
+      </p>
+    </div>
+  </div>
+{% endblock %}

--- a/docker-app/qfieldcloud/core/templates/account/password_reset_from_key_done.html
+++ b/docker-app/qfieldcloud/core/templates/account/password_reset_from_key_done.html
@@ -11,7 +11,9 @@
       <h5 class="card-title mb-3">{% trans 'Change Password' %}</h5>
       <p class="card-text">
         {% url 'account_login' as login_url %}
-        {% blocktrans with login_url=login_url %}The password is now changed. Use the password on the <a href="{{ login_url }}">sign-in form</a>.{% endblocktrans %}
+        {% blocktrans with login_url=login_url %}
+          The password is now changed. Use the password on the <a href="{{ login_url }}">sign-in form</a>.
+        {% endblocktrans %}
       </p>
     </div>
   </div>


### PR DESCRIPTION
This PR customizes the "reset password from key" page, by overriding allauth's `password_reset_from_key.html` and `password_reset_from_key_done.html` templates.

Such a page is generated an loads when opening a link generated with the `Generate reset password URL` action.

Before this PR, the page was not customized so the page looked like raw HTML.

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/4a1d1dc8-5dea-4571-b94d-74410626ed98) | ![image](https://github.com/user-attachments/assets/f45c45fe-60a1-4b18-aa83-536ca71f9fe3) |



After having changed the password:

![image](https://github.com/user-attachments/assets/f3b59ffe-9b07-45b0-a1dc-0eac745930eb)
