### PR TITLE
createbuckets: Use mc alias set instead of mc config

### DIFF
--- a/docker-createbuckets/createbuckets.py
+++ b/docker-createbuckets/createbuckets.py
@@ -37,7 +37,7 @@ for storage_name, storage_config in STORAGES.items():
     bucket_name = storage_config["OPTIONS"]["bucket_name"]
 
     subprocess.run(
-        f"/usr/bin/mc config host add {storage_name} {endpoint_url} {access_key} {secret_key}",
+        f"/usr/bin/mc alias set {storage_name} {endpoint_url} {access_key} {secret_key}",
         shell=True,
         check=True,
     )


### PR DESCRIPTION
The `mc config` command was deprecated for a while, and has finally been removed in the most recent version of the `mc` client: https://github.com/minio/mc/pull/5201

So instead of `mc config host add` we should use `mc alias set` (according to [MinIO Client docs](https://min.io/docs/minio/linux/reference/minio-mc.html#create-an-alias-for-the-s3-compatible-service))

This change should therefore prevent (at least one source of) headaches should we eventually want to upgrade the `mc` version in the `docker-createbuckets` Dockerfile in the future.

---

The most recent version of `mc` would fail like this for an attempt to use `mc config`:

```
createbuckets-1  | mc: <ERROR> `config` is not a recognized command. Get help using `--help` flag.
```
