### PR TITLE
edit(delta): fix delta applied by several jobs when users pushing around the same time

### DIFF
--- a/docker-app/qfieldcloud/core/utils2/jobs.py
+++ b/docker-app/qfieldcloud/core/utils2/jobs.py
@@ -49,7 +49,7 @@ def apply_deltas(
     # so we better assume the deltas will reach a non-"pending" status.
     apply_jobs = models.ApplyJob.objects.filter(
         project=project,
-        status=[
+        status__in=[
             models.Job.Status.PENDING,
             models.Job.Status.QUEUED,
             models.Job.Status.STARTED,


### PR DESCRIPTION
This PR should avoid too many `pending_deltas` hanging around, by making sure to exclude the ones which are already to be applied in ApplyDelta type jobs, for the project.