### PR TITLE
fix(files): make files widget download the latest version when no version is selected

### DIFF
--- a/docker-app/qfieldcloud/core/templates/admin/project_files_widget.html
+++ b/docker-app/qfieldcloud/core/templates/admin/project_files_widget.html
@@ -219,8 +219,8 @@
                             // selected or most recent file version
                             const version = $versionsSelect.value || (
                                 file.versions
-                                    .map(obj => obj.version_id)
-                                    .sort((a, b) => String(b).localeCompare(String(a)))[0]
+                                    .find(obj => obj.is_latest === true)
+                                    .version_id
                             );
                             window.open(buildApiUrl(pathToFile, { version }));
                         });


### PR DESCRIPTION
Basically the title. Considering we'll always have a file version having the `is_latest` boolean flag to true.

![image](https://github.com/user-attachments/assets/87956eb6-04b8-4cc5-96c9-086f0219700a)
