### PR TITLE
Fix file storage bytes help description in the project admin page

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -870,7 +870,7 @@ class ProjectAdmin(QFieldCloudModelAdmin):
     def get_form(self, *args, **kwargs):
         help_texts = {
             "file_storage_bytes": _(
-                "Use this value to limit the maximum number of file versions. When empty current plan's default will be used. Usually availlable to Premium users only."
+                "This value represents the total size of the project in bytes, including the space taken by the stored file versions."
             )
         }
         kwargs.update({"help_texts": help_texts})


### PR DESCRIPTION
Just noticed that the project admin page has a wrong description string for the file storage bytes field:

![image](https://github.com/user-attachments/assets/cba16159-7b7f-4665-b750-5d6a40673850)

This PR fixes the situation. 