### PR TITLE
Introduce concept of data directories

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1464,9 +1464,6 @@ class Project(models.Model):
         Attachment dir is a special directory in the QField infrastructure that holds attachment files
         such as images, pdf etc. By default "DCIM" is considered a attachment directory.
 
-        TODO this function expects whether `attachment_dirs` key in project_details. However,
-        neither the extraction from the projectfile, nor the configuration in QFieldSync are implemented.
-
         Returns:
             A list configured attachment dirs for the project.
         """
@@ -1479,6 +1476,26 @@ class Project(models.Model):
             attachment_dirs = ["DCIM"]
 
         return attachment_dirs
+
+    @property
+    def data_dirs(self) -> list[str]:
+        """Returns a list of configured data dirs for the project.
+
+        Data dir is a special directory in the QField infrastructure that holds assets
+        used by the project symbology, layouts, or project plugins.
+
+        Unlike `attachmentDirs`, the `dataDirs` should always be served as a undivisible
+        part of project files.
+
+        Returns:
+            A list configured data dirs for the project.
+        """
+        data_dirs = []
+
+        if self.project_details and self.project_details.get("data_dirs"):
+            data_dirs = self.project_details.get("data_dirs", [])
+
+        return data_dirs
 
     @property
     def has_attachments_files(self) -> bool:

--- a/docker-qgis/entrypoint.py
+++ b/docker-qgis/entrypoint.py
@@ -95,6 +95,7 @@ def _call_libqfieldsync_packager(
     )
 
     attachment_dirs, _ = project.readListEntry("QFieldSync", "attachmentDirs", ["DCIM"])
+    data_dirs, _ = project.readListEntry("QFieldSync", "dataDirs", [])
     if offliner_type == OfflinerType.QGISCORE:
         offliner = QgisCoreOffliner()
     elif offliner_type == OfflinerType.PYTHONMINI:
@@ -111,7 +112,7 @@ def _call_libqfieldsync_packager(
         str(package_dir),
         vl_extent_wkt,
         vl_extent_crs,
-        attachment_dirs,
+        attachment_dirs + data_dirs,
         offliner=offliner,
         export_type=ExportType.Cloud,
         create_basemap=False,

--- a/docker-qgis/qfc_worker/process_projectfile.py
+++ b/docker-qgis/qfc_worker/process_projectfile.py
@@ -118,6 +118,7 @@ def extract_project_details(project: QgsProject) -> dict[str, str]:
     details["attachment_dirs"], _ = project.readListEntry(
         "QFieldSync", "attachmentDirs", ["DCIM"]
     )
+    details["data_dirs"], _ = project.readListEntry("QFieldSync", "dataDirs", [])
 
     logger.info(
         f"QGIS project layer checks\n{layers_data_to_string(details['layers_by_id'])}",


### PR DESCRIPTION
Since we now have on-demand attachment download, using the attachment directories' trick to ship additional project assets (images used in symbology, print/atlas layouts, and decorators as well as files used by project plugin) has become unreliable. If a given project is set to on demand, the necessary assets will not be downloaded by QField.

A good solution is to stop abusing attachment directories and come up with a new directory type, which I've named 'data'. This is how it looks in QFieldSync when configuring directories:

![image](https://github.com/user-attachments/assets/564cfe7a-0cdb-4d5e-8a84-716239c8185a)

_For the QFieldSync side of things, see https://github.com/opengisch/qfieldsync/pull/685_

@suricactus , as discussed over chat a while back.