### PR TITLE
Add bootstrap to installed apps

### DIFF
--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -133,6 +133,7 @@ INSTALLED_APPS = [
     "migrate_sql",
     "constance",
     "django_extensions",
+    "bootstrap4",
     "django_cleanup.apps.CleanupConfig",
 ]
 


### PR DESCRIPTION
Basically fixing this error: `django.template.exceptions.TemplateSyntaxError: 'bootstrap4' is not a registered tag library`.