### PR TITLE
Add support for seat-based subscription packages

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -2104,7 +2104,7 @@ class PackageJob(Job):
 
 class ProcessProjectfileJob(Job):
     def check_can_be_created(self):
-        # Alsways create jobs because they are cheap
+        # Always create jobs because they are cheap
         # and is always good to have updated metadata
         pass
 

--- a/docker-app/qfieldcloud/subscription/migrations/0007_add_seats_package.py
+++ b/docker-app/qfieldcloud/subscription/migrations/0007_add_seats_package.py
@@ -1,0 +1,37 @@
+from django.db import migrations, models
+
+
+def create_seats_package(apps, schema_editor):
+    PackageType = apps.get_model("subscription", "PackageType")
+    if not PackageType.objects.filter(type="seats").exists():
+        PackageType.objects.create(
+            code="seats_package",
+            type="seats",
+            display_name="Seats",
+            is_public=True,
+            min_quantity=1,
+            max_quantity=500,
+            unit_amount=1,
+            unit_label="seat",
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("subscription", "0006_auto_20230426_2222"),
+    ]
+
+    operations = [
+        # Schema change: add 'seats' to choices
+        migrations.AlterField(
+            model_name="packagetype",
+            name="type",
+            field=models.CharField(
+                choices=[("storage", "Storage"), ("seats", "Seats")],
+                max_length=100,
+                unique=True,
+            ),
+        ),
+        # Data seeding: create the new PackageType entry
+        migrations.RunPython(create_seats_package),
+    ]

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -241,6 +241,7 @@ class PackageType(models.Model):
 
     class Type(models.TextChoices):
         STORAGE = "storage", _("Storage")
+        SEATS = "seats", _("Seats")
 
     code = models.CharField(max_length=100, unique=True)
     # TODO: decide how to localize display_name. Possible approaches:
@@ -499,6 +500,16 @@ class AbstractSubscription(models.Model):
             "These notes are for internal purposes only and will never be shown to the end users."
         ),
     )
+
+    @property
+    def active_seat_package_quantity(self) -> int:
+        seats_type = PackageType.objects.get(type=PackageType.Type.SEATS)
+        return self.get_active_package_quantity(seats_type)
+
+    @property
+    def future_seat_package_quantity(self) -> int:
+        seats_type = PackageType.objects.get(type=PackageType.Type.SEATS)
+        return self.get_future_package_quantity(seats_type)
 
     @property
     @deprecated("Use `AbstractSubscription.active_storage_total_bytes` instead")


### PR DESCRIPTION
This PR introduces initial support for seat-based billing using the existing package system. It aligns with the storage add-on mechanism and allows organizations to reserve and pre-purchase user seats in a flexible and Stripe-integrated way.

**Key Changes**

- Update schema via adding "seats" to `PackageType.Type` enum choices
- Implement `active_seat_package_quantity` and `future_seat_package_quantity` properties on `AbstractSubscription` so to retrieve seat allocations
- Seed a PackageType entry for "seats" with default values (code="seats_package") to enable runtime configuration