### PR TITLE
Remove types from docstrings, we can get them from PEP484 typing and retire `List` etc

### DIFF
--- a/docker-app/qfieldcloud/authentication/auth_backends.py
+++ b/docker-app/qfieldcloud/authentication/auth_backends.py
@@ -30,7 +30,7 @@ class AuthenticationBackend(AllAuthAuthenticationBackend):
         """Almost the same as `contrib.auth.backends.ModelBackend`, but not using the default manager, but the normal `objects` manager
 
         Returns:
-            Person | Organization | Team | None: In theory it can return any of these types, however it will always be a `Person` or `None`
+            In theory it can return any of `Person` | `Organization` | `Team` | `None` types, however it will always be a `Person` or `None`
         """
         UserModel = get_user_model()
 

--- a/docker-app/qfieldcloud/core/drf_utils.py
+++ b/docker-app/qfieldcloud/core/drf_utils.py
@@ -24,10 +24,10 @@ class QfcOrderingFilter(filters.OrderingFilter):
         This method should be used to search a term from a query's ordering fields.
 
         Args:
-            fields (list[str]): list of fields to search
-            term (str): term to search in the list
+            fields: list of fields to search
+            term: term to search in the list
         Returns:
-            str | None: the matching field, if present in the list
+            the matching field, if present in the list
         """
         for field in fields:
             compare_value = field
@@ -47,9 +47,9 @@ class QfcOrderingFilter(filters.OrderingFilter):
         """Parses an ordering field attributes expression.
 
         Args:
-            raw (str): raw expression to parse, e.g.: "alias=my_field_alias,key=value"
+            raw: raw expression to parse, e.g.: "alias=my_field_alias,key=value"
         Returns:
-            dict[str, str]: dict containing the expression's attributes
+            dict containing the expression's attributes
         """
         definition_attrs = raw.split(self.TOKENS_LIST_SEPARATOR)
 
@@ -64,10 +64,11 @@ class QfcOrderingFilter(filters.OrderingFilter):
         """Parses a custom ordering field with attributes expression.
 
         Args:
-            definition (str): raw definition of the ordering field to parse,
+            definition: raw definition of the ordering field to parse,
                 e.g.: "my_field::alias=my_field_alias,key=value"
-        Returns :
-            tuple[str, dict[str, str]]: tuple containing the field name (1st) and its attributes dict (2nd)
+
+        Returns:
+            tuple containing the field name (1st) and its attributes dict (2nd)
         """
         name, attr_str = definition.split(self.SEPARATOR, 1)
         attrs = self._parse_tokenized_attributes(attr_str)
@@ -88,12 +89,12 @@ class QfcOrderingFilter(filters.OrderingFilter):
         but `my_field` is the real model field.
 
         Args:
-            queryset (QuerySet): Django's ORM queryset of the same model as the one used in view of the `ModelViewSet`
-            fields (Iterable[str]): ordering fields passed to the HTTP querystring
-            view (APIView): DRF view instance
-            request (HttpRequest): DRF request instance
+            queryset: Django's ORM queryset of the same model as the one used in view of the `ModelViewSet`
+            fields: ordering fields passed to the HTTP querystring
+            view: DRF view instance
+            request: DRF request instance
         Returns :
-            list[str]: parsed ordering fields where aliases have been replaced
+            parsed ordering fields where aliases have been replaced
         """
         base_fields = super().remove_invalid_fields(queryset, fields, view, request)
         valid_fields = []

