### PR TITLE
Add filtering capabilities to the /api/v1/projects/ endpoint to fetch project(s) details filtered by user name (and optionally a project name)

### DIFF
--- a/docker-app/qfieldcloud/core/filters.py
+++ b/docker-app/qfieldcloud/core/filters.py
@@ -26,9 +26,16 @@ class ProjectFilterSet(django_filters.FilterSet):
         return queryset
 
     def filter_queryset(self, queryset):
+        include_public = "0"
+        if (
+            "include-public" in self.form.data
+            and self.form.data["include-public"] != ""
+        ):
+            include_public = self.form.data["include-public"]
+
         if "include_public" in self.form.cleaned_data:
-            if not self.form.cleaned_data["include_public"]:
-                self.form.cleaned_data["include_public"] = "0"
+            if self.form.cleaned_data["include_public"] == "":
+                self.form.cleaned_data["include_public"] = include_public
 
         return super().filter_queryset(queryset)
 

--- a/docker-app/qfieldcloud/core/filters.py
+++ b/docker-app/qfieldcloud/core/filters.py
@@ -44,6 +44,7 @@ class ProjectFilterSet(django_filters.FilterSet):
         # since Django does not have a good support for hyphens in field names and it was previously used in the API.
         if "include-public" in self.form.data:
             self.form.cleaned_data["include_public"] = self.form.data["include-public"]
+
         return super().filter_queryset(queryset)
 
     class Meta:

--- a/docker-app/qfieldcloud/core/filters.py
+++ b/docker-app/qfieldcloud/core/filters.py
@@ -1,0 +1,11 @@
+import django_filters
+
+from qfieldcloud.core.models import Project
+
+
+class ProjectFilter(django_filters.FilterSet):
+    owner = django_filters.CharFilter(field_name="owner__username", lookup_expr="exact")
+
+    class Meta:
+        model = Project
+        fields = ["owner", "name"]

--- a/docker-app/qfieldcloud/core/filters.py
+++ b/docker-app/qfieldcloud/core/filters.py
@@ -1,11 +1,37 @@
 import django_filters
+from django.db import models
 
-from qfieldcloud.core.models import Project
+from qfieldcloud.core.models import Project, ProjectQueryset
+
+
+class IncludePublicChoices(models.IntegerChoices):
+    EXCLUDE = 0, "Exclude"
+    INCLUDE = 1, "Include"
 
 
 class ProjectFilterSet(django_filters.FilterSet):
     owner = django_filters.CharFilter(field_name="owner__username", lookup_expr="exact")
+    include_public = django_filters.ChoiceFilter(
+        label="Include public projects",
+        choices=IncludePublicChoices.choices,
+        method="filter_include_public",
+    )
+
+    def filter_include_public(self, queryset, name, value):
+        if value != "1":
+            queryset = queryset.exclude(
+                user_role_origin=ProjectQueryset.RoleOrigins.PUBLIC
+            )
+
+        return queryset
+
+    def filter_queryset(self, queryset):
+        if "include_public" in self.form.cleaned_data:
+            if not self.form.cleaned_data["include_public"]:
+                self.form.cleaned_data["include_public"] = "0"
+
+        return super().filter_queryset(queryset)
 
     class Meta:
         model = Project
-        fields = ["owner", "name"]
+        fields = ["name", "owner", "include_public"]

--- a/docker-app/qfieldcloud/core/filters.py
+++ b/docker-app/qfieldcloud/core/filters.py
@@ -3,7 +3,7 @@ import django_filters
 from qfieldcloud.core.models import Project
 
 
-class ProjectFilter(django_filters.FilterSet):
+class ProjectFilterSet(django_filters.FilterSet):
     owner = django_filters.CharFilter(field_name="owner__username", lookup_expr="exact")
 
     class Meta:

--- a/docker-app/qfieldcloud/core/tests/test_project.py
+++ b/docker-app/qfieldcloud/core/tests/test_project.py
@@ -124,6 +124,32 @@ class QfcTestCase(APITransactionTestCase):
         self.assertEqual(json[0]["collaborator"], "user2")
         self.assertEqual(json[0]["role"], "manager")
 
