### PR TITLE
Fix wrong syntax for docker-compose expose.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,7 +191,7 @@ services:
     image: memcached:1
     restart: unless-stopped
     expose:
-      - "11211:11211"
+      - 11211
 
 volumes:
   static_volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,7 +191,7 @@ services:
     image: memcached:1
     restart: unless-stopped
     expose:
-      - 11211
+      - "11211"
 
 volumes:
   static_volume:


### PR DESCRIPTION
"Expose" syntax is only a port number, not a port mapping. Exposes that port to the other docker containers running.
Otherwise it fails with `services.memcached.expose is invalid: should be of the format 'PORT[/PROTOCOL]'`.

However there is also a setting in the override files that exposes the port with a port mapping on the host machine:
```
  memcached:
    ports:
      - "${MEMCACHED_PORT}:11211" # MEMCACHED_PORT is 11211 by default
```

So the question is should the port be exposed on the docker host machine or only to the other containers. I guess in a bigger setup it should be exposed on the host machine in case of distributed docker containers.

Maybe to be discussed before merging.