--- a/docker-app/qfieldcloud/core/invitations_utils.py
+++ b/docker-app/qfieldcloud/core/invitations_utils.py
@@ -100,7 +100,7 @@ def send_invitation(invite, **kwargs):
     """Sends invitation.
 
     Args:
-        invite (Invitation): the invitation to be sent
+        invite: the invitation to be sent
 
     The same as the original Invitation.send_invitation, but without passing the request object.
     https://github.com/bee-keeper/django-invitations/blob/invitations/models.py#L42

--- a/docker-app/qfieldcloud/core/management/commands/deleteorphanedfiles.py
+++ b/docker-app/qfieldcloud/core/management/commands/deleteorphanedfiles.py
@@ -1,5 +1,4 @@
 import uuid
-from typing import Set
 
 from django.core.management.base import BaseCommand
 from qfieldcloud.core import utils
@@ -14,7 +13,7 @@ class Command(BaseCommand):
         parser.add_argument("--dry-run", action="store_true")
         parser.add_argument("--limit", type=int, default=100)
 
-    def get_orphaned_project_ids(self, project_ids: Set[str]) -> Set[str]:
+    def get_orphaned_project_ids(self, project_ids: set[str]) -> set[str]:
         orphaned_project_ids = set()
         existing_project_ids = Project.objects.filter(
             id__in=list(project_ids),

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -200,10 +200,10 @@ class UserManager(InheritanceManagerMixin, DjangoUserManager):
         """Searches a user by `username` or `email` field
 
         Args:
-            username_or_email (str): username or email to search for
+            username_or_email: username or email to search for
 
         Returns:
-            User: The user with that username or email.
+            The user with that username or email.
         """
         return self.get(Q(username=username_or_email) | Q(email=username_or_email))
 
@@ -229,10 +229,10 @@ class User(AbstractUser):
     """User model. Used as base for organizations and teams too.
 
     Args:
-        AbstractUser (AbstractUser): the django's abstract user base
+        the django's abstract user base
 
     Returns:
-        User: the user instance
+        the user instance
 
     Note:
         If you add validators in the constructor, note they will be added multiple times for each class that extends User.
@@ -717,8 +717,8 @@ class Organization(User):
         Active users are users triggering a job or pushing a delta on a project owned by the organization.
 
         Args:
-            period_since (datetime): inclusive beginning of the interval
-            period_until (datetime): inclusive end of the interval
+            period_since: inclusive beginning of the interval
+            period_until: inclusive end of the interval
         """
         assert period_since
         assert period_until
@@ -1029,7 +1029,7 @@ def get_project_file_storage_default() -> str:
     """Get the default file storage for the newly created project
 
     Returns:
-        str: the name of the storage
+        the name of the storage
     """
     return settings.STORAGES_PROJECT_DEFAULT_STORAGE
 
@@ -1227,7 +1227,7 @@ class Project(models.Model):
         """Determine the storage versions to keep based on the owner's subscription plan and project settings.
 
         Returns:
-            int: the number of file versions, should be always greater than 1
+            the number of file versions, should be always greater than 1
         """
         subscription = self.owner.useraccount.current_subscription
 
@@ -1287,7 +1287,7 @@ class Project(models.Model):
         neither the extraction from the projectfile, nor the configuration in QFieldSync are implemented.
 
         Returns:
-            list[str]: A list configured attachment dirs for the project.
+            A list configured attachment dirs for the project.
         """
         attachment_dirs = []
 
@@ -1930,7 +1930,7 @@ class Job(models.Model):
         The version number would be in `Major.Minor.Patch-NAME` format, e.g. 3.40.2-Bratislava
 
         Returns:
-            str | None: QGIS version if found else None.
+            QGIS version if found else None.
         """
         if not self.feedback:
             return None
@@ -1967,10 +1967,10 @@ class Job(models.Model):
         """Extract a step data of a job's feedback.
 
         Args:
-            step_name (str): name of the step to extract data from.
+            step_name: name of the step to extract data from.
 
         Returns:
-            dict[str, Any] | None: data as dict if the step has been found, else None.
+            data as dict if the step has been found, else None.
         """
         if isinstance(self.feedback, dict):
             steps: list[dict[str, Any]] = self.feedback.get("steps", [])

--- a/docker-app/qfieldcloud/core/tests/test_jobs.py
+++ b/docker-app/qfieldcloud/core/tests/test_jobs.py
@@ -42,12 +42,12 @@ class QfcTestCase(APITransactionTestCase):
         """Upload a file to QFieldCloud using API.
 
         Args:
-            project (Project): project that should contain the file.
-            local_filename (str): name of the local file to upload, should be in `testdata` folder.
-            remote_filename (str): name of the uploaded file.
+            project: project that should contain the file.
+            local_filename: name of the local file to upload, should be in `testdata` folder.
+            remote_filename: name of the uploaded file.
 
         Returns:
