### PR TITLE
Do not show an error for missing localized dataset when it is available

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1516,6 +1516,10 @@ class Project(models.Model):
             for layer_data in self.project_details.get("layers_by_id", {}).values():
                 layer_name = layer_data.get("name")
 
+                # All the layers stored in the localized_datasets project will be with errors, so we just skip them. We handled them separately before this for loop.
+                if layer_data.get("error_code") == "localized_dataprovider":
+                    continue
+
                 if layer_data.get("error_code") != "no_error":
                     problems.append(
                         {

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -42,6 +42,8 @@ if TYPE_CHECKING:
     from qfieldcloud.filestorage.models import File
 
 
+LOCALIZED_DATASETS_PROJECT_NAME = "localized_datasets"
+
 # http://springmeblog.com/2018/how-to-implement-multiple-user-types-with-django/
 
 logger = logging.getLogger(__name__)
@@ -1241,12 +1243,11 @@ class Project(models.Model):
     @cached_property
     def localized_datasets_project(self) -> Project | None:
         """
-        Returns the 'localized_datasets' Project instance for the same owner,
-        or None if no such project exists.
+        Returns the localized datasets project for the same owner, or `None` if no such project exists.
         """
         try:
             project = Project.objects.get(
-                name="localized_datasets",
+                name=LOCALIZED_DATASETS_PROJECT_NAME,
                 owner=self.owner,
             )
             return project
@@ -1256,7 +1257,7 @@ class Project(models.Model):
     def get_missing_localized_layers(self) -> list[dict[str, Any]]:
         """
         Of all localized layers, return those whose filenames aren’t in `available_filenames`,
-        which means they are not present in the associated localized_datasets project storage.
+        which means they are not present in the associated localized datasets project storage.
 
         Returns:
             A list of layer-detail dicts (same shape as in `localized_layers`)
@@ -1493,23 +1494,23 @@ class Project(models.Model):
                     },
                 )
                 missing_localized_file_solution = _(
-                    'Upload the missing file to the "<a href="{}">localized_datasets</a>" project or update the layer to point to an available file.'
-                ).format(localized_project_url)
+                    'Upload the missing file to the "<a href="{}">{}</a>" project or update the layer to point to an available file.'
+                ).format(localized_project_url, LOCALIZED_DATASETS_PROJECT_NAME)
             else:
                 problems.append(
                     {
                         "layer": None,
                         "level": "warning",
                         "code": "missing_localized_project",
-                        "description": _(
-                            'Could not find the "localized_datasets" project.'
+                        "description": _('Could not find the "{}" project.').format(
+                            LOCALIZED_DATASETS_PROJECT_NAME
                         ),
                         "solution": _("Ensure the shared dataset project exists."),
                     }
                 )
                 missing_localized_file_solution = _(
-                    'Upload the missing file to the "localized_datasets" project or update the layer to point to an available file.'
-                )
+                    'Upload the missing file to the "{}" project or update the layer to point to an available file.'
+                ).format(LOCALIZED_DATASETS_PROJECT_NAME)
 
             for missing_layer in self.get_missing_localized_layers():
                 problems.append(
@@ -1527,7 +1528,7 @@ class Project(models.Model):
             for layer_data in self.project_details.get("layers_by_id", {}).values():
                 layer_name = layer_data.get("name")
 
-                # All the layers stored in the localized_datasets project will be with errors, so we just skip them. We handled them separately before this for loop.
+                # All the layers stored in the localized datasets project will be with errors, so we just skip them. We handled them separately before this for loop.
                 if layer_data.get("error_code") == "localized_dataprovider":
                     continue
 

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1485,17 +1485,31 @@ class Project(models.Model):
         elif self.project_details:
             localized_project = self.get_localized_datasets_project()
 
-            if not localized_project:
+            if localized_project:
+                localized_project_url = reverse_lazy(
+                    "project_overview",
+                    kwargs={
+                        "username": localized_project.owner.username,
+                        "project": localized_project.name,
+                    },
+                )
+                missing_localized_file_solution = _(
+                    'Upload the missing file to the "<a href="{}">localized_datasets</a>" project or update the layer to point to an available file.'
+                ).format(localized_project_url)
+            else:
                 problems.append(
                     {
                         "layer": None,
                         "level": "warning",
                         "code": "missing_localized_project",
                         "description": _(
-                            "Could not find the 'localized_datasets' project."
+                            'Could not find the "localized_datasets" project.'
                         ),
                         "solution": _("Ensure the shared dataset project exists."),
                     }
+                )
+                missing_localized_file_solution = _(
+                    'Upload the missing file to the "localized_datasets" project or update the layer to point to an available file.'
                 )
 
             for missing_layer in self.get_missing_localized_layers():
@@ -1505,11 +1519,9 @@ class Project(models.Model):
                         "level": "warning",
                         "code": "missing_localized_file",
                         "description": _(
-                            'Localized dataset stored at "{}" is missing in the centralized dataset project.'
+                            'Localized dataset stored at "{}" is missing.'
                         ).format(missing_layer.get("filename")),
-                        "solution": _(
-                            "Upload the missing file to the 'localized_datasets' project or update the layer to point to an available file."
-                        ),
+                        "solution": missing_localized_file_solution,
                     }
                 )
 

--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -77,7 +77,7 @@ class ProjectSerializer(serializers.ModelSerializer):
     localized_datasets_project_id = serializers.SerializerMethodField(read_only=True)
 
     def get_localized_datasets_project_id(self, obj):
-        project = obj.get_localized_datasets_project()
+        project = obj.localized_datasets_project
 
         if project:
             return str(project.id)

--- a/docker-app/qfieldcloud/core/tests/test_project.py
+++ b/docker-app/qfieldcloud/core/tests/test_project.py
@@ -557,24 +557,20 @@ class QfcTestCase(APITransactionTestCase):
         )
 
     def test_get_localized_datasets_project_exists(self):
-        """Test Project.get_localized_datasets_project returns the project if found."""
+        """Test Project.localized_datasets_project returns the project if found."""
         project = Project.objects.create(name="project", owner=self.user1)
         localized_project = Project.objects.create(
             name="localized_datasets", owner=self.user1
         )
 
-        found = project.get_localized_datasets_project()
-
-        self.assertIsNotNone(found)
-        self.assertEqual(found.id, localized_project.id)
+        self.assertIsNotNone(project.localized_datasets_project)
+        self.assertEqual(project.localized_datasets_project.id, localized_project.id)
 
     def test_get_localized_datasets_project_missing(self):
-        """Test Project.get_localized_datasets_project returns None if not found."""
+        """Test Project.localized_datasets_project returns None if not found."""
         project = Project.objects.create(name="project", owner=self.user1)
 
-        found = project.get_localized_datasets_project()
-
-        self.assertIsNone(found)
+        self.assertIsNone(project.localized_datasets_project)
 
     def test_get_missing_localized_layers_when_no_localized_project(self):
         """Test get_missing_localized_layers returns all localized layers if no localized_datasets project exists."""

--- a/docker-app/qfieldcloud/core/tests/test_project.py
+++ b/docker-app/qfieldcloud/core/tests/test_project.py
@@ -7,6 +7,7 @@ from rest_framework.test import APITransactionTestCase
 
 from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core.models import (
+    LOCALIZED_DATASETS_PROJECT_NAME,
     Organization,
     OrganizationMember,
     Person,
@@ -543,7 +544,7 @@ class QfcTestCase(APITransactionTestCase):
 
         project = Project.objects.create(name="project", owner=self.user1)
         localized_project = Project.objects.create(
-            name="localized_datasets", owner=self.user1
+            name=LOCALIZED_DATASETS_PROJECT_NAME, owner=self.user1
         )
 
         response = self.client.get(f"/api/v1/projects/{project.id}/")
@@ -560,7 +561,7 @@ class QfcTestCase(APITransactionTestCase):
         """Test Project.localized_datasets_project returns the project if found."""
         project = Project.objects.create(name="project", owner=self.user1)
         localized_project = Project.objects.create(
-            name="localized_datasets", owner=self.user1
+            name=LOCALIZED_DATASETS_PROJECT_NAME, owner=self.user1
         )
 
         self.assertIsNotNone(project.localized_datasets_project)


### PR DESCRIPTION
Add a bit of extra info about the localized datasets and stick to double quotes in formatting.