### PR TITLE
Support `Range` in HTTP header during downloading files

### DIFF
--- a/docker-app/qfieldcloud/core/exceptions.py
+++ b/docker-app/qfieldcloud/core/exceptions.py
@@ -194,3 +194,9 @@ class ProjectAlreadyExistsError(QFieldCloudException):
     code = "project_already_exists"
     message = "This user already owns a project with the same name."
     status_code = status.HTTP_400_BAD_REQUEST
+
+
+class InvalidRangeError(QFieldCloudException):
+    code = "invalid_http_range"
+    message = "The provided HTTP range header is invalid."
+    status_code = status.HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE

--- a/docker-app/qfieldcloud/filestorage/tests/test_range.py
+++ b/docker-app/qfieldcloud/filestorage/tests/test_range.py
@@ -79,6 +79,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
         self.assertIsNone(parse_range("bytes=1-1", file_size))
         # multiple ranges are not supported (yet), see https://www.rfc-editor.org/rfc/rfc9110.html#section-14.1.2-9.4.1
         self.assertIsNone(parse_range("bytes=1-5, 10-15", file_size))
+        self.assertIsNone(parse_range("bytes=1-5,10-15", file_size))
 
     def test_upload_file_then_download_range_succeeds(self):
         for project in [self.project_default_storage, self.project_webdav_storage]:

--- a/docker-app/qfieldcloud/filestorage/tests/test_range.py
+++ b/docker-app/qfieldcloud/filestorage/tests/test_range.py
@@ -60,9 +60,27 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
 
         self.assertIsNone(result)
 
-        result = parse_range("bytes=-5")
-
-        self.assertIsNone(result)
+        # start position cannot be greater than the end position
+        self.assertIsNone(parse_range("bytes=9-1"))
+        # suffix ranges are not supported (yet), see https://www.rfc-editor.org/rfc/rfc9110.html#rule.suffix-range
+        self.assertIsNone(parse_range("bytes=-5"))
+        # bytes should be numbers
+        self.assertIsNone(parse_range("bytes=one-two"))
+        # whitespaces are not accepted
+        self.assertIsNone(parse_range("bytes= 1-9"))
+        self.assertIsNone(parse_range("bytes=1 -9"))
+        self.assertIsNone(parse_range("bytes=1- 9"))
+        self.assertIsNone(parse_range("bytes=1-9 "))
+        self.assertIsNone(parse_range("bytes=1- "))
+        # typos in bytes
+        self.assertIsNone(parse_range("bites=0-9"))
+        self.assertIsNone(parse_range("starting bytes=0-9"))
+        self.assertIsNone(parse_range("bytes=0-9 closing bytes"))
+        # empty range
+        self.assertIsNone(parse_range("bytes=0-0"))
+        self.assertIsNone(parse_range("bytes=1-1"))
+        # multiple ranges are not supported (yet), see ....
+        ...
 
     def test_upload_file_then_download_range_succeeds(self):
         for project in [self.project_default_storage, self.project_webdav_storage]:

--- a/docker-app/qfieldcloud/filestorage/tests/test_range.py
+++ b/docker-app/qfieldcloud/filestorage/tests/test_range.py
@@ -13,6 +13,7 @@ from qfieldcloud.core.tests.mixins import QfcFilesTestCaseMixin
 from qfieldcloud.core.tests.utils import (
     setup_subscription_plans,
 )
+from qfieldcloud.filestorage.utils import parse_range
 
 logging.disable(logging.CRITICAL)
 
@@ -34,6 +35,34 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             name="project_webdav_storage",
             file_storage="webdav",
         )
