### PR TITLE
clean(storage): study and enhance filestorage migration command

### DIFF
--- a/docker-app/qfieldcloud/filestorage/migrate_project_storage.py
+++ b/docker-app/qfieldcloud/filestorage/migrate_project_storage.py
@@ -36,9 +36,11 @@ def migrate_project_storage(
 
     from_storage = project.file_storage
 
+    # project given as parameter should already have been filtered, to exclude the new/default storage.
+    # basically, this should never happen, but we check it just in case.
     if from_storage == to_storage:
         raise Exception(
-            f'Cannot migrate to storage "{to_storage}", project is already stored there!'
+            f'Cannot migrate to storage "{to_storage}", project {project.id} is already stored there!'
         )
 
     if from_storage not in settings.STORAGES:


### PR DESCRIPTION
This PR to study and optimize the file storage migration command for migrating projects storage.

Considering the projects stored on the `default` storage should not be migrated, this PR excludes them from ore-filtering based on CLI arguments.