### PR TITLE
fix(core): switch collaborator field to SlugRelatedField using username

### DIFF
--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -262,7 +262,7 @@ class OrganizationSerializer(serializers.ModelSerializer):
 class ProjectCollaboratorSerializer(serializers.ModelSerializer):
     collaborator = serializers.SlugRelatedField(
         slug_field="username",
-        queryset=User.objects.all(),
+        queryset=User.objects.filter(type__in=(User.Type.PERSON, User.Type.TEAM)),
         help_text="Username of the person or team to add",
     )
     created_by = serializers.StringRelatedField()

--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -260,7 +260,11 @@ class OrganizationSerializer(serializers.ModelSerializer):
 
 
 class ProjectCollaboratorSerializer(serializers.ModelSerializer):
-    collaborator = serializers.StringRelatedField()
+    collaborator = serializers.SlugRelatedField(
+        slug_field="username",
+        queryset=User.objects.all(),
+        help_text="Username of the person or team to add",
+    )
     created_by = serializers.StringRelatedField()
     updated_by = serializers.StringRelatedField()
 

--- a/docker-app/qfieldcloud/core/tests/test_collaborators.py
+++ b/docker-app/qfieldcloud/core/tests/test_collaborators.py
@@ -1,0 +1,70 @@
+from rest_framework import status
+from rest_framework.test import APITransactionTestCase
+
+from qfieldcloud.authentication.models import AuthToken
+from qfieldcloud.core.models import Person, Project, ProjectCollaborator
+
+from .utils import setup_subscription_plans
+
+
+class QfcTestCase(APITransactionTestCase):
+    def setUp(self):
+        setup_subscription_plans()
+
+        self.user1 = Person.objects.create_user(username="user1", password="abc123")
+        self.token1 = AuthToken.objects.get_or_create(user=self.user1)[0]
+
+        self.user2 = Person.objects.create_user(username="user2", password="abc123")
+        self.token2 = AuthToken.objects.get_or_create(user=self.user2)[0]
+
+    def test_add_collaborator_via_api(self):
+        project = Project.objects.create(
+            name="api_collab_test",
+            is_public=False,
+            owner=self.user1,
+        )
+
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
+
+        response = self.client.post(
+            f"/api/v1/collaborators/{project.id}/",
+            {
+                "collaborator": "user2",
+                "role": "manager",
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        data = response.json()
+
+        self.assertEqual(data["collaborator"], "user2")
+        self.assertEqual(data["role"], "manager")
+        self.assertEqual(data["project_id"], str(project.id))
+
+        collaborators = ProjectCollaborator.objects.filter(project=project)
+
+        self.assertEqual(collaborators.count(), 1)
+
+        project_collaborator = collaborators.first()
+
+        self.assertEqual(project_collaborator.collaborator, self.user2)
+        self.assertEqual(project_collaborator.role, ProjectCollaborator.Roles.MANAGER)
+
+    def test_add_unknown_collaborator_bad_request(self):
+        project = Project.objects.create(
+            name="api_collab_bad",
+            is_public=False,
+            owner=self.user1,
+        )
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
+
+        response = self.client.post(
+            f"/api/v1/collaborators/{project.id}/",
+            {
+                "collaborator": "no_such_user",
+                "role": "reader",
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/docker-app/qfieldcloud/core/views/collaborators_views.py
+++ b/docker-app/qfieldcloud/core/views/collaborators_views.py
@@ -2,7 +2,7 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from qfieldcloud.core import pagination, permissions_utils
-from qfieldcloud.core.models import Person, Project, ProjectCollaborator
+from qfieldcloud.core.models import Project, ProjectCollaborator
 from qfieldcloud.core.serializers import ProjectCollaboratorSerializer
 from rest_framework import generics, permissions, status
 from rest_framework.response import Response
@@ -51,7 +51,7 @@ class ListCreateCollaboratorsView(generics.ListCreateAPIView):
     def post(self, request, projectid):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        collaborator = Person.objects.get(username=request.data["collaborator"])
+        collaborator = serializer.validated_data["collaborator"]
         project = Project.objects.get(id=projectid)
         serializer.save(
             collaborator=collaborator,


### PR DESCRIPTION
This PR solved the issue of adding a collaborator, which caused a KeyError as it was reading directly from request.data["collaborator"]. 

**Changes**
`ProjectCollaboratorSerializer` has been updated so that the collaborator field is now a writable `SlugRelatedField` instead of a read-only `StringRelatedField`.