+
+    def test_parsing_range_function_succeeds(self):
+        start_byte, end_byte = parse_range("bytes=4-8")
+
+        self.assertEquals(start_byte, 4)
+        self.assertEquals(end_byte, 8)
+
+        start_byte, end_byte = parse_range("bytes=2-")
+
+        self.assertEquals(start_byte, 2)
+        self.assertIsNone(end_byte)
+
+    def test_parsing_wrong_invalid_range_function_succeeds(self):
+        result = parse_range("byte=4-8")
+
+        self.assertIsNone(result)
+
+        result = parse_range("bytes=-1-15")
+
+        self.assertIsNone(result)
+
+        result = parse_range("bytes=-10--15")
+
+        self.assertIsNone(result)
+
+        result = parse_range("bytes=-5")
+
+        self.assertIsNone(result)
 
     def test_upload_file_then_download_range_succeeds(self):
         for project in [self.project_default_storage, self.project_webdav_storage]:

--- a/docker-app/qfieldcloud/filestorage/tests/test_range.py
+++ b/docker-app/qfieldcloud/filestorage/tests/test_range.py
@@ -70,6 +70,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
         self.assertIsNone(parse_range("bytes=1- 9", file_size))
         self.assertIsNone(parse_range("bytes=1-9 ", file_size))
         self.assertIsNone(parse_range("bytes=1- ", file_size))
+        self.assertIsNone(parse_range(" bytes=1-9", file_size))
         # typos in bytes
         self.assertIsNone(parse_range("bites=0-9", file_size))
         self.assertIsNone(parse_range("starting bytes=0-9", file_size))

--- a/docker-app/qfieldcloud/filestorage/tests/test_range.py
+++ b/docker-app/qfieldcloud/filestorage/tests/test_range.py
@@ -37,12 +37,12 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
 
     def test_upload_file_then_download_range_succeeds(self):
         for project in [self.project_default_storage, self.project_webdav_storage]:
-            with self.subTest(case=project):
-                # first upload of the file
-                response = self._upload_file(
-                    self.u1, project, "file.name", StringIO("abcdefghijkl")
-                )
+            # first upload of the file
+            response = self._upload_file(
+                self.u1, project, "file.name", StringIO("abcdefghijkl")
+            )
 
+            with self.subTest(case=project):
                 self.assertEqual(response.status_code, status.HTTP_201_CREATED)
                 self.assertEqual(project.files.count(), 1)
                 self.assertEqual(project.get_file("file.name").versions.count(), 1)
@@ -78,12 +78,10 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
 
     def test_upload_file_then_download_wrong_range_fails(self):
         for project in [self.project_default_storage, self.project_webdav_storage]:
-            with self.subTest(case=project):
-                # first upload of the file
-                self._upload_file(
-                    self.u1, project, "file.name", StringIO("abcdefghijkl")
-                )
+            # first upload of the file
+            self._upload_file(self.u1, project, "file.name", StringIO("abcdefghijkl"))
 
+            with self.subTest(case=project):
                 r1 = self._download_file(
                     self.u1, project, "file.name", headers={"Range": "bytes=abc-"}
                 )

