### PR TITLE
fix(sentry): do not send reports about `MultipleProjectsError` to sentry

### DIFF
--- a/docker-app/qfieldcloud/filestorage/view_helpers.py
+++ b/docker-app/qfieldcloud/filestorage/view_helpers.py
@@ -96,7 +96,7 @@ def upload_project_file_version(
         and project.the_qgis_file_name is not None
         and PurePath(filename) != PurePath(project.the_qgis_file_name)
     ):
-        logger.error(f"Only one QGIS project per project allowed for {filename=}!")
+        logger.info(f"Only one QGIS project per project allowed for {filename=}!")
 
         raise MultipleProjectsError("Only one QGIS project per project allowed")
 

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -347,6 +347,7 @@ if SENTRY_DSN:
         from qfieldcloud.core.exceptions import (
             AuthenticationViaTokenFailedError,
             InvalidRangeError,
+            MultipleProjectsError,
             ProjectAlreadyExistsError,
             ValidationError,
         )
@@ -370,6 +371,8 @@ if SENTRY_DSN:
             AuthenticationViaTokenFailedError,
             # The client sent the wrong/unsupported HTTP `Range` header that we cannot satisfy
             InvalidRangeError,
+            # the client attempted to upload a new .qgs/.qgz file, but the project already has one. The user must delete the QGIS file first before reuploading it.
+            MultipleProjectsError,
         )
 
         if "exc_info" in hint:


### PR DESCRIPTION
The client attempted to upload a new .qgs/.qgz file, but the project already has one. The user must delete the QGIS file first before reuploading it.