### PR TITLE
test(delta): multiple deltas with same PK value in different layers are applied correctly

### DIFF
--- a/docker-app/qfieldcloud/core/tests/test_delta.py
+++ b/docker-app/qfieldcloud/core/tests/test_delta.py
@@ -1286,14 +1286,16 @@ class QfcTestCase(APITransactionTestCase):
                         json.dumps(payload[idx], sort_keys=True, indent=2),
                     )
 
-                    for job in Job.objects.all():
-                        job = Job.objects.latest("updated_at")
-                        print("Job:\n", job.type, job.status)
-                        print("Output:\n", job.output)
-                        print(
-                            "Feedback:\n",
-                            json.dumps(job.feedback, sort_keys=True, indent=2),
-                        )
+                    job = Job.objects.filter(type=Job.Type.DELTA_APPLY).latest(
+                        "updated_at"
+                    )
+
+                    print("Job:\n", job.type, job.status)
+                    print("Output:\n", job.output)
+                    print(
+                        "Feedback:\n",
+                        json.dumps(job.feedback, sort_keys=True, indent=2),
+                    )
 
                     raise err
 

--- a/docker-app/qfieldcloud/core/tests/test_delta.py
+++ b/docker-app/qfieldcloud/core/tests/test_delta.py
@@ -1066,6 +1066,8 @@ class QfcTestCase(APITransactionTestCase):
         2. Push the deltas (NOT sync, we should not know the remote PK on the client).
         3. Modify the same two features and push the deltas.
         4. Check that the deltas have been applied correctly.
+        5. Delete the same two features and push the deltas.
+        6. Check that the deltas have been applied correctly.
 
         See https://github.com/opengisch/QFieldCloud/issues/570#issuecomment-3183791135
         """
@@ -1101,6 +1103,23 @@ class QfcTestCase(APITransactionTestCase):
                 ],
                 [
                     "9311eb96-bff8-4d5b-ab36-c314a007cfc4",
+                    "STATUS_APPLIED",
+                    self.user1.username,
+                ],
+            ],
+        )
+        self.upload_and_check_deltas(
+            project=project,
+            delta_filename="multilayer_multidelta_delete.json",
+            token=self.token1.key,
+            final_values=[
+                [
+                    "9311eb96-bff8-4d5b-ab36-c314a007cfc5",
+                    "STATUS_APPLIED",
+                    self.user1.username,
+                ],
+                [
+                    "9311eb96-bff8-4d5b-ab36-c314a007cfc6",
                     "STATUS_APPLIED",
                     self.user1.username,
                 ],

--- a/docker-app/qfieldcloud/core/tests/test_delta.py
+++ b/docker-app/qfieldcloud/core/tests/test_delta.py
@@ -1058,6 +1058,55 @@ class QfcTestCase(APITransactionTestCase):
             self.assertEqual(features[1]["properties"]["int"], 2)
             self.assertEqual(features[2]["properties"]["int"], 3)
 
+    def test_push_list_multilayer_multidelta_same_pk(self):
+        """
+        Test that multiple deltas with same PK value in different layers are applied correctly
+
+        1. Create two features with same local PK in different layers (and unknown remote PK).
+        2. Push the deltas (NOT sync, we should not know the remote PK on the client).
+        3. Modify the same two features and push the deltas.
+        4. Check that the deltas have been applied correctly.
+
+        See https://github.com/opengisch/QFieldCloud/issues/570#issuecomment-3183791135
+        """
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
+        project = self.upload_project_files(self.project1)
+
+        self.upload_and_check_deltas(
+            project=project,
+            delta_filename="multilayer_multidelta_create.json",
+            token=self.token1.key,
+            final_values=[
+                [
+                    "9311eb96-bff8-4d5b-ab36-c314a007cfc1",
+                    "STATUS_APPLIED",
+                    self.user1.username,
+                ],
+                [
+                    "9311eb96-bff8-4d5b-ab36-c314a007cfc2",
+                    "STATUS_APPLIED",
+                    self.user1.username,
+                ],
+            ],
+        )
+        self.upload_and_check_deltas(
+            project=project,
+            delta_filename="multilayer_multidelta_modify.json",
+            token=self.token1.key,
+            final_values=[
+                [
+                    "9311eb96-bff8-4d5b-ab36-c314a007cfc3",
+                    "STATUS_APPLIED",
+                    self.user1.username,
+                ],
+                [
+                    "9311eb96-bff8-4d5b-ab36-c314a007cfc4",
+                    "STATUS_APPLIED",
+                    self.user1.username,
+                ],
+            ],
+        )
+
     def get_file_contents(self, project, filename):
         response = self.client.get(f"/api/v1/files/{project.id}/{filename}/")
 

--- a/docker-app/qfieldcloud/core/tests/test_delta.py
+++ b/docker-app/qfieldcloud/core/tests/test_delta.py
@@ -1058,6 +1058,28 @@ class QfcTestCase(APITransactionTestCase):
             self.assertEqual(features[1]["properties"]["int"], 2)
             self.assertEqual(features[2]["properties"]["int"], 3)
 
+    def test_push_list_multilayer_multidelta(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
+        project = self.upload_project_files(self.project1)
+
+        self.upload_and_check_deltas(
+            project=project,
+            delta_filename="multilayer_multidelta.json",
+            token=self.token1.key,
+            final_values=[
+                [
+                    "5cab83db-e2be-4e1b-8239-b30942bb4810",
+                    "STATUS_APPLIED",
+                    self.user1.username,
+                ],
+                [
+                    "e3ac977e-1cb2-4daf-9acb-f6e28ba016f4",
+                    "STATUS_APPLIED",
+                    self.user1.username,
+                ],
+            ],
+        )
+
     def test_push_list_multilayer_multidelta_same_pk(self):
         """
         Test that multiple deltas with same PK value in different layers are applied correctly

