### PR TITLE
Fix last modified PK value match when modifying multiple offlined layers across multiple pushes

### DIFF
--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -432,12 +432,14 @@ class DeltaApplyJobRun(JobRun):
         local_to_remote_pk_deltas = Delta.objects.filter(
             client_id__in=delta_client_ids,
             last_modified_pk__isnull=False,
-        ).values("client_id", "content__localPk", "last_modified_pk")
+        ).values(
+            "client_id", "content__localLayerId", "content__localPk", "last_modified_pk"
+        )
 
         client_pks_map = {}
 
         for delta_with_modified_pk in local_to_remote_pk_deltas:
-            key = f"{delta_with_modified_pk['client_id']}__{delta_with_modified_pk['content__localPk']}"
+            key = f"{delta_with_modified_pk['client_id']}__{delta_with_modified_pk['content__localLayerId']}__{delta_with_modified_pk['content__localPk']}"
             client_pks_map[key] = delta_with_modified_pk["last_modified_pk"]
 
         deltafile_contents = {

--- a/docker-qgis/qfc_worker/apply_deltas.py
+++ b/docker-qgis/qfc_worker/apply_deltas.py
@@ -816,7 +816,9 @@ def get_feature(
     source_pk = delta["sourcePk"]
 
     if client_pks:
-        client_pk_key = f"{delta['clientId']}__{delta['localPk']}"
+        client_pk_key = (
+            f"{delta['clientId']}__{delta['localLayerId']}__{delta['localPk']}"
+        )
         if client_pk_key in client_pks:
             source_pk = client_pks[client_pk_key]
 


### PR DESCRIPTION
This PR fixes https://github.com/opengisch/QFieldCloud/issues/570 , big thanks to @Joonalai for having been able to nail down replicable steps to trigger this delta apply failure scenario.

Basically, we had code in place to track source primary keys (PK) when applying multiple deltas within a client's downloaded package instance (i.e. clientId). However, that system did not take the local/source layer into account. 

Say QField pushed a delta pushed to QFC that modifies a feature on source layer A where the offlined feature PK (i.e. localPk) is 1. The generated key that maps modified source PKs would be "clientID__1".

The map now looks like this:

"clientID__1": modifiedPk 

Where the modifiedPk = the PK in the source layer A.

If you then push another delta (within the same downloaded package instance, not having synchronized) to QFC that modifies a feature on source layer B _where the local PK of the feature being modified in the offlined layer B matches that of the offlined layer A_ , here 1, you would then generate a key that maps modified PKs that matches the previous push, i.e. "clientID__1".

Yet, the source layer B PK values are not connected at all to source layer A values.

"Best" case scenario, we don't find a matching feature, and we fail to apply the delta. Worse case scenario, we actually match against a completely different feature. That might lead to random deletion of features users never meant to remove.

The solution is to add a layerID value in the key that tracks modified PKs. This is what this PR does.