### PR TITLE
Return ObjectNotFoundError when get_object_or_404 is used in the code

### DIFF
--- a/docker-app/qfieldcloud/core/rest_utils.py
+++ b/docker-app/qfieldcloud/core/rest_utils.py
@@ -2,6 +2,7 @@ import logging
 
 from django.conf import settings
 from django.core import exceptions
+from django.http import Http404
 from rest_framework import exceptions as rest_exceptions
 from rest_framework.response import Response
 
@@ -18,7 +19,7 @@ def exception_handler(exc, context):
         qfc_exc = qfieldcloud_exceptions.NotAuthenticatedError()
     elif isinstance(exc, rest_exceptions.PermissionDenied):
         qfc_exc = qfieldcloud_exceptions.PermissionDeniedError()
-    elif isinstance(exc, exceptions.ObjectDoesNotExist):
+    elif isinstance(exc, (exceptions.ObjectDoesNotExist, Http404)):
         qfc_exc = qfieldcloud_exceptions.ObjectNotFoundError(detail=str(exc))
     elif isinstance(exc, exceptions.ValidationError):
         qfc_exc = qfieldcloud_exceptions.ValidationError(detail=str(exc))

--- a/docker-app/qfieldcloud/core/rest_utils.py
+++ b/docker-app/qfieldcloud/core/rest_utils.py
@@ -26,7 +26,11 @@ def exception_handler(exc, context):
     elif isinstance(exc, qfieldcloud_exceptions.QFieldCloudException):
         qfc_exc = exc
     elif isinstance(exc, rest_exceptions.APIException):
-        qfc_exc = qfieldcloud_exceptions.APIError(exc.detail, exc.status_code)
+        # Map DRF API exceptions to qfc exceptions. Note the `detail` attribute is always present but not properly typed in `APIException`
+        qfc_exc = qfieldcloud_exceptions.APIError(
+            detail=getattr(exc, "detail"),
+            status_code=exc.status_code,
+        )
     else:
         # Unexpected ! We rethrow original exception to make debugging tests easier
         if settings.IN_TEST_SUITE:


### PR DESCRIPTION
Literally the title, when there is 404, we need to handle the error into a JSON friendly `ObjectNotFoundError`.