-            Response: response to the POST HTTP request.
+            response to the POST HTTP request.
         """
         file_path = testdata_path(local_filename)
         response = self.client.post(

--- a/docker-app/qfieldcloud/core/utils.py
+++ b/docker-app/qfieldcloud/core/utils.py
@@ -379,11 +379,11 @@ def get_project_files(project_id: str, path: str = "") -> list[S3Object]:
     """Returns a list of files and their versions.
 
     Args:
-        project_id (str): the project id
-        path (str): additional filter prefix
+        project_id: the project id
+        path: additional filter prefix
 
     Returns:
-        list[S3ObjectWithVersions]: the list of files
+        the list of files
 
     Todo:
         * Delete with QF-4963 Drop support for legacy storage
@@ -401,10 +401,10 @@ def get_project_files_with_versions(
     """Returns a generator of files and their versions.
 
     Args:
-        project_id (str): the project id
+        project_id: the project id
 
     Returns:
-        Generator[S3ObjectWithVersions]: the list of files
+        the list of files
 
     Todo:
         * Delete with QF-4963 Drop support for legacy storage
@@ -421,10 +421,10 @@ def get_project_file_with_versions(
     """Returns a list of files and their versions.
 
     Args:
-        project_id (str): the project id
+        project_id: the project id
 
     Returns:
-        list[S3ObjectWithVersions]: the list of files
+        the list of files
 
     Todo:
         * Delete with QF-4963 Drop support for legacy storage
@@ -445,10 +445,10 @@ def get_project_package_files(project_id: str, package_id: str) -> list[S3Object
     """Returns a list of package files.
 
     Args:
-        project_id (str): the project id
+        project_id: the project id
 
     Returns:
-        list[S3ObjectWithVersions]: the list of package files
+        the list of package files
 
     Todo:
         * Delete with QF-4963 Drop support for legacy storage

--- a/docker-app/qfieldcloud/core/utils2/delta_utils.py
+++ b/docker-app/qfieldcloud/core/utils2/delta_utils.py
@@ -11,9 +11,9 @@ def generate_deltafile(
     The given deltas must be an iterable with at least one element.
 
     Args:
-        deltas (Iterable[dict[str, Any]]): deltas in the deltafile
-        project_id (UUID): project ID
-        id (UUID): deltafile UUID
+        deltas: deltas in the deltafile
+        project_id: project ID
+        id: deltafile UUID
     """
     deltas = list(deltas)
     deltafile = {

--- a/docker-app/qfieldcloud/core/utils2/projects.py
+++ b/docker-app/qfieldcloud/core/utils2/projects.py
@@ -12,12 +12,12 @@ def create_collaborator(
     """Creates a new collaborator (qfieldcloud.core.ProjectCollaborator) if possible
 
     Args:
-        project (Project): the project to add collaborator to
-        user (Person | Team): the user to be added as collaborator
-        created_by (Person): the user that initiated the collaborator creation
+        project: the project to add collaborator to
+        user: the user to be added as collaborator
+        created_by: the user that initiated the collaborator creation
 
     Returns:
-        tuple[bool, str]: success, message - whether the collaborator creation was success and explanation message of the outcome
+        success, message - whether the collaborator creation was success and explanation message of the outcome
     """
     success, message = False, ""
     user_type_name = "Team" if isinstance(user, Team) else "User"
@@ -58,12 +58,12 @@ def create_collaborator_by_username_or_email(
     """Creates a new collaborator (qfieldcloud.core.ProjectCollaborator) if possible
 
     Args:
-        project (Project): the project to add collaborator to
-        user (str): the username or email to be added as collaborator or invited to join QFieldCloud
-        created_by (Person): the user that initiated the collaborator creation
+        project: the project to add collaborator to
+        user: the username or email to be added as collaborator or invited to join QFieldCloud
+        created_by: the user that initiated the collaborator creation
 
     Returns:
-        tuple[bool, str]: success, message - whether the collaborator creation was success and explanation message of the outcome
+        success, message - whether the collaborator creation was success and explanation message of the outcome
     """
     success, message = False, ""
     users = list(

--- a/docker-app/qfieldcloud/core/utils2/storage.py
+++ b/docker-app/qfieldcloud/core/utils2/storage.py
@@ -59,7 +59,7 @@ def _delete_by_prefix_versioned(prefix: str):
     In other words, it is a soft delete. Read more here: https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeletingObjectVersions.html
 
     Args:
-        prefix (str): Object's prefix to search and delete. Check the given prefix if it matches the expected format before using this function!
+        prefix: Object's prefix to search and delete. Check the given prefix if it matches the expected format before using this function!
 
     Raises:
         RuntimeError: When the given prefix is not a string, empty string or leading slash. Check is very basic, do a throrogh checks before calling!
@@ -87,7 +87,7 @@ def _delete_by_prefix_permanently(prefix: str):
     In other words, it is a hard delete. Read more here: https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeletingObjectVersions.html
 
     Args:
-        prefix (str): Object's prefix to search and delete. Check the given prefix if it matches the expected format before using this function!
+        prefix: Object's prefix to search and delete. Check the given prefix if it matches the expected format before using this function!
 
     Raises:
         RuntimeError: When the given prefix is not a string, empty string or leading slash. Check is very basic, do a throrogh checks before calling!
@@ -113,7 +113,7 @@ def _delete_by_key_versioned(key: str):
     In other words, it is a soft delete.
 
     Args:
-        key (str): Object's key to search and delete. Check the given key if it matches the expected format before using this function!
+        key: Object's key to search and delete. Check the given key if it matches the expected format before using this function!
 
     Raises:
         RuntimeError: When the given key is not a string, empty string or leading slash. Check is very basic, do a throrogh checks before calling!
@@ -150,7 +150,7 @@ def _delete_by_key_permanently(key: str):
     In other words, it is a hard delete.
 
     Args:
-        key (str): Object's key to search and delete. Check the given key if it matches the expected format before using this function!
+        key: Object's key to search and delete. Check the given key if it matches the expected format before using this function!
 
     Raises:
         RuntimeError: When the given key is not a string, empty string or leading slash. Check is very basic, do a throrogh checks before calling!
@@ -226,11 +226,11 @@ def get_attachment_dir_prefix(
     """Returns the attachment dir where the file belongs to or empty string if it does not.
 
     Args:
-        project (Project): project to check
-        filename (str): filename to check
+        project: project to check
+        filename: filename to check
 
     Returns:
-        str: the attachment dir or empty string if no match found
+        the attachment dir or empty string if no match found
     """
     for attachment_dir in project.attachment_dirs:
         if filename.startswith(attachment_dir):
@@ -327,12 +327,12 @@ def upload_user_avatar(
     NOTE this function does NOT modify the `UserAccount.legacy_avatar_uri` field
 
     Args:
-        user (User):
-        file (IO): file used as avatar
-        mimetype (ImageMimeTypes): file mimetype
+        user:
+        file: file used as avatar
+        mimetype: file mimetype
 
     Returns:
-        str: URI to the avatar
+        URI to the avatar
 
     Todo:
         * Delete with QF-4963 Drop support for legacy storage
@@ -355,7 +355,7 @@ def delete_user_avatar(user: qfieldcloud.core.models.User) -> None:  # noqa: F82
     NOTE this function does NOT modify the `UserAccount.legacy_avatar_uri` field
 
     Args:
-        user (User):
+        user:
 
     Todo:
         * Delete with QF-4963 Drop support for legacy storage
@@ -385,13 +385,13 @@ def upload_project_thumbail(
     NOTE this function does NOT modify the `Project.thumbnail_uri` field
 
     Args:
-        project (Project):
-        file (IO): file used as thumbail
-        mimetype (str): file mimetype
-        filename (str): filename
+        project:
+        file: file used as thumbail
+        mimetype: file mimetype
+        filename: filename
 
     Returns:
-        str: URI to the thumbnail
+        URI to the thumbnail
 
     Todo:
         * Delete with QF-4963 Drop support for legacy storage
@@ -588,7 +588,7 @@ def delete_all_project_files_permanently(project_id: str) -> None:
     """Deletes all project files permanently.
 
     Args:
-        project_id (str): the project which files shall be deleted. Note that the `project_id` might be a of a already deleted project which files are still dangling around.
+        project_id: the project which files shall be deleted. Note that the `project_id` might be a of a already deleted project which files are still dangling around.
 
     Raises:
         RuntimeError: if the produced Object Storage key to delete is not in the right format
@@ -671,13 +671,13 @@ def delete_project_file_version_permanently(
     """Deletes a specific version of given file.
 
     Args:
-        project (Project): project the file belongs to
-        filename (str): filename the version belongs to
-        version_id (str): version id to delete
-        include_older (bool, optional): when True, versions older than the passed `version` will also be deleted. If the version_id is the latest version of a file, this parameter will treated as False. Defaults to False.
+        project: project the file belongs to
+        filename: filename the version belongs to
+        version_id: version id to delete
+        include_older: when True, versions older than the passed `version` will also be deleted. If the version_id is the latest version of a file, this parameter will treated as False. Defaults to False.
 
     Returns:
-        int: the number of versions deleted
+        the number of versions deleted
 
     Todo:
         * Delete with QF-4963 Drop support for legacy storage

--- a/docker-app/qfieldcloud/core/views/accounts_views.py
+++ b/docker-app/qfieldcloud/core/views/accounts_views.py
@@ -15,11 +15,11 @@ def redirect_to_referer_or_view(
     this will create a redirection to a default view.
 
     Args:
-        request (HttpRequest): incoming client request.
-        view_name (str): name of the view to redirect to.
+        request: incoming client request.
+        view_name: name of the view to redirect to.
 
     Returns:
-        HttpResponseRedirect: client redirect http response.
+        client redirect http response.
     """
     referer = request.headers.get("referer", "")
     if url_has_allowed_host_and_scheme(referer, allowed_hosts=settings.ALLOWED_HOSTS):

--- a/docker-app/qfieldcloud/filestorage/migrate_project_storage.py
+++ b/docker-app/qfieldcloud/filestorage/migrate_project_storage.py
@@ -28,9 +28,9 @@ def migrate_project_storage(
     """Migrates project storage from the old s3 version-enabled storage to platform independent `django-storages`-based file handling.
 
     Args:
-        project (Project): Target project to be migrated
-        to_storage (str): Target storage to migrate to
-        force (bool, optional): Overwrite the target storage if the project files already exist by deleting all objects with the project id prefix. Defaults to False.
+        project: Target project to be migrated
+        to_storage: Target storage to migrate to
+        force: Overwrite the target storage if the project files already exist by deleting all objects with the project id prefix. Defaults to False.
     """
     logger.info(f'Migrating project "{project.name}" ({str(project.id)})...')
 

--- a/docker-app/qfieldcloud/filestorage/models.py
+++ b/docker-app/qfieldcloud/filestorage/models.py
@@ -151,19 +151,19 @@ class FileVersionQueryset(models.QuerySet):
         This method runs in a transaction. It creates/updates a `File` object and creates a new `FileVersion` object.
 
         Args:
-            project (Project): the project the file belongs to
-            filename (str): the filename
-            content (ContentFile): the file content
-            file_type (File.FileType): the file type
-            uploaded_by (User): the `User` that uploaded the file
-            uploaded_at (datetime | None, optional): the timestamp when the file has been uploaded. When `None`, the value is set to the current timestamp. Defaults to None.
-            created_at (datetime | None, optional): the timestamp when the file has been created. When `None`, the value is set to the current timestamp. Defaults to None.
-            version_id (UUID | None, optional): The uuid to be used assigned to that version. When `None`, the value is a new random UUID4. This argument is used to move from legacy versioned object storage to the new `django-storages` version. Defaults to None.
-            package_job_id (UUID | None, optional): The package job the file belongs to. Defaults to None.
-            legacy_version_id (str | None, optional): The object storage version ID from the legacy storage. Defaults to None.
+            project: the project the file belongs to
+            filename: the filename
+            content: the file content
+            file_type: the file type
+            uploaded_by: the `User` that uploaded the file
+            uploaded_at: the timestamp when the file has been uploaded. When `None`, the value is set to the current timestamp. Defaults to None.
+            created_at: the timestamp when the file has been created. When `None`, the value is set to the current timestamp. Defaults to None.
+            version_id: The uuid to be used assigned to that version. When `None`, the value is a new random UUID4. This argument is used to move from legacy versioned object storage to the new `django-storages` version. Defaults to None.
+            package_job_id: The package job the file belongs to. Defaults to None.
+            legacy_version_id: The object storage version ID from the legacy storage. Defaults to None.
 
         Returns:
-            FileVersion: the file version that has been created
+            the file version that has been created
         """
         now = timezone.now()
 

--- a/docker-app/qfieldcloud/filestorage/utils.py
+++ b/docker-app/qfieldcloud/filestorage/utils.py
@@ -43,10 +43,10 @@ def is_valid_filename(filename: str) -> bool:
     """Whether the provided filename is valid.
 
     Args:
-        filename (str): the filename to be checked
+        filename: the filename to be checked
 
     Returns:
-        bool: the filename is valid
+        the filename is valid
     """
     try:
         validate_filename(filename)
@@ -73,11 +73,11 @@ def is_admin_restricted_file(filename: str, projectfile_filename: str | None) ->
     NOTE If no `projectfile_filename` is passed, then the function always returns `False`.
 
     Args:
-        filename (str): the filename being checked
-        projectfile_filename (str | None): the filename of the QGIS projectfile. If not provided, the function always returns `False`.
+        filename: the filename being checked
+        projectfile_filename: the filename of the QGIS projectfile. If not provided, the function always returns `False`.
 
     Returns:
-        bool: whether the file is restricted file
+        whether the file is restricted file
     """
     if not projectfile_filename:
         return False
@@ -115,11 +115,11 @@ def calc_etag(file: ContentFile, part_size: int = 8 * 1024 * 1024) -> str:
     See the inspiration of this implementation here: https://stackoverflow.com/a/58239738/1226137
 
     Args:
-        file (str): the file to calculate etag for
-        part_size (int): the size of the Object Storage part. Most Object Storages use 8MB. Defaults to 8*1024*1024.
+        file: the file to calculate etag for
+        part_size: the size of the Object Storage part. Most Object Storages use 8MB. Defaults to 8*1024*1024.
 
     Returns:
-        str: the calculated ETag value
+        the calculated ETag value
     """
     if file.size <= part_size:
         BLOCKSIZE = 65536

--- a/docker-app/qfieldcloud/filestorage/view_helpers.py
+++ b/docker-app/qfieldcloud/filestorage/view_helpers.py
@@ -284,8 +284,8 @@ def delete_project_file_version(
     The version can be passed either with `version` query parameter or `x-file-version` header.
 
     Args:
-        request (Request): The Django request
-        filename (str): The filename to be deleted
+        request: The Django request
+        filename: The filename to be deleted
 
     Raises:
         Exception: Raised when the passed `version` will delete the only `FileVersion` remaining for that file.

--- a/docker-app/qfieldcloud/filestorage/views.py
+++ b/docker-app/qfieldcloud/filestorage/views.py
@@ -151,12 +151,12 @@ class FileCrudView(views.APIView):
         The check is done anyways when we search for a file.
 
         Args:
-            request (Request): the DRF request
-            project_id (UUID): the project UUID
-            filename (str): the filename to delete
+            request: the DRF request
+            project_id: the project UUID
+            filename: the filename to delete
 
         Returns:
-            Response: empty response with 204
+            empty response with 204
         """
         delete_project_file_version(request, project_id, filename)
 

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -377,7 +377,7 @@ class SubscriptionQuerySet(models.QuerySet):
         """Returns all subscriptions that are managed by given `user_id`. It means the owner personal account and all organizations they own.
 
         Args:
-            user_id (int): the user we are searching against
+            user_id: the user we are searching against
         """
         if not user_id:
             # NOTE: for logged out AnonymousUser the user_id is None
@@ -636,7 +636,7 @@ class AbstractSubscription(models.Model):
         self,
         package_type: PackageType,
         quantity: int,
-        active_since: datetime = None,
+        active_since: datetime | None = None,
     ):
         if not self.plan.is_premium:
             raise NotPremiumPlanException(
@@ -687,10 +687,10 @@ class AbstractSubscription(models.Model):
         """Returns the current subscription, if not exists returns a newly created subscription with the default plan.
 
         Args:
-            account (UserAccount): the account the subscription belongs to.
+            account: the account the subscription belongs to.
 
         Returns:
-            Self: the current subscription
+            the current subscription
 
         TODO Python 3.11 the actual return type is Self
         """
@@ -720,10 +720,10 @@ class AbstractSubscription(models.Model):
         """Updates the subscription properties.
 
         Args:
-            subscription (Subscription): subscription to be updated
+            subscription: subscription to be updated
 
         Returns:
-            Self: the same as the subscription argument
+            the same as the subscription argument
 
         TODO Python 3.11 the actual return type is Self
         """
@@ -764,11 +764,11 @@ class AbstractSubscription(models.Model):
         """Creates the default subscription for a given account.
 
         Args:
-            account (UserAccount): the account the subscription belongs to.
-            active_since (datetime): active since for the subscription
+            account: the account the subscription belongs to.
+            active_since: active since for the subscription
 
         Returns:
-            Self: the created subscription.
+            the created subscription.
 
         TODO Python 3.11 the actual return type is Self
         """
@@ -810,13 +810,13 @@ class AbstractSubscription(models.Model):
         """Creates a subscription for a given account to a given plan. If the plan is a trial, create the default subscription in the end of the period.
 
         Args:
-            account (UserAccount): the account the subscription belongs to.
-            plan (Plan): the plan to subscribe to. Note if the the plan is a trial, the first return value would be the trial subscription, otherwise it would be None.
-            created_by (Person): created by.
-            active_since (datetime | None): active since for the subscription.
+            account: the account the subscription belongs to.
+            plan: the plan to subscribe to. Note if the the plan is a trial, the first return value would be the trial subscription, otherwise it would be None.
+            created_by: created by.
+            active_since: active since for the subscription.
 
         Returns:
-            tuple[AbstractSubscription | None, AbstractSubscription]: the created trial subscription if the given plan was a trial and the regular subscription.
+            the created trial subscription if the given plan was a trial and the regular subscription.
 
         TODO Python 3.11 the actual return type is Self
         """

--- a/docker-qgis/qfc_worker/process_projectfile.py
+++ b/docker-qgis/qfc_worker/process_projectfile.py
@@ -132,8 +132,8 @@ def generate_thumbnail(the_qgis_file_name: str, thumbnail_filename: Path) -> Non
     As from https://docs.qgis.org/3.16/en/docs/pyqgis_developer_cookbook/composer.html#simple-rendering
 
     Args:
-        the_qgis_file_name (str)
-        thumbnail_filename (Path)
+        the_qgis_file_name:
+        thumbnail_filename:
     """
     logger.info("Generate project thumbnail image…")
 

--- a/docker-qgis/qfc_worker/utils.py
+++ b/docker-qgis/qfc_worker/utils.py
@@ -17,7 +17,7 @@ import xml.etree.ElementTree as ET
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import IO, Any, Callable, NamedTuple, Optional
+from typing import IO, Any, Callable, NamedTuple
 
 from libqfieldsync.layer import LayerSource
 from libqfieldsync.utils.bad_layer_handler import (
@@ -565,7 +565,7 @@ def has_ping(hostname: str) -> bool:
     return not bool(error) and "100% packet loss" not in out.decode("utf8")
 
 
-def get_layer_filename(layer: QgsMapLayer) -> Optional[str]:
+def get_layer_filename(layer: QgsMapLayer) -> str | None:
     metadata = QgsProviderRegistry.instance().providerMetadata(
         layer.dataProvider().name()
     )
@@ -630,7 +630,7 @@ def json_default(obj):
 
 def run_workflow(
     workflow: Workflow,
-    feedback_filename: Optional[Path | IO],
+    feedback_filename: Path | IO | None,
 ) -> dict[str, Any]:
     """Executes the steps required to run a task and return structured feedback from the execution
 
@@ -972,7 +972,7 @@ class XmlErrorLocation(NamedTuple):
 
 def get_qgis_xml_error_location(
     invalid_token_error_msg: str,
-) -> Optional[XmlErrorLocation]:
+) -> XmlErrorLocation | None:
     """Get column and line numbers from the provided error message."""
     if "invalid token" not in invalid_token_error_msg.casefold():
         return None
@@ -987,7 +987,7 @@ def get_qgis_xml_error_location(
 
 def get_qgis_xml_error_context(
     invalid_token_error_msg: str, fh: io.BufferedReader
-) -> Optional[str]:
+) -> str | None:
     """Get a slice of the line where the exception occurred, with all faulty occurrences sanitized."""
     location = get_qgis_xml_error_location(invalid_token_error_msg)
     if location:

--- a/docker-qgis/qfc_worker/utils.py
+++ b/docker-qgis/qfc_worker/utils.py
@@ -249,7 +249,7 @@ def strip_feature_count_from_project_xml(the_qgis_file_name: str) -> None:
     """Rewrites project XML file with feature count disabled.
 
     Args:
-        the_qgis_file_name (str): filename of the QGIS filename (.qgs or .qgz)
+        the_qgis_file_name: filename of the QGIS filename (.qgs or .qgz)
     """
     archive = None
     xml_file = the_qgis_file_name
@@ -641,8 +641,8 @@ def run_workflow(
     Some return values can used as arguments for next steps, as defined in `public_returns`.
 
     Args:
-        workflow (Workflow): workflow to be executed
-        feedback_filename (IO | Path): write feedback to an IO device, to Path filename, or don't write it
+        workflow: workflow to be executed
+        feedback_filename: write feedback to an IO device, to Path filename, or don't write it
     """
     feedback: dict[str, Any] = {
         "feedback_version": "2.0",

--- a/scripts/check_envvars.py
+++ b/scripts/check_envvars.py
@@ -2,12 +2,11 @@
 import argparse
 import re
 from pathlib import Path
-from typing import Dict, List, Set
 
 import yaml
 
 
-def get_env_varnames_from_envfile(filename: str) -> Set[str]:
+def get_env_varnames_from_envfile(filename: str) -> set[str]:
     result = set()
 
     with open(filename) as f:
@@ -32,7 +31,7 @@ def get_env_varnames_from_envfile(filename: str) -> Set[str]:
         return result
 
 
-def get_env_varnames_from_docker_compose(filename: Path) -> Set[str]:
+def get_env_varnames_from_docker_compose(filename: Path) -> set[str]:
     regex = r"\$\{(\w+)(:-?\w+?)?\}"
     result = set()
 
@@ -49,7 +48,7 @@ def get_env_varnames_from_docker_compose(filename: Path) -> Set[str]:
 
 def get_env_varnames_from_docker_compose_files(
     search_path: str,
-) -> Dict[str, List[str]]:
+) -> dict[str, list[str]]:
     env_vars = {}
 
     for path in Path(search_path).glob("**/docker-compose*.yml"):
@@ -63,7 +62,7 @@ def get_env_varnames_from_docker_compose_files(
     return env_vars
 
 
-def get_env_varnames_from_k8s_kustomization(filename: Path) -> Set[str]:
+def get_env_varnames_from_k8s_kustomization(filename: Path) -> set[str]:
     result = set()
 
     with open(filename) as f:
@@ -75,13 +74,13 @@ def get_env_varnames_from_k8s_kustomization(filename: Path) -> Set[str]:
     return result
 
 
-def get_env_varnames_from_k8s_secrets(filename: Path) -> Set[str]:
+def get_env_varnames_from_k8s_secrets(filename: Path) -> set[str]:
     with open(filename) as f:
         config = yaml.load(f, Loader=yaml.SafeLoader)
         return set(config["spec"]["encryptedData"].keys())
 
 
-def get_env_varnames_from_k8s_environments(search_path: str) -> Dict[str, List[str]]:
+def get_env_varnames_from_k8s_environments(search_path: str) -> dict[str, list[str]]:
     env_vars = {}
 
     for path in Path(search_path).iterdir():


### PR DESCRIPTION
We don't need to repeat ourselves with:
```
def foo(n: int):
  """
  Args:
      n (int): number
  Returns:
      (int): result
  """
```
As modern tools are fine with just:

```
def foo(n: int) -> int:
  """
  Args:
      n: number
  Returns:
      result
  """
```