+    def test_list_filtered_projects(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token2.key)
+
+        # 1) list projects for specific user name other than the logged in user
+        response = self.client.get("/api/v1/projects/user1")
+        self.assertTrue(status.is_success(response.status_code))
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["name"], "project1")
+        self.assertEqual(response.data[0]["owner"], "user1")
+
+        # 2) list projects for specific user name matching logged in user
+        response = self.client.get("/api/v1/projects/user2")
+        self.assertTrue(status.is_success(response.status_code))
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0]["name"], "project1")
+        self.assertEqual(response.data[0]["owner"], "user2")
+        self.assertEqual(response.data[1]["name"], "project2")
+        self.assertEqual(response.data[1]["owner"], "user2")
+
+        # 3) list project for specific user name (matching logged in user) and project name
+        response = self.client.get("/api/v1/projects/user2/project2")
+        self.assertTrue(status.is_success(response.status_code))
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["name"], "project2")
+        self.assertEqual(response.data[0]["owner"], "user2")
+
     def test_list_projects_of_authenticated_user(self):
         # Create a project of user1
         self.project1 = Project.objects.create(

--- a/docker-app/qfieldcloud/core/tests/test_project.py
+++ b/docker-app/qfieldcloud/core/tests/test_project.py
@@ -126,24 +126,16 @@ class QfcTestCase(APITransactionTestCase):
 
     def test_list_filtered_projects(self):
         # Create a project of user1 with public access to user2
-        self.project1 = Project.objects.create(
-            name="project1", is_public=True, owner=self.user1
-        )
+        Project.objects.create(name="project1", is_public=True, owner=self.user1)
 
         # Create a project of user1 without access to user2
-        self.project1 = Project.objects.create(
-            name="project2", is_public=False, owner=self.user1
-        )
+        Project.objects.create(name="project2", is_public=False, owner=self.user1)
 
         # Create a private project of user2
-        self.project3 = Project.objects.create(
-            name="project1", is_public=False, owner=self.user2
-        )
+        Project.objects.create(name="project1", is_public=False, owner=self.user2)
 
         # Create a public project of user2
-        self.project4 = Project.objects.create(
-            name="project2", is_public=True, owner=self.user2
-        )
+        Project.objects.create(name="project2", is_public=True, owner=self.user2)
 
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token2.key)
 

--- a/docker-app/qfieldcloud/core/tests/test_project.py
+++ b/docker-app/qfieldcloud/core/tests/test_project.py
@@ -125,6 +125,26 @@ class QfcTestCase(APITransactionTestCase):
         self.assertEqual(json[0]["role"], "manager")
 
     def test_list_filtered_projects(self):
+        # Create a project of user1 with public access to user2
+        self.project1 = Project.objects.create(
+            name="project1", is_public=True, owner=self.user1
+        )
+
+        # Create a project of user1 without access to user2
+        self.project1 = Project.objects.create(
+            name="project2", is_public=False, owner=self.user1
+        )
+
+        # Create a private project of user2
+        self.project3 = Project.objects.create(
+            name="project1", is_public=False, owner=self.user2
+        )
+
+        # Create a public project of user2
+        self.project4 = Project.objects.create(
+            name="project2", is_public=True, owner=self.user2
+        )
+
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token2.key)
 
         # 1) list projects for specific user name other than the logged in user
@@ -138,10 +158,13 @@ class QfcTestCase(APITransactionTestCase):
         response = self.client.get("/api/v1/projects/?owner=user2")
         self.assertTrue(status.is_success(response.status_code))
         self.assertEqual(len(response.data), 2)
-        self.assertEqual(response.data[0]["name"], "project1")
-        self.assertEqual(response.data[0]["owner"], "user2")
-        self.assertEqual(response.data[1]["name"], "project2")
-        self.assertEqual(response.data[1]["owner"], "user2")
+
+        json = response.json()
+        json = sorted(json, key=lambda k: k["name"])
+        self.assertEqual(json[0]["name"], "project1")
+        self.assertEqual(json[0]["owner"], "user2")
+        self.assertEqual(json[1]["name"], "project2")
+        self.assertEqual(json[1]["owner"], "user2")
 
         # 3) list project for specific user name (matching logged in user) and project name
         response = self.client.get("/api/v1/projects/?owner=user2&project=project2")

--- a/docker-app/qfieldcloud/core/tests/test_project.py
+++ b/docker-app/qfieldcloud/core/tests/test_project.py
@@ -128,14 +128,14 @@ class QfcTestCase(APITransactionTestCase):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token2.key)
 
         # 1) list projects for specific user name other than the logged in user
