### PR TITLE
feat(admin): add assigned_to to inline project secrets

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -680,10 +680,10 @@ class SecretAdmin(QFieldCloudModelAdmin):
     model = Secret
     form = ProjectSecretForm
     fields = (
-        "project",
         "name",
         "type",
         "assigned_to",
+        "project",
         "organization",
         "created_by",
         "value",

--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -734,16 +734,25 @@ class SecretAdmin(QFieldCloudModelAdmin):
 
     def get_changeform_initial_data(self, request):
         project_id = request.GET.get("project_id")
+        organization_id = request.GET.get("organization_id")
 
-        if project_id:
+        try:
             project = Project.objects.get(id=project_id)
-        else:
+        except Exception:
             project = None
 
-        return {"project": project}
+        try:
+            organization = Organization.objects.get(id=organization_id)
+        except Exception:
+            organization = None
+
+        return {
+            "project": project,
+            "organization": organization,
+        }
 
 
-class ProjectSecretInline(QFieldCloudInlineAdmin):
+class SecretInlineBase(QFieldCloudInlineAdmin):
     model = Secret
     fields = ("link_to_secret", "type", "assigned_to", "created_by")
     readonly_fields = ("link_to_secret",)
@@ -764,6 +773,10 @@ class ProjectSecretInline(QFieldCloudInlineAdmin):
     def has_delete_permission(self, request, obj=None):
         return False
 
+    def get_query_params(self) -> dict[str, str]:
+        """Return query parameters for the 'Add Secret' button."""
+        return {}
+
     @property
     def bottom_html(self):
         if self.parent_obj:
@@ -775,11 +788,29 @@ class ProjectSecretInline(QFieldCloudInlineAdmin):
                     </a>
                 """,
                 url=reverse("admin:core_secret_add"),
-                query_params=urlencode({"project_id": self.parent_obj.pk}),
+                query_params=urlencode(self.get_query_params()),
                 text="Add Secret",
             )
         else:
             return ""
+
+
+class ProjectSecretInline(SecretInlineBase):
+    def get_query_params(self) -> dict[str, str]:
+        """Return query parameters for the 'Add Secret' button."""
+        return {
+            "project_id": str(self.parent_obj.pk),
+        }
+
+
+class OrganizationSecretInline(SecretInlineBase):
+    fk_name = "organization"
+
+    def get_query_params(self) -> dict[str, str]:
+        """Return query parameters for the 'Add Secret' button."""
+        return {
+            "organization_id": str(self.parent_obj.pk),
+        }
 
 
 class ProjectForm(ModelForm):
@@ -1367,6 +1398,7 @@ class OrganizationAdmin(QFieldCloudModelAdmin):
         ProjectInline,
         OrganizationMemberInline,
         TeamInline,
+        OrganizationSecretInline,
     )
     fields = (
         "storage_usage__field",

--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -745,7 +745,7 @@ class SecretAdmin(QFieldCloudModelAdmin):
 
 class ProjectSecretInline(QFieldCloudInlineAdmin):
     model = Secret
-    fields = ("link_to_secret", "type", "created_by")
+    fields = ("link_to_secret", "type", "assigned_to", "created_by")
     readonly_fields = ("link_to_secret",)
     max_num = 0
     extra = 0


### PR DESCRIPTION
Inline secrets in projects admin:

| before | after |
|-|-|
| <img width="1654" height="456" alt="image" src="https://github.com/user-attachments/assets/27b1f479-b4b8-40be-8d3b-315f6b73aed8" /> | <img width="1654" height="456" alt="image" src="https://github.com/user-attachments/assets/89ccf090-7171-4bc1-a2b4-fd5aa1ba0885" /> |

Same goes for the newly added inline secrets in organizations admin.

Standalone admin:
| before | after |
|-|-|
| <img width="1654" height="718" alt="image" src="https://github.com/user-attachments/assets/81725fc6-2021-405b-9417-c4a152516477" /> | <img width="1654" height="718" alt="image" src="https://github.com/user-attachments/assets/71d3c008-fedf-446b-b449-db7113fe58ed" /> |
