### PR TITLE
fix(admin): searching for secrets admin throws error 500

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -703,7 +703,7 @@ class SecretAdmin(QFieldCloudModelAdmin):
         "name__icontains",
         "project__name__icontains",
         "assigned_to__username__icontains",
-        "organization__name__icontains",
+        "organization__username__icontains",
     )
 
     @admin.display(ordering="created_by", description=_("Created by"))


### PR DESCRIPTION
search fields should not contain `organization__name__icontains`, but `organization__username__icontains`.