### PR TITLE
feat: added configuration to set incident info and status page url

### DIFF
--- a/docker-app/qfieldcloud/core/tests/test_api.py
+++ b/docker-app/qfieldcloud/core/tests/test_api.py
@@ -1,9 +1,6 @@
 import logging
-import time
 
 from django.conf import settings
-from django.core.cache import cache
-from rest_framework import status
 from rest_framework.test import APITransactionTestCase
 
 from qfieldcloud.authentication.models import AuthToken
@@ -16,9 +13,6 @@ logging.disable(logging.CRITICAL)
 
 class QfcTestCase(APITransactionTestCase):
     def setUp(self):
-        # Empty cache value
-        cache.delete("status_results")
-
         # Create needed subscription relations
         setup_subscription_plans()
 
@@ -33,26 +27,6 @@ class QfcTestCase(APITransactionTestCase):
             for n in range(self.total_projects)
         )
         Project.objects.bulk_create(projects)
-
-    def test_api_status(self):
-        response = self.client.get("/api/v1/status/")
-
-        self.assertTrue(status.is_success(response.status_code))
-
-        data = response.json()
-
-        self.assertIn("database", data)
-        self.assertEqual(data["database"], "ok")
-
-        self.assertIn("storage", data)
-        self.assertEqual(data["storage"], "ok")
-
-    def test_api_status_cache(self):
-        tic = time.perf_counter()
-        self.client.get("/api/v1/status/")
-        toc = time.perf_counter()
-
-        self.assertGreater(toc - tic, 0)
 
     def test_api_pagination_limitoffset(self):
         """Test LimitOffset pagination custom implementation"""

