### PR TITLE
Fix user-defined environment variables not being passed to the QGIS worker

### DIFF
--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -301,6 +301,7 @@ class JobRun:
             settings.QFIELDCLOUD_QGIS_IMAGE_NAME,
             command,
             environment={
+                **extra_envvars,
                 "PGSERVICE_FILE_CONTENTS": pgservice_file_contents,
                 "QFIELDCLOUD_TOKEN": token.key,
                 "QFIELDCLOUD_URL": settings.QFIELDCLOUD_WORKER_QFIELDCLOUD_URL,

--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -303,6 +303,7 @@ class JobRun:
             environment={
                 **extra_envvars,
                 "PGSERVICE_FILE_CONTENTS": pgservice_file_contents,
+                "QFIELDCLOUD_EXTRA_ENVVARS": json.dumps(sorted(extra_envvars.keys())),
                 "QFIELDCLOUD_TOKEN": token.key,
                 "QFIELDCLOUD_URL": settings.QFIELDCLOUD_WORKER_QFIELDCLOUD_URL,
                 "JOB_ID": self.job_id,

--- a/docker-qgis/qfc_worker/utils.py
+++ b/docker-qgis/qfc_worker/utils.py
@@ -152,6 +152,10 @@ def start_app() -> str:
     """
     global QGISAPP
 
+    extra_envvars = os.environ.get("QFIELDCLOUD_EXTRA_ENVVARS")
+
+    logging.info(f"Available user defined environment variables: {extra_envvars}")
+
     if QGISAPP is None:
         logging.info(
             f"Starting QGIS app version {Qgis.versionInt()} ({Qgis.devVersion()})..."

--- a/docker-qgis/qfc_worker/utils.py
+++ b/docker-qgis/qfc_worker/utils.py
@@ -152,7 +152,7 @@ def start_app() -> str:
     """
     global QGISAPP
 
-    extra_envvars = os.environ.get("QFIELDCLOUD_EXTRA_ENVVARS")
+    extra_envvars = os.environ.get("QFIELDCLOUD_EXTRA_ENVVARS", "[]")
 
     logging.info(f"Available user defined environment variables: {extra_envvars}")
 


### PR DESCRIPTION
Basically the title. The envvars defined as secrets were always intended to be passed to the worker. We finally do it.