### PR TITLE
refactor(localized): rename all `localized_` prefixed variables to `shared_` regarding shared projects

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1264,6 +1264,13 @@ class Project(models.Model):
         except Project.DoesNotExist:
             return None
 
+    @cached_property
+    def is_shared_datasets_project(self) -> bool:
+        """
+        Returns `True` if the project is the shared datasets project, otherwise `False`.
+        """
+        return self.name == SHARED_DATASETS_PROJECT_NAME
+
     def get_missing_localized_layers(self) -> list[dict[str, Any]]:
         """
         Of all localized layers, return those whose filenames aren’t in `available_filenames`,

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     from qfieldcloud.filestorage.models import File
 
 
-LOCALIZED_DATASETS_PROJECT_NAME = "localized_datasets"
+SHARED_DATASETS_PROJECT_NAME = "shared_datasets"
 
 # http://springmeblog.com/2018/how-to-implement-multiple-user-types-with-django/
 
@@ -1251,13 +1251,13 @@ class Project(models.Model):
     )
 
     @cached_property
-    def localized_datasets_project(self) -> Project | None:
+    def shared_datasets_project(self) -> Project | None:
         """
         Returns the localized datasets project for the same owner, or `None` if no such project exists.
         """
         try:
             project = Project.objects.get(
-                name=LOCALIZED_DATASETS_PROJECT_NAME,
+                name=SHARED_DATASETS_PROJECT_NAME,
                 owner=self.owner,
             )
             return project
@@ -1278,19 +1278,19 @@ class Project(models.Model):
         if not self.project_details:
             return []
 
-        if not self.localized_datasets_project:
+        if not self.shared_datasets_project:
             # Return all layers if the project is missing
             return self.localized_layers
 
         if self.uses_legacy_storage:
-            available_localized_files = utils.get_project_files(
-                str(self.localized_datasets_project.id)
+            available_shared_files = utils.get_project_files(
+                str(self.shared_datasets_project.id)
             )
-            available_filenames = [file.name for file in available_localized_files]
+            available_filenames = [file.name for file in available_shared_files]
 
         else:
             available_filenames = File.objects.filter(
-                project=self.localized_datasets_project
+                project=self.shared_datasets_project
             ).values_list("name", flat=True)
 
         missing_localized_layers = []
@@ -1489,7 +1489,7 @@ class Project(models.Model):
         problems = []
 
         # Check if localized datasets project, then skip the rest of the checks as they are not applicable
-        if self.name == LOCALIZED_DATASETS_PROJECT_NAME:
+        if self.name == SHARED_DATASETS_PROJECT_NAME:
             return problems
 
         if not self.has_the_qgis_file:
@@ -1506,17 +1506,17 @@ class Project(models.Model):
             )
 
         elif self.project_details:
-            if self.localized_datasets_project:
+            if self.shared_datasets_project:
                 localized_project_url = reverse_lazy(
                     "project_overview",
                     kwargs={
-                        "username": self.localized_datasets_project.owner.username,
-                        "project": self.localized_datasets_project.name,
+                        "username": self.shared_datasets_project.owner.username,
+                        "project": self.shared_datasets_project.name,
                     },
                 )
                 missing_localized_file_solution = _(
                     'Upload the missing file to the "<a href="{}">{}</a>" project or update the layer to point to an available file.'
-                ).format(localized_project_url, LOCALIZED_DATASETS_PROJECT_NAME)
+                ).format(localized_project_url, SHARED_DATASETS_PROJECT_NAME)
             else:
                 problems.append(
                     {
@@ -1524,14 +1524,14 @@ class Project(models.Model):
                         "level": "warning",
                         "code": "missing_localized_project",
                         "description": _('Could not find the "{}" project.').format(
-                            LOCALIZED_DATASETS_PROJECT_NAME
+                            SHARED_DATASETS_PROJECT_NAME
                         ),
                         "solution": _("Ensure the shared dataset project exists."),
                     }
                 )
                 missing_localized_file_solution = _(
                     'Upload the missing file to the "{}" project or update the layer to point to an available file.'
-                ).format(LOCALIZED_DATASETS_PROJECT_NAME)
+                ).format(SHARED_DATASETS_PROJECT_NAME)
 
             for missing_layer in self.get_missing_localized_layers():
                 problems.append(

--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -74,13 +74,11 @@ class ProjectSerializer(serializers.ModelSerializer):
     user_role = serializers.CharField(read_only=True)
     user_role_origin = serializers.CharField(read_only=True)
     private = serializers.BooleanField(allow_null=True, default=None)
-    localized_datasets_project_id = serializers.SerializerMethodField(read_only=True)
+    shared_datasets_project_id = serializers.SerializerMethodField(read_only=True)
 
-    def get_localized_datasets_project_id(self, obj):
-        project = obj.localized_datasets_project
-
-        if project:
-            return str(project.id)
+    def get_shared_datasets_project_id(self, obj: Project) -> str | None:
+        if obj.shared_datasets_project:
+            return str(obj.shared_datasets_project.id)
         else:
             return None
 
@@ -144,7 +142,7 @@ class ProjectSerializer(serializers.ModelSerializer):
             "status",
             "user_role",
             "user_role_origin",
-            "localized_datasets_project_id",
+            "shared_datasets_project_id",
         )
         read_only_fields = (
             "private",

--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -143,6 +143,7 @@ class ProjectSerializer(serializers.ModelSerializer):
             "user_role",
             "user_role_origin",
             "shared_datasets_project_id",
+            "is_shared_datasets_project",
         )
         read_only_fields = (
             "private",

--- a/docker-app/qfieldcloud/core/tests/test_localized_projects.py
+++ b/docker-app/qfieldcloud/core/tests/test_localized_projects.py
@@ -6,7 +6,7 @@ from rest_framework.test import APITransactionTestCase
 
 from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core.models import (
-    LOCALIZED_DATASETS_PROJECT_NAME,
+    SHARED_DATASETS_PROJECT_NAME,
     Job,
     Person,
     Project,
@@ -37,8 +37,8 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             name="project1", is_public=False, owner=self.user1
         )
 
-        self.localized_datasets_project = Project.objects.create(
-            name=LOCALIZED_DATASETS_PROJECT_NAME, is_public=False, owner=self.user1
+        self.shared_datasets_project = Project.objects.create(
+            name=SHARED_DATASETS_PROJECT_NAME, is_public=False, owner=self.user1
         )
 
     def get_localized_filenames_by_project_details(self, project: Project) -> list:
@@ -59,15 +59,15 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
         ]
         return filenames
 
-    def test_localized_datasets_project_id(self):
+    def test_shared_datasets_project_id(self):
         """
         Verifies that the localized dataset project ID is correctly returned
         as part of the main project's API metadata.
         """
         data = self.client.get(f"/api/v1/projects/{self.project1.id}/").json()
         self.assertEqual(
-            data.get("localized_datasets_project_id"),
-            str(self.localized_datasets_project.id),
+            data.get("shared_datasets_project_id"),
+            str(self.shared_datasets_project.id),
         )
 
     def test_localized_datasets_property(self):
@@ -106,7 +106,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
         """
         resp = self._upload_file(
             self.user1,
-            self.localized_datasets_project,
+            self.shared_datasets_project,
             "delta/polygons.geojson",
             io.FileIO(testdata_path("delta/polygons.geojson"), "rb"),
         )