--- a/docker-app/qfieldcloud/core/tests/test_status.py
+++ b/docker-app/qfieldcloud/core/tests/test_status.py
@@ -1,0 +1,170 @@
+import logging
+import time
+from datetime import datetime
+
+from constance import config
+from constance.test import override_config
+from django.core.cache import cache
+from django.test import override_settings
+from rest_framework import status
+from rest_framework.test import APITransactionTestCase
+
+from qfieldcloud.core.views.status_views import StatusValue
+
+logging.disable(logging.CRITICAL)
+
+
+class QfcTestCase(APITransactionTestCase):
+    def setUp(self):
+        # Empty cache value
+        cache.clear()
+
+        # # Create needed subscription relations
+        # setup_subscription_plans()
+
+        # # Set up a user to own projects
+        # self.user = Person.objects.create_user(username="user1", password="abc123")
+        # self.token = AuthToken.objects.get_or_create(user=self.user)[0]
+
+    def test_status_api(self):
+        response = self.client.get("/api/v1/status/")
+
+        self.assertTrue(status.is_success(response.status_code))
+
+        data = response.json()
+
+        self.assertIn("database", data)
+        self.assertEqual(data["database"], StatusValue.OK)
+
+        self.assertIn("storage", data)
+        self.assertEqual(data["storage"], StatusValue.OK)
+
+        self.assertIn("status_page_url", data)
+        self.assertEqual(data["status_page_url"], config.STATUS_PAGE_URL)
+
+        self.assertIn("incident_timestamp_utc", data)
+        self.assertIsNone(data["incident_timestamp_utc"])
+
+        self.assertIn("incident_message", data)
+        self.assertIsNone(data["incident_message"])
+
+    @override_settings(STORAGES={})
+    def test_status_storage_fails_with_no_storages(self):
+        response = self.client.get("/api/v1/status/")
+
+        self.assertTrue(status.is_success(response.status_code))
+
+        data = response.json()
+
+        self.assertIn("database", data)
+        self.assertEqual(data["database"], StatusValue.OK)
+
+        self.assertIn("storage", data)
+        self.assertEqual(data["storage"], StatusValue.ERROR)
+
+        self.assertIn("status_page_url", data)
+        self.assertEqual(data["status_page_url"], config.STATUS_PAGE_URL)
+
+        self.assertIn("incident_timestamp_utc", data)
+        self.assertIsNone(data["incident_timestamp_utc"])
+
+        self.assertIn("incident_message", data)
+        self.assertIsNone(data["incident_message"])
+
+    @override_settings(
+        STORAGES={
+            "default": {
+                "BACKEND": "qfieldcloud.filestorage.backend.QfcS3Boto3Storage",
+                "OPTIONS": {
+                    "access_key": "minioadmin",
+                    "secret_key": "minioadmin",
+                    "bucket_name": "nonexistent-bucket",
+                    "region_name": "",
+                    "endpoint_url": "http://wrong.url",
+                },
+                "QFC_IS_LEGACY": False,
+            }
+        }
+    )
+    def test_status_storage_fails_with_wrong_config(self):
+        response = self.client.get("/api/v1/status/")
+
+        self.assertTrue(status.is_success(response.status_code))
+
+        data = response.json()
+
+        self.assertIn("database", data)
+        self.assertEqual(data["database"], StatusValue.OK)
+
+        self.assertIn("storage", data)
+        self.assertEqual(data["storage"], StatusValue.ERROR)
+
+        self.assertIn("status_page_url", data)
+        self.assertEqual(data["status_page_url"], config.STATUS_PAGE_URL)
+
+        self.assertIn("incident_timestamp_utc", data)
+        self.assertIsNone(data["incident_timestamp_utc"])
+
+        self.assertIn("incident_message", data)
+        self.assertIsNone(data["incident_message"])
+
+    @override_config(
+        INCIDENT_IS_ACTIVE=True,
+        INCIDENT_MESSAGE="Sample incident message.",
+        INCIDENT_TIMESTAMP_UTC=datetime(2002, 10, 18, 12, 0, 0),
+    )
+    def test_status_with_active_incident(self):
+        response = self.client.get("/api/v1/status/")
+
+        self.assertTrue(status.is_success(response.status_code))
+
+        data = response.json()
+
+        self.assertIn("database", data)
+        self.assertEqual(data["database"], StatusValue.OK)
+
+        self.assertIn("storage", data)
+        self.assertEqual(data["storage"], StatusValue.OK)
+
+        self.assertIn("status_page_url", data)
+        self.assertEqual(data["status_page_url"], config.STATUS_PAGE_URL)
+
+        self.assertIn("incident_message", data)
+        self.assertEqual(data["incident_message"], "Sample incident message.")
+
+        self.assertIn("incident_timestamp_utc", data)
+        self.assertEqual(data["incident_timestamp_utc"], "2002-10-18T12:00:00")
+
+    @override_config(
+        INCIDENT_IS_ACTIVE=False,
+        INCIDENT_MESSAGE="Sample incident message.",
+        INCIDENT_TIMESTAMP_UTC=datetime(2002, 10, 18, 12, 0, 0),
+    )
+    def test_status_with_inactive_incident(self):
+        response = self.client.get("/api/v1/status/")
+
+        self.assertTrue(status.is_success(response.status_code))
+
+        data = response.json()
+
+        self.assertIn("database", data)
+        self.assertEqual(data["database"], StatusValue.OK)
+
+        self.assertIn("storage", data)
+        self.assertEqual(data["storage"], StatusValue.OK)
+
+        self.assertIn("status_page_url", data)
+        self.assertEqual(data["status_page_url"], config.STATUS_PAGE_URL)
+
+        self.assertIn("incident_message", data)
+        self.assertIsNone(data["incident_message"])
+
+        self.assertIn("incident_timestamp_utc", data)
+        self.assertIsNone(data["incident_timestamp_utc"])
+
+    def test_status_cache(self):
+        tic = time.perf_counter()
+        self.client.get("/api/v1/status/")
+        toc = time.perf_counter()
+
+        self.assertGreater(toc - tic, 0)

--- a/docker-app/qfieldcloud/core/tests/test_status.py
+++ b/docker-app/qfieldcloud/core/tests/test_status.py
@@ -19,13 +19,6 @@ class QfcTestCase(APITransactionTestCase):
         # Empty cache value
         cache.clear()
 
-        # # Create needed subscription relations
-        # setup_subscription_plans()
-
-        # # Set up a user to own projects
-        # self.user = Person.objects.create_user(username="user1", password="abc123")
-        # self.token = AuthToken.objects.get_or_create(user=self.user)[0]
-
     def test_status_api(self):
         response = self.client.get("/api/v1/status/")
 