--- a/docker-app/qfieldcloud/core/tests/test_delta.py
+++ b/docker-app/qfieldcloud/core/tests/test_delta.py
@@ -1175,7 +1175,13 @@ class QfcTestCase(APITransactionTestCase):
             {"file": self.get_delta_file_with_project_id(project, delta_file)},
             format="multipart",
         )
-        return rest_framework.status.is_success(response.status_code)
+
+        is_sucess = rest_framework.status.is_success(response.status_code)
+
+        if not is_sucess:
+            print("Failed to upload delta file:", response.status_code, response.data)
+
+        return is_sucess
 
     def upload_and_check_deltas(
         self,

--- a/docker-app/qfieldcloud/core/tests/testdata/delta/deltas/multilayer_multidelta.json
+++ b/docker-app/qfieldcloud/core/tests/testdata/delta/deltas/multilayer_multidelta.json
@@ -34,11 +34,11 @@
             "sourceLayerId": "polygons_f18b6046_8e46_4206_a698_641c58e5ac73",
             "method": "patch",
             "new": {
-                "geometry": "POLYGON ((666 666, 5 2, 5 5, 2 5, 666 666 ))",
+                "geometry": "POLYGON ((666 666, 5 2, 5 5, 2 5, 666 666))",
                 "attributes": {
-                    "dbl": 0.666,
-                    "int": 666,
-                    "str": "str666"
+                    "dbl": 0.777,
+                    "int": 777,
+                    "str": "str777"
                 }
             },
             "old": {

--- a/docker-app/qfieldcloud/core/tests/testdata/delta/deltas/multilayer_multidelta_create.json
+++ b/docker-app/qfieldcloud/core/tests/testdata/delta/deltas/multilayer_multidelta_create.json
@@ -1,0 +1,41 @@
+{
+    "deltas": [
+        {
+            "uuid": "9311eb96-bff8-4d5b-ab36-c314a007cfc1",
+            "clientId": "cd517e24-a520-4021-8850-e5af70e3a612",
+            "exportId": "f70c7286-fcec-4dbe-85b5-63d4735dac47",
+            "localPk": "1000",
+            "sourcePk": "",
+            "localLayerId": "points_xy_897d5ed7_b810_4624_abe3_9f7c0a93d6a1",
+            "sourceLayerId": "points_xy_897d5ed7_b810_4624_abe3_9f7c0a93d6a1",
+            "method": "create",
+            "new": {
+                "attributes": {
+                    "fid": 1000,
+                    "int": 1000
+                }
+            }
+        },
+        {
+            "uuid": "9311eb96-bff8-4d5b-ab36-c314a007cfc2",
+            "clientId": "cd517e24-a520-4021-8850-e5af70e3a612",
+            "exportId": "f70c7286-fcec-4dbe-85b5-63d4735dac47",
+            "localPk": "2000",
+            "sourcePk": "",
+            "localLayerId": "points_c2784cf9_c9c3_45f6_9ce5_98a6047e4d6c",
+            "sourceLayerId": "points_c2784cf9_c9c3_45f6_9ce5_98a6047e4d6c",
+            "method": "create",
+            "new": {
+                "geometry": "POINT (666 0)",
+                "attributes": {
+                    "fid": 2000,
+                    "int": 2000
+                }
+            }
+        }
+    ],
+    "files": [],
+    "id": "b7c17bc6-e5af-4fa7-b905-4b395729d782",
+    "project": "504ef91b-43f2-4b2e-a617-ea9f29cd7abc",
+    "version": "1.0"
+}

--- a/docker-app/qfieldcloud/core/tests/testdata/delta/deltas/multilayer_multidelta_delete.json
+++ b/docker-app/qfieldcloud/core/tests/testdata/delta/deltas/multilayer_multidelta_delete.json
@@ -1,0 +1,39 @@
+{
+    "deltas": [
+        {
+            "uuid": "9311eb96-bff8-4d5b-ab36-c314a007cfc5",
+            "clientId": "cd517e24-a520-4021-8850-e5af70e3a612",
+            "exportId": "f70c7286-fcec-4dbe-85b5-63d4735dac47",
+            "localPk": "1000",
+            "sourcePk": "",
+            "localLayerId": "points_xy_897d5ed7_b810_4624_abe3_9f7c0a93d6a1",
+            "sourceLayerId": "points_xy_897d5ed7_b810_4624_abe3_9f7c0a93d6a1",
+            "method": "delete",
+            "old": {
+                "attributes": {
+                    "int": 1000
+                }
+            }
+        },
+        {
+            "uuid": "9311eb96-bff8-4d5b-ab36-c314a007cfc6",
+            "clientId": "cd517e24-a520-4021-8850-e5af70e3a612",
+            "exportId": "f70c7286-fcec-4dbe-85b5-63d4735dac47",
+            "localPk": "2000",
+            "sourcePk": "",
+            "localLayerId": "points_c2784cf9_c9c3_45f6_9ce5_98a6047e4d6c",
+            "sourceLayerId": "points_c2784cf9_c9c3_45f6_9ce5_98a6047e4d6c",
+            "method": "delete",
+            "old": {
+                "geometry": "POINT (666 0)",
+                "attributes": {
+                    "int": 2000
+                }
+            }
+        }
+    ],
+    "files": [],
+    "id": "b7c17bc6-e5af-4fa7-b905-4b395729d784",
+    "project": "504ef91b-43f2-4b2e-a617-ea9f29cd7abc",
+    "version": "1.0"
+}

--- a/docker-app/qfieldcloud/core/tests/testdata/delta/deltas/multilayer_multidelta_modify.json
+++ b/docker-app/qfieldcloud/core/tests/testdata/delta/deltas/multilayer_multidelta_modify.json
@@ -1,0 +1,50 @@
+{
+    "deltas": [
+        {
+            "uuid": "9311eb96-bff8-4d5b-ab36-c314a007cfc3",
+            "clientId": "cd517e24-a520-4021-8850-e5af70e3a612",
+            "exportId": "f70c7286-fcec-4dbe-85b5-63d4735dac47",
+            "localPk": "1000",
+            "sourcePk": "",
+            "localLayerId": "points_xy_897d5ed7_b810_4624_abe3_9f7c0a93d6a1",
+            "sourceLayerId": "points_xy_897d5ed7_b810_4624_abe3_9f7c0a93d6a1",
+            "method": "patch",
+            "new": {
+                "attributes": {
+                    "int": 1001
+                }
+            },
+            "old": {
+                "attributes": {
+                    "int": 1000
+                }
+            }
+        },
+        {
+            "uuid": "9311eb96-bff8-4d5b-ab36-c314a007cfc4",
+            "clientId": "cd517e24-a520-4021-8850-e5af70e3a612",
+            "exportId": "f70c7286-fcec-4dbe-85b5-63d4735dac47",
+            "localPk": "2000",
+            "sourcePk": "",
+            "localLayerId": "points_c2784cf9_c9c3_45f6_9ce5_98a6047e4d6c",
+            "sourceLayerId": "points_c2784cf9_c9c3_45f6_9ce5_98a6047e4d6c",
+            "method": "patch",
+            "new": {
+                "geometry": "POINT (777 0)",
+                "attributes": {
+                    "int": 2002
+                }
+            },
+            "old": {
+                "geometry": "POINT (666 0)",
+                "attributes": {
+                    "int": 2000
+                }
+            }
+        }
+    ],
+    "files": [],
+    "id": "b7c17bc6-e5af-4fa7-b905-4b395729d783",
+    "project": "504ef91b-43f2-4b2e-a617-ea9f29cd7abc",
+    "version": "1.0"
+}


### PR DESCRIPTION
This will reduce the `could not find feature` errors by ensuring the proper fid mapping is available.

1. Create two features with same local PK in different layers (and unknown remote PK).
2. Push the deltas (NOT sync, we should not know the remote PK on the client).
3. Modify the same two features and push the deltas.
4. Check that the deltas have been applied correctly.
5. Delete the same two features and push the deltas.
6. Check that the deltas have been applied correctly.

Follow-up of https://github.com/opengisch/QFieldCloud/pull/1307 .