### PR TITLE
Fix internal server error 500 when calling /api/v1/projects/ from browser

### DIFF
--- a/docker-app/qfieldcloud/core/views/projects_views.py
+++ b/docker-app/qfieldcloud/core/views/projects_views.py
@@ -37,14 +37,15 @@ class ProjectViewSetPermissions(permissions.BasePermission):
             return permissions_utils.can_create_project(user, owner_obj)
 
         projectid = permissions_utils.get_param_from_request(request, "projectid")
-        project = Project.objects.get(id=projectid)
+        if projectid:
+            project = Project.objects.get(id=projectid)
 
-        if view.action == "retrieve":
-            return permissions_utils.can_retrieve_project(user, project)
-        elif view.action == "destroy":
-            return permissions_utils.can_delete_project(user, project)
-        elif view.action in ["update", "partial_update"]:
-            return permissions_utils.can_update_project(user, project)
+            if view.action == "retrieve":
+                return permissions_utils.can_retrieve_project(user, project)
+            elif view.action == "destroy":
+                return permissions_utils.can_delete_project(user, project)
+            elif view.action in ["update", "partial_update"]:
+                return permissions_utils.can_update_project(user, project)
 
         return False
 


### PR DESCRIPTION
Fixes server error 500 when calling /api/v1/projects/ within a browser. On app.qfield.cloud, the error shows as:

![image](https://github.com/user-attachments/assets/2bc64676-d30c-4604-bcec-19c7cf369c46)

While on classic localhost installation, the error shows as:

![image](https://github.com/user-attachments/assets/99acc6cb-64ae-4b6a-8d97-8c86a7e2ea08)