@@ -132,17 +132,17 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
 
         # Localized layers found in the localized datasets project
         if self.project1.uses_legacy_storage:
-            available_localized_files = utils.get_project_files(
-                self.localized_datasets_project.id
+            available_shared_files = utils.get_project_files(
+                self.shared_datasets_project.id
             )
             available_localized_filenames = [
-                file.name for file in available_localized_files
+                file.name for file in available_shared_files
             ]
 
         else:
             available_localized_filenames = set(
                 File.objects.filter(
-                    project_id=self.localized_datasets_project.id
+                    project_id=self.shared_datasets_project.id
                 ).values_list("name", flat=True)
             )
 
@@ -169,7 +169,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
         # Upload the missing bumblebees.gpkg file
         resp = self._upload_file(
             self.user1,
-            self.localized_datasets_project,
+            self.shared_datasets_project,
             "bumblebees.gpkg",
             io.FileIO(testdata_path("bumblebees.gpkg"), "rb"),
         )
@@ -189,7 +189,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
         """
         resp = self._upload_file(
             self.user1,
-            self.localized_datasets_project,
+            self.shared_datasets_project,
             "bumblebees.gpkg",
             io.FileIO(testdata_path("bumblebees.gpkg"), "rb"),
         )

--- a/docker-app/qfieldcloud/core/tests/test_project.py
+++ b/docker-app/qfieldcloud/core/tests/test_project.py
@@ -555,6 +555,25 @@ class QfcTestCase(APITransactionTestCase):
 
         self.assertEqual(json["shared_datasets_project_id"], str(localized_project.id))
 
+    def test_project_serializer_is_shared_datasets_project(self):
+        """Test that ProjectSerializer returns is_shared_datasets_project correctly."""
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
+
+        project = Project.objects.create(name="project", owner=self.user1)
+        localized_project = Project.objects.create(
+            name=SHARED_DATASETS_PROJECT_NAME, owner=self.user1
+        )
+
+        response = self.client.get(f"/api/v1/projects/{project.id}/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()["is_shared_datasets_project"])
+
+        response = self.client.get(f"/api/v1/projects/{localized_project.id}/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["is_shared_datasets_project"])
+
     def test_get_shared_datasets_project_exists(self):
         """Test Project.shared_datasets_project returns the project if found."""
         project = Project.objects.create(name="project", owner=self.user1)
@@ -572,7 +591,7 @@ class QfcTestCase(APITransactionTestCase):
         self.assertIsNone(project.shared_datasets_project)
 
     def test_get_missing_localized_layers_when_no_localized_project(self):
-        """Test get_missing_localized_layers returns all localized layers if no localized_datasets project exists."""
+        """Test get_missing_localized_layers returns all localized layers if no shared datasets project exists."""
         project = Project.objects.create(name="project", owner=self.user1)
 
         project.project_details = {

--- a/docker-app/qfieldcloud/core/tests/test_project.py
+++ b/docker-app/qfieldcloud/core/tests/test_project.py
@@ -7,7 +7,7 @@ from rest_framework.test import APITransactionTestCase
 
 from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core.models import (
-    LOCALIZED_DATASETS_PROJECT_NAME,
+    SHARED_DATASETS_PROJECT_NAME,
     Organization,
     OrganizationMember,
     Person,
@@ -538,13 +538,13 @@ class QfcTestCase(APITransactionTestCase):
             self.assertEqual(len(layers), 1)
             self.assertEqual(layers[0]["filename"], "localized:layer1.tif")
 
-    def test_project_serializer_localized_datasets_project_id(self):
-        """Test that ProjectSerializer returns the correct localized_datasets_project_id."""
+    def test_project_serializer_shared_datasets_project_id(self):
+        """Test that ProjectSerializer returns the correct shared_datasets_project_id."""
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
 
         project = Project.objects.create(name="project", owner=self.user1)
         localized_project = Project.objects.create(
-            name=LOCALIZED_DATASETS_PROJECT_NAME, owner=self.user1
+            name=SHARED_DATASETS_PROJECT_NAME, owner=self.user1
         )
 
         response = self.client.get(f"/api/v1/projects/{project.id}/")
@@ -553,25 +553,23 @@ class QfcTestCase(APITransactionTestCase):
 
         json = response.json()
 
-        self.assertEqual(
-            json["localized_datasets_project_id"], str(localized_project.id)
-        )
+        self.assertEqual(json["shared_datasets_project_id"], str(localized_project.id))
 
-    def test_get_localized_datasets_project_exists(self):
-        """Test Project.localized_datasets_project returns the project if found."""
+    def test_get_shared_datasets_project_exists(self):
+        """Test Project.shared_datasets_project returns the project if found."""
         project = Project.objects.create(name="project", owner=self.user1)
         localized_project = Project.objects.create(
-            name=LOCALIZED_DATASETS_PROJECT_NAME, owner=self.user1
+            name=SHARED_DATASETS_PROJECT_NAME, owner=self.user1
         )
 
-        self.assertIsNotNone(project.localized_datasets_project)
-        self.assertEqual(project.localized_datasets_project.id, localized_project.id)
+        self.assertIsNotNone(project.shared_datasets_project)
+        self.assertEqual(project.shared_datasets_project.id, localized_project.id)
 
-    def test_get_localized_datasets_project_missing(self):
-        """Test Project.localized_datasets_project returns None if not found."""
+    def test_get_shared_datasets_project_missing(self):
+        """Test Project.shared_datasets_project returns None if not found."""
         project = Project.objects.create(name="project", owner=self.user1)
 
-        self.assertIsNone(project.localized_datasets_project)
+        self.assertIsNone(project.shared_datasets_project)
 
     def test_get_missing_localized_layers_when_no_localized_project(self):
         """Test get_missing_localized_layers returns all localized layers if no localized_datasets project exists."""


### PR DESCRIPTION
Also rename the project name from `localized_datasets` to `shared_datasets`.

Improves the readability and explainability of the feature.

Note: there is a "breaking change" in the sense that `Project.localized_datasets_project_id` was renamed to `Project.shared_datasets_project_id` in the serializer, but the clients do not support this feature officially yet anyways, so it is acceptable.