### PR TITLE
Add webdav storage backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,36 @@ LETSENCRYPT_STAGING=1
 #         "QFC_IS_LEGACY": false
 #     }
 # }
+
+# WebDav storage setup with `bytemark/WebDAV` docker image:
+# NOTE: HTTP basic auth user and password must be the same as the WEBDAV_USERNAME and WEBDAV_PASSWORD env variables.
+# {
+#     "webdav": {
+#         "BACKEND": "qfieldcloud.filestorage.backend.QfcWebDavStorage",
+#         "OPTIONS": {
+#             "webdav_url": "http://qfc_webdav_user:qfc_webdav_pwd@webdav",
+#             "public_url": "http://webdav",
+#             "basic_auth": "qfc_webdav_user:qfc_webdav_pwd"
+#         },
+#         "QFC_IS_LEGACY": false
+#     }
+# }
+
+# WebDav storage setup with an external NextCloud server:
+# NOTE: USERNAME and PASSWORD refer to a user's credentials on the NextCloud server.
+# NOTE: NEXTCLOUD_SHARE_TOKEN refer to a public share token that can be generated from the NextCloud UI.
+# {
+#     "webdav_nextcloud": {
+#         "BACKEND": "qfieldcloud.filestorage.backend.QfcWebDavStorage",
+#         "OPTIONS": {
+#             "webdav_url": "https://USERNAME:PASSWORD@my.nextcloud.server/remote.php/dav/files/USERNAME",
+#             "public_url": "https://my.nextcloud.server/public.php/webdav",
+#             "basic_auth": "NEXTCLOUD_SHARE_TOKEN:"
+#         },
+#         "QFC_IS_LEGACY": false
+#     }
+# }
+
 STORAGES='{
         "default": {
             "BACKEND": "qfieldcloud.filestorage.backend.QfcS3Boto3Storage",
@@ -105,6 +135,26 @@ MINIO_API_PORT=8009
 # NOTE: Ignored if `minio` is not used.
 # DEFAULT: 8010
 MINIO_BROWSER_PORT=8010
+
+# Public port to the webdav server.
+# NOTE: Ignored if `webdav` docker service is not used.
+# DEFAULT: 8020
+WEBDAV_PUBLIC_PORT=8020
+
+# Username of the user in the webdav server.
+# NOTE: Ignored if `webdav` docker service is not used.
+# DEFAULT: qfc_webdav_user
+WEBDAV_USERNAME=qfc_webdav_user
+
+# Password of the user in the webdav server.
+# NOTE: Ignored if `webdav` docker service is not used.
+# DEFAULT: qfc_webdav_pwd
+WEBDAV_PASSWORD=qfc_webdav_pwd
+
+# Comma-separated list of values for the mini WebDAV server names.
+# NOTE: Ignored if `webdav` docker service is not used.
+# DEFAULT: "172.17.0.1,webdav"
+WEBDAV_SERVER_NAMES="172.17.0.1,webdav"
 
 WEB_HTTP_PORT=80
 WEB_HTTPS_PORT=443

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,15 @@ jobs:
                   },
                   "QFC_IS_LEGACY": true
               },
