### PR TITLE
Improve the has_restricted_projectfiles display name and description

### DIFF
--- a/docker-app/qfieldcloud/core/migrations/0076_project_restrict_project_modification.py
+++ b/docker-app/qfieldcloud/core/migrations/0076_project_restrict_project_modification.py
@@ -14,7 +14,8 @@ class Migration(migrations.Migration):
             name="has_restricted_projectfiles",
             field=models.BooleanField(
                 default=False,
-                help_text="Restrict modifications of QGIS/QField projectfiles to managers and administrators.",
+                verbose_name="Restrict project files",
+                help_text="If enabled, modifications of QGIS project configuration (.qgs, qgz, qgd) and QField project plugins files will be restricted to managers and administrators.",
             ),
         ),
     ]

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1189,8 +1189,9 @@ class Project(models.Model):
 
     has_restricted_projectfiles = models.BooleanField(
         default=False,
+        verbose_name=_("Restrict project files"),
         help_text=_(
-            "Restrict modifications of QGIS/QField projectfiles to managers and administrators."
+            "If enabled, modifications of QGIS project configuration (.qgs, qgz, qgd) and QField project plugins files will be restricted to managers and administrators."
         ),
     )
 


### PR DESCRIPTION
Because projectfiles is not an actual word :wink: 

Before (taken from app.qfield.cloud):
![image](https://github.com/user-attachments/assets/01e0cc5f-09c3-4cb8-a684-05521d2dac69)

PR:
![image](https://github.com/user-attachments/assets/53828f24-5ef7-45e3-9483-81a2981d919c)
