### PR TITLE
fix(dockerfile): docker warning that entrypoints should be passed as JSON

### DIFF
--- a/docker-createbuckets/Dockerfile
+++ b/docker-createbuckets/Dockerfile
@@ -12,4 +12,4 @@ RUN chmod +x /usr/bin/mc
 COPY ./createbuckets.py /createbuckets.py
 RUN chmod +x /createbuckets.py
 
-ENTRYPOINT /createbuckets.py
+ENTRYPOINT ["/createbuckets.py"]


### PR DESCRIPTION
```
Check warning on line 15 in docker-createbuckets/Dockerfile

GitHub Actions
/ Build and Push (createbuckets)
JSON arguments recommended for ENTRYPOINT/CMD to prevent unintended behavior related to OS signals

JSONArgsRecommended: JSON arguments recommended for ENTRYPOINT to prevent unintended behavior related to OS signals
More info: https://docs.docker.com/go/dockerfile/rule/json-args-recommended/
```