### PR TITLE
feat(api): support search by project name or owner username in /projects

### DIFF
--- a/docker-app/qfieldcloud/core/views/projects_views.py
+++ b/docker-app/qfieldcloud/core/views/projects_views.py
@@ -13,6 +13,7 @@ from qfieldcloud.core.models import Project, ProjectQueryset
 from qfieldcloud.core.serializers import ProjectSerializer
 from qfieldcloud.core.utils2 import storage
 from qfieldcloud.subscription.exceptions import QuotaError
+from rest_framework import filters as drf_filters
 from rest_framework import generics, permissions, viewsets
 
 User = get_user_model()
@@ -79,7 +80,12 @@ class ProjectViewSet(viewsets.ModelViewSet):
     lookup_url_kwarg = "projectid"
     permission_classes = [permissions.IsAuthenticated, ProjectViewSetPermissions]
     pagination_class = pagination.QfcLimitOffsetPagination()
-    filter_backends = [filters.DjangoFilterBackend, QfcOrderingFilter]
+    filter_backends = [
+        drf_filters.SearchFilter,
+        filters.DjangoFilterBackend,
+        QfcOrderingFilter,
+    ]
+    search_fields = ["owner__username", "name"]
     filterset_class = ProjectFilterSet
     ordering_fields = ["owner__username::alias=owner", "name", "created_at"]
 


### PR DESCRIPTION
Verified that there shouldn't be any performance issues as indices are used.

The search is performed as substring search after converting to UPPER().

See https://www.django-rest-framework.org/api-guide/filtering/#searchfilter