+              "webdav": {
+                  "BACKEND": "qfieldcloud.filestorage.backend.QfcWebDavStorage",
+                  "OPTIONS": {
+                      "webdav_url": "http://qfc_webdav_user:qfc_webdav_pwd@webdav",
+                      "public_url": "http://webdav",
+                      "basic_auth": "qfc_webdav_user:qfc_webdav_pwd"
+                  },
+                  "QFC_IS_LEGACY": false
+              },
               "default": {
                   "BACKEND": "qfieldcloud.filestorage.backend.QfcS3Boto3Storage",
                   "OPTIONS": {

--- a/docker-app/qfieldcloud/core/tests/utils.py
+++ b/docker-app/qfieldcloud/core/tests/utils.py
@@ -1,12 +1,18 @@
 import io
 import os
 import tempfile
+import urllib
 from datetime import timedelta
 from time import sleep
 from typing import IO, Iterable
 
+from django.http import FileResponse, HttpResponse
+from django.urls import reverse
 from django.utils import timezone
+from rest_framework.response import Response
+from rest_framework.test import APITransactionTestCase
 
+from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core.models import Job, Project, User
 from qfieldcloud.subscription.models import Plan, Subscription
 
@@ -148,3 +154,95 @@ def wait_for_project_ok_status(project: Project, wait_s: int = 30):
 
 def fail(msg):
     raise AssertionError(msg or "Test case failed")
+
+
+class QfcFilesTestCase(APITransactionTestCase):
+    """
+    Generic Test case class that is able to perform file operations.
+    E.g. upload, download, delete.
+    """
+
+    def _upload_file(
+        self, user: User, project: Project, filename: str, content: IO
+    ) -> HttpResponse | Response:
+        token = AuthToken.objects.get_or_create(user=user)[0]
+
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
+
+        response = self.client.post(
+            reverse(
+                "filestorage_crud_file",
+                kwargs={
+                    "project_id": project.id,
+                    "filename": filename,
+                },
+            ),
+            {
+                "file": content,
+            },
+        )
+
+        self.client.credentials(HTTP_AUTHORIZATION="")
+
+        return response
+
+    def _download_file(
+        self,
+        user: User,
+        project: Project,
+        filename: str,
+        params: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> HttpResponse | Response | FileResponse:
+        token = AuthToken.objects.get_or_create(user=user)[0]
+
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
+
+        response = self.client.get(
+            reverse(
+                "filestorage_crud_file",
+                kwargs={
+                    "project_id": project.id,
+                    "filename": filename,
+                },
+            ),
+            data=params,
+            headers=headers,
+        )
+
+        self.client.credentials(HTTP_AUTHORIZATION="")
+
+        return response
+
+    def _delete_file(
+        self,
+        user: User,
+        project: Project,
+        filename: str,
+        params: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> HttpResponse | Response:
+        token = AuthToken.objects.get_or_create(user=user)[0]
+
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
+
+        url = reverse(
+            "filestorage_crud_file",
+            kwargs={
+                "project_id": project.id,
+                "filename": filename,
+            },
+        )
+
+        if params is not None:
+            url += "?"
+            url += urllib.parse.urlencode(params)
+
+        response = self.client.delete(
+            url,
+            headers=headers,
+        )
+
+        self.client.credentials(HTTP_AUTHORIZATION="")
+
+        return response

--- a/docker-app/qfieldcloud/core/utils2/storage.py
+++ b/docker-app/qfieldcloud/core/utils2/storage.py
@@ -24,6 +24,7 @@ from mypy_boto3_s3.type_defs import ObjectIdentifierTypeDef
 import qfieldcloud.core.models
 import qfieldcloud.core.utils
 from qfieldcloud.core.utils2.audit import LogEntry, audit
+from qfieldcloud.filestorage.backend import QfcS3Boto3Storage
 
 logger = logging.getLogger(__name__)
 
@@ -449,6 +450,10 @@ def delete_project_thumbnail(
 def purge_previous_thumbnails_versions(
     project: qfieldcloud.core.models.Project,
 ) -> None:
+    # this method applies only to S3 storage
+    if not isinstance(project.file_storage, QfcS3Boto3Storage):
+        return
+
     bucket = storages[project.file_storage].bucket  # type: ignore
     prefix = project.thumbnail.name
 

--- a/docker-app/qfieldcloud/filestorage/backend.py
+++ b/docker-app/qfieldcloud/filestorage/backend.py
@@ -1,5 +1,212 @@
+import base64
+import os
+
+import requests
+from django.core.exceptions import ImproperlyConfigured
+from django.core.files.base import ContentFile
+from django.core.files.storage import Storage
+from django.http import HttpResponse
 from storages.backends.s3boto3 import S3Boto3Storage
 
 
 class QfcS3Boto3Storage(S3Boto3Storage):
-    pass
+    def patch_nginx_download_redirect(self, response: HttpResponse) -> None:
+        """Patches a nginx redirect response for usage with S3.
+        At the moment, does nothing.
+
+        Arguments:
+            response: HTTP redirect response to patch.
+        """
+        pass
+
+
+class QfcWebDavStorage(Storage):
+    """
+    Storage backend using WebDAV.
+    Adapted and inspired by this repository: https://github.com/marazmiki/django-webdav-storage
+    Copyright (c) 2020, Mikhail Porokhovnichenko
+    """
+
+    def __init__(self, **options):
+        self.requests = self.get_requests_session(**options)
+
+        self.webdav_url = options.get("webdav_url")
+        if not self.webdav_url:
+            raise ImproperlyConfigured("Please define the `webdav_url` storage option")
+
+        self.public_url = options.get("public_url")
+        if not self.public_url:
+            raise ImproperlyConfigured("Please define the `public_url` storage option")
+
+        self.basic_auth = options.get("basic_auth")
+        if not self.basic_auth:
+            raise ImproperlyConfigured("Please define the `basic_auth` storage option")
+
+    def get_requests_session(self, **kwargs) -> requests.Session:
+        """
+        Creates a HTTP session for requesting webdav later.
+        """
+        return requests.Session()
+
+    def perform_webdav_request(
+        self, method: str, name: str, *args, **kwargs
+    ) -> requests.Response:
+        """Performs a webdav request.
+
+        Arguments:
+            method: webdav method, e.g. "HEAD", "GET", "PUT", "DELETE", etc.
+            name: relative path of the file on the webdav server.
+
+        Returns:
+            HTTP response related to the sent request.
+        """
+        url = self.get_webdav_url(name)
+        method = method.lower()
+
+        response = getattr(self.requests, method)(url, *args, **kwargs)
+        response.raise_for_status()
+
+        return response
+
+    def get_webdav_url(self, name: str) -> str:
+        """Returns the HTTP url for a webdav file.
+
+        Arguments:
+            name: relative path of the file on the webdav server.
+
+        Returns:
+            HTTP url for the file.
+        """
+        return self.webdav_url.rstrip("/") + "/" + name.lstrip("/")
+
+    def get_public_url(self, name: str) -> str:
+        """Returns the public HTTP url for a webdav file.
+
+        Arguments:
+            name: relative path of the file on the webdav server.
+
+        Returns:
+            Public HTTP url for the file.
+        """
+        return self.public_url.rstrip("/") + "/" + name.lstrip("/")
+
+    def _open(self, name: str, mode: str = "rb") -> ContentFile:
+        """Reads the content of a file from the configured webdav storage.
+
+        Arguments:
+            name: relative path of the file on the webdav server.
+            mode: opening mode (default: "rb").
+
+        Returns:
+            Content of the requested file.
+        """
+        content = self.perform_webdav_request("GET", name).content
+        return ContentFile(content, name)
+
+    def _save(self, name: str, content: ContentFile) -> str:
+        """Saves a file on the configured webdav storage.
+
+        Arguments:
+            name: relative path of the file on the webdav server.
+            content: content of the file to save.
+
+        Returns:
+            relative path of the file on the webdav server.
+        """
+        self.make_collection(name)
+
+        if hasattr(content, "temporary_file_path"):
+            with open(content.temporary_file_path(), "rb") as f:
+                self.perform_webdav_request(method="PUT", name=name, data=f)
+        else:
+            content.file.seek(0)
+            self.perform_webdav_request(method="PUT", name=name, data=content.file)
+
+        return name
+
+    def make_collection(self, name: str) -> None:
+        """Creates a so-called collection on the configured webdav storage for a file.
+        Typically creates parent folders if not existing.
+
+        Arguments:
+            name: relative path of the file on the webdav server.
+        """
+        coll_path = self.webdav_url
+
+        for directory in name.split("/")[:-1]:
+            col = os.path.join(coll_path, directory, "")
+            resp = self.requests.head(col)
+
+            if not resp.ok:
+                resp = self.requests.request("MKCOL", col)
+                resp.raise_for_status()
+
+            coll_path = os.path.join(coll_path, directory)
+
+    def delete(self, name: str) -> None:
+        """Deletes a file from a configured webdav storage.
+
+        Arguments:
+            name: relative path of the file on the webdav server.
+        """
+        try:
+            self.perform_webdav_request("DELETE", name)
+        except requests.HTTPError:
+            pass
+
+    def exists(self, name: str) -> bool:
+        """Checks if a file exists on a configured webdav storage.
+
+        Arguments:
+            name: relative path of the file on the webdav server.
+
+        Returns:
+            True if exists, False if not.
+        """
+        try:
+            self.perform_webdav_request("HEAD", name)
+        except requests.exceptions.HTTPError:
+            return False
+
+        return True
+
+    def size(self, name: str) -> int:
+        """Returns the size of a file on a configured webdav storage.
+
+        Arguments:
+            name: relative path of the file on the webdav server.
+
+        Raises:
+            IOError: if something wrong happens during the network request.
+
+        Returns:
+            Size in bytes of the requested file.
+        """
+        try:
+            return int(
+                self.perform_webdav_request("HEAD", name).headers["content-length"]
+            )
+        except (ValueError, requests.exceptions.HTTPError):
+            raise IOError("Unable get size for %s" % name)
+
+    def url(self, name: str, **kwargs) -> str:  # type: ignore
+        """Returns the URL of a file from the configured webdav storage.
+
+        Arguments:
+            name: relative path of the file on the webdav server.
+
+        Returns:
+            Public webdav URL of the file.
+        """
+        return self.get_public_url(name)
+
+    def patch_nginx_download_redirect(self, response: HttpResponse) -> None:
+        """Patches a nginx redirect response for usage with WebDAV.
+        Adds configured webdav/HTTP basic auth, required for nginx redirect.
+
+        Arguments:
+            response: HTTP redirect response to patch.
+        """
+        b64_auth = base64.b64encode(self.basic_auth.encode()).decode()
+        basic_auth = f"Basic {b64_auth}"
+        response["webdav_auth"] = basic_auth

--- a/docker-app/qfieldcloud/filestorage/tests/test_webdav.py
+++ b/docker-app/qfieldcloud/filestorage/tests/test_webdav.py
@@ -1,0 +1,66 @@
+import logging
+from io import StringIO
+
+from django.http import FileResponse
+from rest_framework import status
+
+from qfieldcloud.authentication.models import AuthToken
+from qfieldcloud.core.models import (
+    Person,
+    Project,
+)
+from qfieldcloud.core.tests.utils import (
+    QfcFilesTestCase,
+    setup_subscription_plans,
+)
+
+logging.disable(logging.CRITICAL)
+
+
+class QfcTestCase(QfcFilesTestCase):
+    def setUp(self):
+        setup_subscription_plans()
+
+        # Create a user
+        self.u1 = Person.objects.create_user(username="u1", password="abc123")
+        self.t1 = AuthToken.objects.get_or_create(user=self.u1)[0]
+        self.p1 = Project.objects.create(
+            owner=self.u1,
+            name="p1",
+            file_storage="webdav",
+        )
+
+    def test_upload_file_succeeds(self):
+        # 1) first upload of the file
+        response = self._upload_file(self.u1, self.p1, "file.name", StringIO("Hello!"))
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(self.p1.files.count(), 1)
+        self.assertEqual(self.p1.get_file("file.name").versions.count(), 1)
+
+        # 2) adding a second version
+        response = self._upload_file(self.u1, self.p1, "file.name", StringIO("Hello2!"))
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(self.p1.files.count(), 1)
+        self.assertEqual(self.p1.get_file("file.name").versions.count(), 2)
+
+    def test_upload_then_download_file_succeeds(self):
+        # 1) first upload of the file
+        self._upload_file(self.u1, self.p1, "file.name", StringIO("Hello!"))
+
+        # 2) download file
+        response = self._download_file(self.u1, self.p1, "file.name")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsInstance(response, FileResponse)
+        self.assertEqual(b"".join(response.streaming_content), b"Hello!")
+
+    def test_upload_then_delete_file_succeeds(self):
+        # 1) first upload of the file
+        self._upload_file(self.u1, self.p1, "file.name", StringIO("Hello!"))
+
+        # 2) delete file
+        response = self._delete_file(self.u1, self.p1, "file.name")
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/docker-app/qfieldcloud/filestorage/view_helpers.py
+++ b/docker-app/qfieldcloud/filestorage/view_helpers.py
@@ -260,6 +260,8 @@ def download_field_file(
         response["X-Accel-Redirect"] = "/storage-download/"
         response["redirect_uri"] = url
 
+        field_file.storage.patch_nginx_download_redirect(response)  # type: ignore
+
         return response
     elif settings.DEBUG or settings.IN_TEST_SUITE:
         return FileResponse(

--- a/docker-app/qfieldcloud/settings_utils.py
+++ b/docker-app/qfieldcloud/settings_utils.py
@@ -14,9 +14,15 @@ class S3StorageOptions(TypedDict):
     endpoint_url: str
 
 
+class WebDavStorageOptions(TypedDict):
+    webdav_url: str
+    public_url: str
+    basic_auth: str
+
+
 class DjangoStorages(TypedDict):
     BACKEND: str
-    OPTIONS: S3StorageOptions
+    OPTIONS: S3StorageOptions | WebDavStorageOptions
     QFC_IS_LEGACY: bool
 
 
@@ -68,9 +74,11 @@ def get_storages_config() -> StoragesConfig:
         if (
             service_config["BACKEND"]
             != "qfieldcloud.filestorage.backend.QfcS3Boto3Storage"
+            and service_config["BACKEND"]
+            != "qfieldcloud.filestorage.backend.QfcWebDavStorage"
         ):
             raise ConfigValidationError(
-                'Envvar `STORAGES[{}][BACKEND]` is expected to be "qfieldcloud.filestorage.backend.QfcS3Boto3Storage", but "{}" given!'.format(
+                'Envvar `STORAGES[{}][BACKEND]` is expected to be "qfieldcloud.filestorage.backend.QfcS3Boto3Storage" or "qfieldcloud.filestorage.backend.QfcWebDavStorage", but "{}" given!'.format(
                     service_name, service_config["BACKEND"]
                 )
             )

--- a/docker-compose.override.standalone.yml
+++ b/docker-compose.override.standalone.yml
@@ -79,6 +79,19 @@ services:
     environment:
       STORAGES: ${STORAGES}
 
+  webdav:
+    image: bytemark/webdav:2.4
+    restart: unless-stopped
+    ports:
+      - ${WEBDAV_PUBLIC_PORT}:80
+    environment:
+      AUTH_TYPE: Basic
+      USERNAME: ${WEBDAV_USERNAME}
+      PASSWORD: ${WEBDAV_PASSWORD}
+      SERVER_NAMES: ${WEBDAV_SERVER_NAMES}
+    volumes:
+      - webdav_data:/var/lib/dav
+
 volumes:
   postgres_data:
   geodb_data:
@@ -87,3 +100,4 @@ volumes:
   minio_data2:
   minio_data3:
   minio_data4:
+  webdav_data:

--- a/docker-createbuckets/createbuckets.py
+++ b/docker-createbuckets/createbuckets.py
@@ -23,6 +23,12 @@ STORAGES: dict[str, DjangoStorages] = json.loads(os.environ["STORAGES"])
 
 
 for storage_name, storage_config in STORAGES.items():
+    if storage_config["BACKEND"] != "qfieldcloud.filestorage.backend.QfcS3Boto3Storage":
+        print(
+            f'Skipping storage "{storage_name}" with backend `{storage_config["BACKEND"]}`, no need to create S3 bucket.'
+        )
+        continue
+
     print(f"Creating bucket for: {storage_name}", flush=True)
 
     endpoint_url = storage_config["OPTIONS"]["endpoint_url"]

--- a/docker-nginx/templates/default.conf.template
+++ b/docker-nginx/templates/default.conf.template
@@ -126,7 +126,10 @@ server {
     # Only allow internal redirects
     internal;
 
+    # used for redirecting file requests to storage.
     set $redirect_uri "$upstream_http_redirect_uri";
+    # webdav storage requires a HTTP auth (Basic, mostly).
+    set $webdav_auth "$upstream_http_webdav_auth";
 
     # required DNS
     resolver 8.8.8.8;
@@ -143,7 +146,7 @@ server {
 
     # remove the authorization and the cookie headers
     proxy_set_header Connection '';
-    proxy_set_header Authorization '';
+    proxy_set_header Authorization $webdav_auth;
     proxy_set_header Cookie '';
     proxy_set_header Content-Type '';
     proxy_set_header Accept-Encoding '';


### PR DESCRIPTION
This PR adds a Django storage backend for webdav, adapted and inspired [by this repository](https://github.com/marazmiki/django-webdav-storage).

Allows to use a new storage of type `qfieldcloud.filestorage.backend.QfcWebDAVStorage`, which implements basic methods for storing a project's files on it.

2 webdav server implementations tested:

- NextCloud's webdav.
- `bytemark/webdav` docker image (generic and basic webdav implementation), used for testing.

PR steps:

- [x] add Django webdav backend
- [x] add `bytemark/webdav` service to the test and standalone environment
- [x] add tests for uploading / downloading / deleting files of a project configured with the webdav storage