--- a/docker-app/qfieldcloud/filestorage/tests/test_range.py
+++ b/docker-app/qfieldcloud/filestorage/tests/test_range.py
@@ -1,0 +1,117 @@
+import logging
+from io import StringIO
+
+from rest_framework import status
+from rest_framework.test import APITransactionTestCase
+
+from qfieldcloud.authentication.models import AuthToken
+from qfieldcloud.core.models import (
+    Person,
+    Project,
+)
+from qfieldcloud.core.tests.mixins import QfcFilesTestCaseMixin
+from qfieldcloud.core.tests.utils import (
+    setup_subscription_plans,
+)
+
+logging.disable(logging.CRITICAL)
+
+
+class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
+    def setUp(self):
+        setup_subscription_plans()
+
+        # Create a user
+        self.u1 = Person.objects.create_user(username="u1", password="abc123")
+        self.t1 = AuthToken.objects.get_or_create(user=self.u1)[0]
+        self.project_default_storage = Project.objects.create(
+            owner=self.u1,
+            name="project_default_storage",
+            file_storage="default",
+        )
+        self.project_webdav_storage = Project.objects.create(
+            owner=self.u1,
+            name="project_webdav_storage",
+            file_storage="webdav",
+        )
+
+    def test_upload_file_then_download_range_succeeds(self):
+        for project in [self.project_default_storage, self.project_webdav_storage]:
+            with self.subTest(case=project):
+                # first upload of the file
+                response = self._upload_file(
+                    self.u1, project, "file.name", StringIO("abcdefghijkl")
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+                self.assertEqual(project.files.count(), 1)
+                self.assertEqual(project.get_file("file.name").versions.count(), 1)
+
+                # download parts of the file, with specific ranges
+                r1 = self._download_file(
+                    self.u1, project, "file.name", headers={"Range": "bytes=0-2"}
+                )
+
+                self.assertEquals(r1.status_code, status.HTTP_206_PARTIAL_CONTENT)
+                self.assertEquals(r1.content, b"abc")
+
+                r2 = self._download_file(
+                    self.u1, project, "file.name", headers={"Range": "bytes=5-8"}
+                )
+
+                self.assertEquals(r2.status_code, status.HTTP_206_PARTIAL_CONTENT)
+                self.assertEquals(r2.content, b"fghi")
+
+                r3 = self._download_file(
+                    self.u1, project, "file.name", headers={"Range": "bytes=7-"}
+                )
+
+                self.assertEquals(r3.status_code, status.HTTP_206_PARTIAL_CONTENT)
+                self.assertEquals(r3.content, b"hijkl")
+
+                r4 = self._download_file(
+                    self.u1, project, "file.name", headers={"Range": "bytes=0-"}
+                )
+
+                self.assertEquals(r4.status_code, status.HTTP_206_PARTIAL_CONTENT)
+                self.assertEquals(r4.content, b"abcdefghijkl")
+
+    def test_upload_file_then_download_wrong_range_fails(self):
+        for project in [self.project_default_storage, self.project_webdav_storage]:
+            with self.subTest(case=project):
+                # first upload of the file
+                self._upload_file(
+                    self.u1, project, "file.name", StringIO("abcdefghijkl")
+                )
+
+                r1 = self._download_file(
+                    self.u1, project, "file.name", headers={"Range": "bytes=abc-"}
+                )
+
+                self.assertEquals(
+                    r1.status_code, status.HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE
+                )
+
+                r2 = self._download_file(
+                    self.u1, project, "file.name", headers={"Range": "bytes=-def"}
+                )
+
+                self.assertEquals(
+                    r2.status_code, status.HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE
+                )
+
+                r3 = self._download_file(
+                    self.u1, project, "file.name", headers={"Range": "bytes=-1-"}
+                )
+
+                self.assertEquals(
+                    r3.status_code, status.HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE
+                )
+
+                r4 = self._download_file(
+                    self.u1, project, "file.name", headers={"Range": "bytes=1-55"}
+                )
+
+                self.assertEquals(
+                    r4.status_code, status.HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE
+                )

--- a/docker-app/qfieldcloud/filestorage/tests/test_range.py
+++ b/docker-app/qfieldcloud/filestorage/tests/test_range.py
@@ -37,10 +37,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
         )
 
     def test_parsing_range_function_succeeds(self):
-        start_byte, end_byte = parse_range("bytes=4-8")
-
-        self.assertEquals(start_byte, 4)
-        self.assertEquals(end_byte, 8)
+        self.assertEquals(parse_range("bytes=4-8"), (4, 8))
 
         start_byte, end_byte = parse_range("bytes=2-")
 

--- a/docker-app/qfieldcloud/filestorage/tests/test_range.py
+++ b/docker-app/qfieldcloud/filestorage/tests/test_range.py
@@ -1,6 +1,7 @@
 import logging
 from io import StringIO
 
+from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APITransactionTestCase
 
@@ -18,6 +19,7 @@ from qfieldcloud.filestorage.utils import parse_range
 logging.disable(logging.CRITICAL)
 
 
+@override_settings(QFIELDCLOUD_MINIMUM_RANGE_HEADER_LENGTH=0)
 class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
     def setUp(self):
         setup_subscription_plans()

