### PR TITLE
typing: do not assign None if the variable is not None-able 

### DIFF
--- a/docker-app/qfieldcloud/core/tests/test_packages.py
+++ b/docker-app/qfieldcloud/core/tests/test_packages.py
@@ -96,8 +96,8 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
         project: Project,
         files: list[tuple[str, str]],
         expected_files: list[str],
-        job_create_error: tuple[int, str] = None,
-        tempdir: str = None,
+        job_create_error: tuple[int, str] | None = None,
+        tempdir: str | None = None,
         invalid_layers: list[str] = [],
     ):
         self.upload_files(token, project, files)
@@ -110,8 +110,8 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
         token: str,
         project: Project,
         expected_files: list[str],
-        job_create_error: tuple[int, str] = None,
-        tempdir: str = None,
+        job_create_error: tuple[int, str] | None = None,
+        tempdir: str | None = None,
         invalid_layers: list[str] = [],
     ):
         self.client.credentials(HTTP_AUTHORIZATION=f"Token {token}")

--- a/docker-app/qfieldcloud/core/tests/test_packages.py
+++ b/docker-app/qfieldcloud/core/tests/test_packages.py
@@ -98,7 +98,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
         expected_files: list[str],
         job_create_error: tuple[int, str] | None = None,
         tempdir: str | None = None,
-        invalid_layers: list[str] = [],
+        invalid_layers: list[str] | None = None,
     ):
         self.upload_files(token, project, files)
         self.check_package(
@@ -112,7 +112,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
         expected_files: list[str],
         job_create_error: tuple[int, str] | None = None,
         tempdir: str | None = None,
-        invalid_layers: list[str] = [],
+        invalid_layers: list[str] | None = None,
     ):
         self.client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
 
@@ -179,7 +179,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
                 for layer_id in package_payload["layers"]:
                     layer_data = package_payload["layers"][layer_id]
 
-                    if layer_id in invalid_layers:
+                    if invalid_layers and layer_id in invalid_layers:
                         self.assertFalse(layer_data["is_valid"], layer_id)
                     else:
                         self.assertTrue(layer_data["is_valid"], layer_id)

--- a/docker-app/qfieldcloud/core/tests/test_queryset.py
+++ b/docker-app/qfieldcloud/core/tests/test_queryset.py
@@ -156,8 +156,8 @@ class QfcTestCase(APITransactionTestCase):
         self,
         project,
         user,
-        role: ProjectCollaborator.Roles = None,
-        origin: ProjectQueryset.RoleOrigins = None,
+        role: ProjectCollaborator.Roles | None = None,
+        origin: ProjectQueryset.RoleOrigins | None = None,
         is_valid: bool = True,
     ):
         """Asserts that user has give role/origin on project"""

--- a/docker-app/qfieldcloud/core/tests/utils.py
+++ b/docker-app/qfieldcloud/core/tests/utils.py
@@ -54,7 +54,7 @@ def setup_subscription_plans():
 
 def set_subscription(
     users: User | Iterable[User],
-    code: str = None,
+    code: str | None = None,
     **kwargs,
 ):
     users: list[User] = [users] if isinstance(users, User) else users

--- a/docker-app/qfieldcloud/subscription/tests/test_organization.py
+++ b/docker-app/qfieldcloud/subscription/tests/test_organization.py
@@ -30,8 +30,8 @@ class QfcTestCase(APITransactionTestCase):
         self,
         project,
         user,
-        role: ProjectCollaborator.Roles = None,
-        origin: ProjectQueryset.RoleOrigins = None,
+        role: ProjectCollaborator.Roles | None = None,
+        origin: ProjectQueryset.RoleOrigins | None = None,
         is_valid: bool = True,
     ):
         """Asserts that user has give role/origin on project"""


### PR DESCRIPTION
Typing and dangerous Python practices fixes around the code.