### PR TITLE
fix(nginx): disable ipv6 for the resolver in internal redirects for file download

### DIFF
--- a/docker-nginx/templates/default.conf.template
+++ b/docker-nginx/templates/default.conf.template
@@ -155,7 +155,7 @@ server {
     set $file_range "$upstream_http_file_range";
 
     # required DNS
-    resolver 8.8.8.8;
+    resolver 8.8.8.8 ipv6=off;
 
     # Stops the local disk from being written to (just forwards data through)
     proxy_max_temp_file_size 0;


### PR DESCRIPTION
For hosts that are not having ipv6 enabled we get an error. Unfortunately the resolver resolves to ipv6 by default.