--- a/docker-app/qfieldcloud/filestorage/utils.py
+++ b/docker-app/qfieldcloud/filestorage/utils.py
@@ -169,7 +169,7 @@ def parse_range(input_range: str, file_size: int) -> tuple[int, int | None] | No
         If compliant, a tuple with start and end (if any) bytes number.
         If not, returns None.
     """
-    match = re.match(r"bytes=(\d+)-(\d+)?$", input_range)
+    match = re.match(r"^bytes=(\d+)-(\d+)?$", input_range)
 
     if not match:
         return None

--- a/docker-app/qfieldcloud/filestorage/utils.py
+++ b/docker-app/qfieldcloud/filestorage/utils.py
@@ -167,7 +167,7 @@ def parse_range(input_range: str, file_size: int) -> tuple[int, int | None] | No
 
     Returns:
         If compliant, a tuple with start and end (if any) bytes number.
-        If not, returns None.
+        If not, returns `None`.
     """
     match = re.match(r"^bytes=(\d+)-(\d+)?$", input_range)
 

--- a/docker-app/qfieldcloud/filestorage/utils.py
+++ b/docker-app/qfieldcloud/filestorage/utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import re
 import uuid
 from pathlib import Path, PurePath
 from typing import Any
@@ -155,3 +156,27 @@ def to_uuid(value: Any) -> uuid.UUID | None:
         return uuid.UUID(value)
     except ValueError:
         return None
+
+
+def parse_range(input_range: str) -> tuple[int, int | None] | None:
+    """Parses a range HTTP Header string.
+
+    Arguments:
+        range: string value of a HTTP range header to parse.
+
+    Returns:
+        If compliant, a tuple with start and end (if any) bytes number.
+    """
+    match = re.match(r"bytes=(\d+)-(\d+)?", input_range)
+
+    if not match:
+        return None
+
+    range_start = int(match.group(1))
+
+    if match.group(2):
+        range_end = int(match.group(2))
+    else:
+        range_end = None
+
+    return (range_start, range_end)

--- a/docker-app/qfieldcloud/filestorage/utils.py
+++ b/docker-app/qfieldcloud/filestorage/utils.py
@@ -166,6 +166,7 @@ def parse_range(input_range: str) -> tuple[int, int | None] | None:
 
     Returns:
         If compliant, a tuple with start and end (if any) bytes number.
+        If not, returns None.
     """
     match = re.match(r"bytes=(\d+)-(\d+)?", input_range)
 

--- a/docker-app/qfieldcloud/filestorage/utils.py
+++ b/docker-app/qfieldcloud/filestorage/utils.py
@@ -158,25 +158,33 @@ def to_uuid(value: Any) -> uuid.UUID | None:
         return None
 
 
-def parse_range(input_range: str) -> tuple[int, int | None] | None:
+def parse_range(input_range: str, file_size: int) -> tuple[int, int | None] | None:
     """Parses a range HTTP Header string.
 
     Arguments:
         range: string value of a HTTP range header to parse.