--- a/docker-app/qfieldcloud/core/views/status_views.py
+++ b/docker-app/qfieldcloud/core/views/status_views.py
@@ -1,10 +1,32 @@
-from django.core.cache import cache
+import logging
+from enum import Enum
+from typing import TypedDict
+
+from constance import config
 from django.core.files.storage import storages
 from django.db import connections
+from django.http import HttpRequest
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import status, views
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
+
+logger = logging.getLogger(__name__)
+
+
+class StatusValue(str, Enum):
+    OK = "ok"
+    ERROR = "error"
+
+
+class StatusDict(TypedDict):
+    database: StatusValue
+    storage: StatusValue
+    status_page_url: str | None
+    incident_message: str | None
+    incident_timestamp_utc: str | None
 
 
 @extend_schema_view(
@@ -13,38 +35,77 @@ from rest_framework.response import Response
 class APIStatusView(views.APIView):
     permission_classes = [AllowAny]
 
-    def get(self, request):
-        # Try to get the status from the cache
-        results = cache.get("status_results", {})
-        if not results:
-            # check database
-            results["database"] = "ok"
-            db_conn = connections["default"]
-            try:
-                with db_conn.cursor() as cursor:
-                    cursor.execute("SELECT 1")
-            except Exception:
-                results["database"] = "error"
+    @method_decorator(cache_page(60))
+    def get(self, _request: HttpRequest) -> Response:
+        results: StatusDict = {
+            "database": self._check_db(),
+            "storage": self._check_storages(),
+            "status_page_url": None,
+            "incident_message": None,
+            "incident_timestamp_utc": None,
+        }
 
-            # check storages
-            results["storage"] = "ok"
-            for storage_key in storages.backends.keys():
-                storage = storages[storage_key]
+        # add status page url if set
+        if config.STATUS_PAGE_URL:
+            results["status_page_url"] = config.STATUS_PAGE_URL
 
-                if not hasattr(storage, "check_status"):
-                    # Some storages may not have the check_status method.
-                    # e.g. ManifestStaticFilesStorage.
-                    continue
+        # add info about ongoing incident if any
+        if config.INCIDENT_IS_ACTIVE:
+            logger.warning(
+                "Incident is active, reporting incident details in status API since %s with message: %s",
+                config.INCIDENT_TIMESTAMP_UTC,
+                config.INCIDENT_MESSAGE,
+            )
 
-                try:
-                    if not storage.check_status():
-                        results["storage"] = "error"
-                        break
-                except Exception:
-                    results["storage"] = "error"
-                    break
-
-            # Cache the result for 10 minutes
-            cache.set("status_results", results, 600)
+            results["incident_message"] = config.INCIDENT_MESSAGE
+            results["incident_timestamp_utc"] = config.INCIDENT_TIMESTAMP_UTC
 
         return Response(results, status=status.HTTP_200_OK)
+
+    def _check_db(self) -> StatusValue:
+        try:
+            db_conn = connections.create_connection("default")
+
+            with db_conn.cursor() as cursor:
+                cursor.execute("SELECT 1")
+
+            return StatusValue.OK
+        except Exception:
+            logger.error('Failed to connect to the database "default".', exc_info=True)
+
+            # just to be safe, we catch all exceptions and set the status to error again.
+            return StatusValue.ERROR
+
+    def _check_storages(self) -> StatusValue:
+        checked_storage_count = 0
+
+        # check all storages are reachable
+        for storage_key in storages.backends.keys():
+            storage = storages[storage_key]
+
+            if not hasattr(storage, "check_status"):
+                # Some storages may not have the check_status method.
+                # e.g. ManifestStaticFilesStorage.
+                continue
+
+            checked_storage_count += 1
+
+            try:
+                if not storage.check_status():
+                    logger.error(f"Storage '{storage_key}' is not reachable.")
+
+                    # no need to check other storages if one already failed
+                    return StatusValue.ERROR
+            except Exception:
+                logger.error(
+                    f"Storage '{storage_key}' raised an error while checking status.",
+                    exc_info=True,
+                )
+
+                return StatusValue.ERROR
+
+        if checked_storage_count == 0:
+            # If no storage was checked, we consider it an error.
+            return StatusValue.ERROR
+
+        return StatusValue.OK

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -11,7 +11,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 
 import os
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
@@ -635,6 +635,22 @@ CONSTANCE_BACKEND = "constance.backends.database.DatabaseBackend"
 CONSTANCE_DATABASE_CACHE_BACKEND = "default"
 CONSTANCE_DATABASE_CACHE_AUTOFILL_TIMEOUT = 60 * 60 * 24
 CONSTANCE_CONFIG = {
+    "INCIDENT_IS_ACTIVE": (
+        False,
+        "Is there an ongoing incident? If checked, a banner will be shown on top of every page with the content of `INCIDENT_MESSAGE`.",
+        bool,
+    ),
+    "INCIDENT_TIMESTAMP_UTC": (
+        datetime(2025, 1, 1, 0, 0, 0),
+        "When the incident started. Put time in UTC!",
+        datetime,
+    ),
+    "INCIDENT_MESSAGE": (
+        "QFieldCloud is currently experiencing stability issues. Our team is investigating the problem.",
+        """The banner content to be shown on top of every page if `INCIDENT_IS_ACTIVE` is checked.
+        If the `STATUS_PAGE_URL` is set, a link to the status page will be appended automatically.""",
+        "textarea",
+    ),
     "WORKER_TIMEOUT_S": (
         600,
         "Timeout of the workers before being terminated by the wrapper in seconds.",
@@ -660,6 +676,11 @@ CONSTANCE_CONFIG = {
         "Days in which the trial period expires.",
         int,
     ),
+    "STATUS_PAGE_URL": (
+        "https://status.qfield.cloud/",
+        "Status page URL",
+        str,
+    ),
 }
 CONSTANCE_ADDITIONAL_FIELDS = {
     "textarea": [
@@ -670,6 +691,11 @@ CONSTANCE_ADDITIONAL_FIELDS = {
     ]
 }
 CONSTANCE_CONFIG_FIELDSETS = {
+    "Incidents": (
+        "INCIDENT_IS_ACTIVE",
+        "INCIDENT_TIMESTAMP_UTC",
+        "INCIDENT_MESSAGE",
+    ),
     "Worker": (
         "WORKER_TIMEOUT_S",
         "WORKER_QGIS_MEMORY_LIMIT",
@@ -677,6 +703,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
     ),
     "Debug": ("SENTRY_REQUEST_MAX_SIZE_TO_SEND",),
     "Subscription": ("TRIAL_PERIOD_DAYS",),
+    "Web": ("STATUS_PAGE_URL",),
 }
 
 # Minimum number of bytes to ask a range when requesting a file part, otherwise a HTTP 416 is returned. Set to 0 to allow any number of bytes in the range.


### PR DESCRIPTION
Added constance fields:

- STATUS_PAGE_URL - sets the status page
- INCIDENT_IS_ACTIVE - whether there is a known incident or not
- INCIDENT_TIMESTAMP_UTC - indicates when the incident started. We need
two separate fields with `INCIDENT_IS_ACTIVE` and
`INCIDENT_TIMESTAMP_UTC` because `constance` does not support the latter
to be nullable (it must be a datetime instance).
- INCIDENT_MESSAGE - message that can be shown to the users

<img width="2097" height="988" alt="image" src="https://github.com/user-attachments/assets/8d28b175-8a0b-4479-af50-8069764d3fa3" />


Also some tests improvements: moved tests about the GET status API in a dedicated file and test the newly added fields `status_page_url`, `incident_timestamp_utc` and `incident_message`
Addings tests for the `database == error` field is hard, as one cannot simply
overwrite the `DATABASES` settings. Django prevents this with:
> Overriding setting DATABASES can lead to unexpected behavior.

Finally, HTTP clients can enjoy cool stuff like:
```
{
    "database": "ok",
    "storage": "ok",
    "status_page_url": "https://status.qfield.cloud/",
    "incident_message": "QFieldCloud is currently experiencing stability issues. Our team is investigating the problem.",
    "incident_timestamp_utc": "2025-01-01T00:00:00"
}
```