-        response = self.client.get("/api/v1/projects/user1")
+        response = self.client.get("/api/v1/projects/?owner=user1")
         self.assertTrue(status.is_success(response.status_code))
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["name"], "project1")
         self.assertEqual(response.data[0]["owner"], "user1")
 
         # 2) list projects for specific user name matching logged in user
-        response = self.client.get("/api/v1/projects/user2")
+        response = self.client.get("/api/v1/projects/?owner=user2")
         self.assertTrue(status.is_success(response.status_code))
         self.assertEqual(len(response.data), 2)
         self.assertEqual(response.data[0]["name"], "project1")
@@ -144,7 +144,7 @@ class QfcTestCase(APITransactionTestCase):
         self.assertEqual(response.data[1]["owner"], "user2")
 
         # 3) list project for specific user name (matching logged in user) and project name
-        response = self.client.get("/api/v1/projects/user2/project2")
+        response = self.client.get("/api/v1/projects/?owner=user2&project=project2")
         self.assertTrue(status.is_success(response.status_code))
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["name"], "project2")

--- a/docker-app/qfieldcloud/core/tests/test_project.py
+++ b/docker-app/qfieldcloud/core/tests/test_project.py
@@ -147,15 +147,22 @@ class QfcTestCase(APITransactionTestCase):
 
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token2.key)
 
-        # 1) list projects for specific user name other than the logged in user
-        response = self.client.get("/api/v1/projects/?owner=user1")
+        # 1) list non-public projects for specific user name other than the logged in user
+        response = self.client.get("/api/v1/projects/?owner__username=user1")
+        self.assertTrue(status.is_success(response.status_code))
+        self.assertEqual(len(response.data), 0)
+
+        # 1) list all projects (including public ones) for specific user name other than the logged in user
+        response = self.client.get(
+            "/api/v1/projects/?owner__username=user1&include-public=1"
+        )
         self.assertTrue(status.is_success(response.status_code))
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["name"], "project1")
         self.assertEqual(response.data[0]["owner"], "user1")
 
         # 2) list projects for specific user name matching logged in user
-        response = self.client.get("/api/v1/projects/?owner=user2")
+        response = self.client.get("/api/v1/projects/?owner__username=user2")
         self.assertTrue(status.is_success(response.status_code))
         self.assertEqual(len(response.data), 2)
 
@@ -167,7 +174,9 @@ class QfcTestCase(APITransactionTestCase):
         self.assertEqual(json[1]["owner"], "user2")
 
         # 3) list project for specific user name (matching logged in user) and project name
-        response = self.client.get("/api/v1/projects/?owner=user2&project=project2")
+        response = self.client.get(
+            "/api/v1/projects/?owner__username=user2&name=project2"
+        )
         self.assertTrue(status.is_success(response.status_code))
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["name"], "project2")

--- a/docker-app/qfieldcloud/core/tests/test_project.py
+++ b/docker-app/qfieldcloud/core/tests/test_project.py
@@ -140,21 +140,19 @@ class QfcTestCase(APITransactionTestCase):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token2.key)
 
         # 1) list non-public projects for specific user name other than the logged in user
-        response = self.client.get("/api/v1/projects/?owner__username=user1")
+        response = self.client.get("/api/v1/projects/?owner=user1")
         self.assertTrue(status.is_success(response.status_code))
         self.assertEqual(len(response.data), 0)
 
         # 1) list all projects (including public ones) for specific user name other than the logged in user
-        response = self.client.get(
-            "/api/v1/projects/?owner__username=user1&include-public=1"
-        )
+        response = self.client.get("/api/v1/projects/?owner=user1&include-public=1")
         self.assertTrue(status.is_success(response.status_code))
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["name"], "project1")
         self.assertEqual(response.data[0]["owner"], "user1")
 
         # 2) list projects for specific user name matching logged in user
-        response = self.client.get("/api/v1/projects/?owner__username=user2")
+        response = self.client.get("/api/v1/projects/?owner=user2")
         self.assertTrue(status.is_success(response.status_code))
         self.assertEqual(len(response.data), 2)
 
@@ -166,9 +164,7 @@ class QfcTestCase(APITransactionTestCase):
         self.assertEqual(json[1]["owner"], "user2")
 
         # 3) list project for specific user name (matching logged in user) and project name