+        file_size: size of the file to get range for, in bytes.
 
     Returns:
         If compliant, a tuple with start and end (if any) bytes number.
         If not, returns None.
     """
-    match = re.match(r"bytes=(\d+)-(\d+)?", input_range)
+    match = re.match(r"bytes=(\d+)-(\d+)?$", input_range)
 
     if not match:
         return None
 
     range_start = int(match.group(1))
 
+    if range_start >= file_size:
+        return None
+
     if match.group(2):
         range_end = int(match.group(2))
+
+        if range_end >= file_size or range_end <= range_start:
+            return None
+
     else:
         range_end = None
 

--- a/docker-app/qfieldcloud/filestorage/view_helpers.py
+++ b/docker-app/qfieldcloud/filestorage/view_helpers.py
@@ -249,12 +249,10 @@ def download_field_file(
             )
 
         file_size = field_file.size
-        range_start = range_match[0]
+        range_start, range_end = range_match[0]
 
-        if range_match[1]:
-            range_end = range_match[1]
-        else:
-            range_end = file_size - 1
+		if range_end is None:
+		    range_end = file_size - 1
 
         if (
             range_start >= file_size

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -653,6 +653,9 @@ CONSTANCE_CONFIG_FIELDSETS = {
     "Subscription": ("TRIAL_PERIOD_DAYS",),
 }
 
+# Maximum number of bytes to ask a range when requesting a file part
+QFIELDCLOUD_MINIMUM_RANGE_HEADER_LENGTH = 1000000
+
 # Name of the qgis docker image used as a worker by worker_wrapper
 QFIELDCLOUD_QGIS_IMAGE_NAME = os.environ["QFIELDCLOUD_QGIS_IMAGE_NAME"]
 

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -653,7 +653,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
     "Subscription": ("TRIAL_PERIOD_DAYS",),
 }
 
-# Maximum number of bytes to ask a range when requesting a file part
+# Minimum number of bytes to ask a range when requesting a file part, otherwise a HTTP 416 is returned. Set to 0 to allow any number of bytes in the range.
 QFIELDCLOUD_MINIMUM_RANGE_HEADER_LENGTH = 1000000
 
 # Name of the qgis docker image used as a worker by worker_wrapper

--- a/docker-app/qfieldcloud/testing.py
+++ b/docker-app/qfieldcloud/testing.py
@@ -5,5 +5,4 @@ from django.test.runner import DiscoverRunner
 class QfcTestSuiteRunner(DiscoverRunner):
     def __init__(self, *args, **kwargs):
         settings.IN_TEST_SUITE = True
-        settings.QFIELDCLOUD_MINIMUM_RANGE_HEADER_LENGTH = 1
         super().__init__(*args, **kwargs)

--- a/docker-app/qfieldcloud/testing.py
+++ b/docker-app/qfieldcloud/testing.py
@@ -5,4 +5,5 @@ from django.test.runner import DiscoverRunner
 class QfcTestSuiteRunner(DiscoverRunner):
     def __init__(self, *args, **kwargs):
         settings.IN_TEST_SUITE = True
+        settings.QFIELDCLOUD_MINIMUM_RANGE_HEADER_LENGTH = 1
         super().__init__(*args, **kwargs)

--- a/docker-nginx/templates/default.conf.template
+++ b/docker-nginx/templates/default.conf.template
@@ -130,6 +130,8 @@ server {
     set $redirect_uri "$upstream_http_redirect_uri";
     # webdav storage requires a HTTP auth (Basic, mostly).
     set $webdav_auth "$upstream_http_webdav_auth";
+    # if a Range header is provided
+    set $file_range "$upstream_http_file_range";
 
     # required DNS
     resolver 8.8.8.8;
@@ -152,6 +154,7 @@ server {
     proxy_set_header Accept-Encoding '';
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Range $file_range;
 
     # hide Object Storage related headers
     proxy_hide_header Access-Control-Allow-Credentials;


### PR DESCRIPTION
This PR intends to allow downloading only a byte range of a file, using QFieldCloud API, by providing a `Range` HTTP header. Can be used if a big file's first download has crashed for some reason, this new header allows then to download only the missing bytes.

**cURL usage example**:

```sh
curl -X GET -L "https://my.qfieldcloud.server/api/v1/files/<PROJECT_ID>/<FILE_NAME>" \
  -H "Authorization: Token <AUTH_TOKEN>" -H "Range: bytes=5-10"
```
 
**Examples of cURL HTTP headers that can be forwarded to the API, on the `/api/v1/files/<project_id>/<file_name>/` endpoint**:

- `-H "Range: bytes=2-7"` -> will download from byte number n°3 included to byte n°8 included.
- `-H "Range: bytes=3-"` -> will download from byte number n°4 included up to the last byte of the file.

**Steps**:

- [x] make API serve only a file's byte range when a `Range` HTTP header is provided, on a configured S3 storage
- [ ] make API serve only a file's byte range when a `Range` HTTP header is provided, on a configured webdav storage
- [x] add tests downloading only a file's specific byte ranges