### PR TITLE
Shared Datasets: do not warn about missing datasets when they do exist

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1309,16 +1309,9 @@ class Project(models.Model):
             # Return all layers if the project is missing
             return self.localized_layers
 
-        if self.uses_legacy_storage:
-            available_shared_files = utils.get_project_files(
-                str(self.shared_datasets_project.id)
-            )
-            available_filenames = [file.name for file in available_shared_files]
-
-        else:
-            available_filenames = File.objects.filter(
-                project=self.shared_datasets_project
-            ).values_list("name", flat=True)
+        available_filenames = File.objects.filter(
+            project=self.shared_datasets_project
+        ).values_list("name", flat=True)
 
         missing_localized_layers = []
         for layer in self.localized_layers:

--- a/docker-app/qfieldcloud/core/tests/test_localized_projects.py
+++ b/docker-app/qfieldcloud/core/tests/test_localized_projects.py
@@ -40,10 +40,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             name=SHARED_DATASETS_PROJECT_NAME,
             is_public=False,
             owner=self.user1,
-        )
-
-        Project.objects.filter(pk=self.shared_datasets_project.pk).update(
-            file_storage="default"
+            file_storage="default",
         )
 
         self.shared_datasets_project.refresh_from_db()
@@ -139,9 +136,9 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
 
         # Localized layers found in the localized datasets project
         available_localized_filenames = set(
-            File.objects.filter(project_id=self.shared_datasets_project.id).values_list(
-                "name", flat=True
-            )
+            File.objects.filter(
+                project_id=self.shared_datasets_project.id,
+            ).values_list("name", flat=True)
         )
 
         self.assertEqual(len(available_localized_filenames), 1)

--- a/docker-app/qfieldcloud/core/tests/test_localized_projects.py
+++ b/docker-app/qfieldcloud/core/tests/test_localized_projects.py
@@ -10,7 +10,6 @@ from qfieldcloud.core.models import (
     Job,
     Person,
     Project,
-    utils,
 )
 from qfieldcloud.core.tests.mixins import QfcFilesTestCaseMixin
 from qfieldcloud.core.tests.utils import (
@@ -38,8 +37,16 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
         )
 
         self.shared_datasets_project = Project.objects.create(
-            name=SHARED_DATASETS_PROJECT_NAME, is_public=False, owner=self.user1
+            name=SHARED_DATASETS_PROJECT_NAME,
+            is_public=False,
+            owner=self.user1,
         )
+
+        Project.objects.filter(pk=self.shared_datasets_project.pk).update(
+            file_storage="default"
+        )
+
+        self.shared_datasets_project.refresh_from_db()
 
     def get_localized_filenames_by_project_details(self, project: Project) -> list:
         filenames = []
@@ -131,20 +138,11 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
         self.assertIsNotNone(processprojectfile_job.feedback)
 
         # Localized layers found in the localized datasets project
-        if self.project1.uses_legacy_storage:
-            available_shared_files = utils.get_project_files(
-                self.shared_datasets_project.id
+        available_localized_filenames = set(
+            File.objects.filter(project_id=self.shared_datasets_project.id).values_list(
+                "name", flat=True
             )
-            available_localized_filenames = [
-                file.name for file in available_shared_files
-            ]
-
-        else:
-            available_localized_filenames = set(
-                File.objects.filter(
-                    project_id=self.shared_datasets_project.id
-                ).values_list("name", flat=True)
-            )
+        )
 
         self.assertEqual(len(available_localized_filenames), 1)
 


### PR DESCRIPTION
This PR resolved the issue with the warning about missing shared datasets in the project, even when the datasets were present and accessible.

**Scenario**
A project has been created in legacy storage mode
The dedicated `shared_datasets` project has been created in default storage mode

**Solution**
As the dedicated `shared_datasets` project is always created via default storage, all its files must be retrieved via the `file` model. 
