### PR TITLE
fix(secrets): make the project field nullable in secret admin

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -627,7 +627,15 @@ class OwnerTypeFilter(admin.SimpleListFilter):
 class ProjectSecretForm(ModelForm):
     class Meta:
         model = Secret
-        fields = ("project", "name", "type", "value", "created_by")
+        fields = (
+            "project",
+            "name",
+            "type",
+            "assigned_to",
+            "organization",
+            "value",
+            "created_by",
+        )
 
     name = fields.CharField(widget=widgets.TextInput)
     value = fields.CharField(widget=widgets.Textarea)

--- a/docker-app/qfieldcloud/core/migrations/0085_alter_secret_options_and_more.py
+++ b/docker-app/qfieldcloud/core/migrations/0085_alter_secret_options_and_more.py
@@ -139,6 +139,7 @@ class Migration(migrations.Migration):
             name="project",
             field=models.ForeignKey(
                 null=True,
+                blank=True,
                 on_delete=django.db.models.deletion.CASCADE,
                 related_name="secrets",
                 to="core.project",

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -2458,7 +2458,11 @@ class Secret(models.Model):
     )
     type = models.CharField(max_length=32, choices=Type.choices)
     project = models.ForeignKey(
-        Project, on_delete=models.CASCADE, related_name="secrets", null=True
+        Project,
+        on_delete=models.CASCADE,
+        related_name="secrets",
+        null=True,
+        blank=True,
     )
 
     # The user the secret belongs to. Allows a user to have custom overrides to project envvars and pgservice.


### PR DESCRIPTION
Secrets are not strongly related to a Project now, since there are also Organization-assigned Secrets. This PR makes the project nullable in the Admin form for Secrets.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/ef2f26f1-dbd3-47d9-b901-12fa93149060) | ![image](https://github.com/user-attachments/assets/dc7ee613-b220-4518-8528-53b3c9572b61) |

Migration-less approach considered here.