### PR TITLE
Improve attachment on demand help description

### DIFF
--- a/docker-app/qfieldcloud/core/migrations/0084_project_is_attachment_download_on_demand.py
+++ b/docker-app/qfieldcloud/core/migrations/0084_project_is_attachment_download_on_demand.py
@@ -14,7 +14,8 @@ class Migration(migrations.Migration):
             name="is_attachment_download_on_demand",
             field=models.BooleanField(
                 default=False,
-                help_text="If enabled, it indicates to the client (e.g. QField) that the attachments may be downloaded on demand.",
+                verbose_name="On demand attachment files download",
+                help_text="If enabled, attachment files should be downloaded on demand with QField.",
             ),
         ),
     ]

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1285,7 +1285,7 @@ class Project(models.Model):
     is_attachment_download_on_demand = models.BooleanField(
         default=False,
         help_text=_(
-            "If enabled, it indicates to the client (e.g. QField) that the attachments may be downloaded on demand."
+            "If enabled, attachment files should be downloaded on demand on QField."
         ),
     )
 

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1284,8 +1284,9 @@ class Project(models.Model):
     # projects with large or numerous attachments.
     is_attachment_download_on_demand = models.BooleanField(
         default=False,
+        verbose_name=_("On demand attachment files download"),
         help_text=_(
-            "If enabled, attachment files should be downloaded on demand on QField."
+            "If enabled, attachment files should be downloaded on demand with QField."
         ),
     )
 


### PR DESCRIPTION
Trying to improve the wording a bit to ease understand. Using "should" instead of "may" to make it clear it's a behavior that will be enforced. I think we don't need the QField client bit, removing it makes for a shorter and clearer reading IMHO.