-        response = self.client.get(
-            "/api/v1/projects/?owner__username=user2&name=project2"
-        )
+        response = self.client.get("/api/v1/projects/?owner=user2&name=project2")
         self.assertTrue(status.is_success(response.status_code))
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["name"], "project2")

--- a/docker-app/qfieldcloud/core/urls.py
+++ b/docker-app/qfieldcloud/core/urls.py
@@ -44,11 +44,6 @@ organizations/<str:organization_name>/teams/<str:team_name>/members/
 urlpatterns = [
     *filestorage_urlpatterns,
     path("projects/public/", projects_views.PublicProjectsListView.as_view()),
-    path("projects/<str:username>/", projects_views.FilteredProjectsListView.as_view()),
-    path(
-        "projects/<str:username>/<str:project>/",
-        projects_views.FilteredProjectsListView.as_view(),
-    ),
     path("", include(router.urls)),
     path("users/", users_views.ListUsersView.as_view()),
     path(

--- a/docker-app/qfieldcloud/core/urls.py
+++ b/docker-app/qfieldcloud/core/urls.py
@@ -44,6 +44,11 @@ organizations/<str:organization_name>/teams/<str:team_name>/members/
 urlpatterns = [
     *filestorage_urlpatterns,
     path("projects/public/", projects_views.PublicProjectsListView.as_view()),
+    path("projects/<str:username>/", projects_views.FilteredProjectsListView.as_view()),
+    path(
+        "projects/<str:username>/<str:project>/",
+        projects_views.FilteredProjectsListView.as_view(),
+    ),
     path("", include(router.urls)),
     path("users/", users_views.ListUsersView.as_view()),
     path(

--- a/docker-app/qfieldcloud/core/views/projects_views.py
+++ b/docker-app/qfieldcloud/core/views/projects_views.py
@@ -10,7 +10,7 @@ from drf_spectacular.utils import (
 from qfieldcloud.core import pagination, permissions_utils
 from qfieldcloud.core.drf_utils import QfcOrderingFilter
 from qfieldcloud.core.exceptions import ObjectNotFoundError
-from qfieldcloud.core.filters import ProjectFilter
+from qfieldcloud.core.filters import ProjectFilterSet
 from qfieldcloud.core.models import Project, ProjectQueryset
 from qfieldcloud.core.serializers import ProjectSerializer
 from qfieldcloud.core.utils2 import storage
@@ -93,7 +93,7 @@ class ProjectViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated, ProjectViewSetPermissions]
     pagination_class = pagination.QfcLimitOffsetPagination()
     filter_backends = [filters.DjangoFilterBackend, QfcOrderingFilter]
-    filterset_class = ProjectFilter
+    filterset_class = ProjectFilterSet
     ordering_fields = ["owner__username::alias=owner", "name", "created_at"]
 
     def get_queryset(self):

--- a/docker-app/qfieldcloud/core/views/projects_views.py
+++ b/docker-app/qfieldcloud/core/views/projects_views.py
@@ -10,6 +10,7 @@ from drf_spectacular.utils import (
 from qfieldcloud.core import pagination, permissions_utils
 from qfieldcloud.core.drf_utils import QfcOrderingFilter
 from qfieldcloud.core.exceptions import ObjectNotFoundError
+from qfieldcloud.core.filters import ProjectFilter
 from qfieldcloud.core.models import Project, ProjectQueryset
 from qfieldcloud.core.serializers import ProjectSerializer
 from qfieldcloud.core.utils2 import storage
@@ -92,7 +93,7 @@ class ProjectViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated, ProjectViewSetPermissions]
     pagination_class = pagination.QfcLimitOffsetPagination()
     filter_backends = [filters.DjangoFilterBackend, QfcOrderingFilter]
-    filterset_fields = ("owner__username", "name")
+    filterset_class = ProjectFilter
     ordering_fields = ["owner__username::alias=owner", "name", "created_at"]
 
     def get_queryset(self):


### PR DESCRIPTION
@suricactus , as discussed, the PR adds two GET parameters to /api/v1/projects/ to filter the list by owner and/or project name. E.g., `/api/v1/projects/?owner=ivan&name=kebab`.

This will allow us to provide easier permalinks to retrieve cloud project details via API within QField.