### PR TITLE
fix: prevent N+1 problem when listing projects with a lot of files

### DIFF
--- a/docker-app/qfieldcloud/core/fields.py
+++ b/docker-app/qfieldcloud/core/fields.py
@@ -6,6 +6,7 @@ from typing import Any, Protocol, cast
 from django.core.files.storage import storages
 from django.db import models
 from django.db.models.fields.files import FieldFile, ImageField, ImageFieldFile
+from django.utils.functional import lazy
 
 
 class FileStorageNameModelProtocol(Protocol):
@@ -47,21 +48,29 @@ class DynamicStorageFieldFile(FieldFile):
 
         super().__init__(instance, field, name)
 
-        # NOTE if the model is not saved yet, there is a chance that it was instantiated without values
-        # for the foreign keys. In some models, e.g. `filestorage.FileVersion`, calling `_get_file_storage_name`
-        # requires a foreign key value. Therefore we return the `default` storage for those cases.
-        try:
-            storage_name = instance._get_file_storage_name()
-        except Exception:
-            if instance._state.adding:
-                storage_name = "default"
-            else:
-                raise
+        # NOTE lazy evaluation is used to greatly optimize the performance of the field.
+        # The the `__init__` is called every time when the model where the field is used is instantiated,
+        # but the storage is not needed until the file is accessed.
+        @lazy
+        def get_storage():
+            # NOTE if the model is not saved yet, there is a chance that it was instantiated without values
+            # for the foreign keys. In some models, e.g. `filestorage.FileVersion`, calling `_get_file_storage_name`
+            # requires a foreign key value. Therefore we return the `default` storage for those cases.
+            try:
+                storage_name = instance._get_file_storage_name()
+            except Exception:
+                if instance._state.adding:
+                    storage_name = "default"
+                else:
+                    raise
 
-        if not storage_name:
-            raise EmptyStorageNameError(instance=instance)
+            if not storage_name:
+                raise EmptyStorageNameError(instance=instance)
 
-        self.storage = storages[storage_name]
+            """Get the storage instance based on the storage name."""
+            return storages[storage_name]
+
+        self.storage = get_storage()
 
 
 class DynamicStorageFileField(models.FileField):


### PR DESCRIPTION
See individual commit messages and comments in the code.

We remove the default `storage` attribute added by the base class `FieldFile`, and we later add a cached property that computes the `storage` dynamically.
This is done to avoid the `storage` being calculated at each instantiation of the `DynamicStorageFieldFile`.
Using the cached and on-demand `storage` property calculation greatly optimizes the performance of the field, by saving N*3 database query calls.
The actual value of the `storage` property is not needed until the file is accessed.

Further optimize with `select_related` and `prefetch_related` on the files endpoint.