### PR TITLE
Fix error 500 when using the DRF in-browser viewer on GET /projects

### DIFF
--- a/docker-app/qfieldcloud/core/views/projects_views.py
+++ b/docker-app/qfieldcloud/core/views/projects_views.py
@@ -18,7 +18,12 @@ User = get_user_model()
 
 
 class ProjectViewSetPermissions(permissions.BasePermission):
-    def has_permission(self, request, view):
+    def has_permission(self, request, view) -> bool:
+        if view.action is None:
+            # If `view.action` is `None`, means that we are getting a OPTIONS request.
+            # We don't know what it is, so we deny permission.
+            return False
+
         if view.action == "list":
             # The queryset is already filtered by what the user can see
             return True


### PR DESCRIPTION
Turns out that there is a fake OPTIONS requests being processed, which sets the `view.action` to `None` instead of one of the known strings, e.g. the expected `list`.

Therefore we start returning `False` if the `view.action` is unknown as the most conservative approach.

NOTE most probably there are other list views that suffer from the same problem.