### PR TITLE
feat(drf): ensure the login on drf browseable API page is also using allauth

### DIFF
--- a/docker-app/qfieldcloud/urls.py
+++ b/docker-app/qfieldcloud/urls.py
@@ -99,6 +99,22 @@ urlpatterns = [
     path("api/v1/auth/providers/", auth_views.ListProvidersView.as_view()),
     path("api/v1/auth/logout/", auth_views.LogoutView.as_view()),
     path("api/v1/", include("qfieldcloud.core.urls")),
+    path(
+        "auth/login/",
+        RedirectView.as_view(
+            url="/accounts/login/",
+            query_string=True,
+            permanent=False,
+        ),
+    ),
+    path(
+        "auth/logout/",
+        RedirectView.as_view(
+            url="/accounts/logout/",
+            query_string=True,
+            permanent=False,
+        ),
+    ),
     path("auth/", include("rest_framework.urls")),
     path("accounts/", include("allauth.urls")),
     path("invitations/", include("invitations.urls", namespace="invitations")),


### PR DESCRIPTION
Using the DRF browserable API, the users are invited to login but the login form that appears does not go through allauth. This should be fixed by now by explicitly redirecting users to the allauth alternatives. Unfortunately we still need to keep the `    path("auth/", include("rest_framework.urls")),`, otherwise the login button does not appear at all.


<img width="2260" height="927" alt="image" src="https://github.com/user-attachments/assets/14bff357-c52b-464e-95ce-e972b6bc30ae" />
