### PR TITLE
feat(status): add health check for database and configured storages

### DIFF
--- a/docker-app/qfieldcloud/core/tests/test_api.py
+++ b/docker-app/qfieldcloud/core/tests/test_api.py
@@ -36,9 +36,16 @@ class QfcTestCase(APITransactionTestCase):
 
     def test_api_status(self):
         response = self.client.get("/api/v1/status/")
+
         self.assertTrue(status.is_success(response.status_code))
-        self.assertEqual(response.json()["storage"], "ok")
-        self.assertEqual(response.json()["geodb"], "ok")
+
+        data = response.json()
+
+        self.assertIn("database", data)
+        self.assertEqual(data["database"], "ok")
+
+        self.assertIn("storage", data)
+        self.assertEqual(data["storage"], "ok")
 
     def test_api_status_cache(self):
         tic = time.perf_counter()


### PR DESCRIPTION
This PR adds a health-check status for every configured storage in the `/status` endpoint, as well as one for the database.

Before, the server was responding a json like : `{"geodb":"ok","storage":"ok"}`

This PR makes QFC respond a json like : `{"database": "ok", "storage": "ok"}`

- No more `geodb` check
- Each storage is checked based on its type (S3, webdav, etc.), one single `storage` key keeps being answered by the API.