### PR TITLE
Fix downloading package files from projects with multiple packages

### DIFF
--- a/docker-app/qfieldcloud/core/views/package_views.py
+++ b/docker-app/qfieldcloud/core/views/package_views.py
@@ -355,6 +355,7 @@ class LatestPackageDownloadFilesView(views.APIView):
             project_id,
             filename,
             file_type=file_type,
+            package_job_id=project.last_package_job_id,
         )
 
 

--- a/docker-app/qfieldcloud/filestorage/models.py
+++ b/docker-app/qfieldcloud/filestorage/models.py
@@ -49,7 +49,7 @@ class File(models.Model):
         related_name="files",
     )
 
-    package_job_id: int
+    package_job_id: UUID
     package_job = models.ForeignKey(
         Job,
         on_delete=models.DO_NOTHING,


### PR DESCRIPTION
Basically we need to filter not only by file type, name and version id, but when the file_type is PACKAGE, we also need to filter by package_job_id.

_Follow up of #1183 , which was merged then reverted._