### PR TITLE
fix(nginx): CSRF check failure when debug mode is enabled

### DIFF
--- a/docker-nginx/templates/default.conf.template
+++ b/docker-nginx/templates/default.conf.template
@@ -148,21 +148,32 @@ server {
     proxy_pass http://django;
   }
 
-  # Handle 5xx errors conditionally to keep django stackstrace while debugging
+  # Handle 5xx errors conditionally to keep django stack trace while debugging
   location @handle_500_error {
-      # Set the host header to be the original one
-      proxy_set_header Host $http_host;
+    # since we might `proxy_pass` in case of debug mode, we need all the proxy settings here as well, otherwise they will not be propagated.
+    proxy_http_version 1.1;
 
-      # Check the debug_mode variable derived from the environment variable
-      if ($debug_mode = "on") {
-          # If debug mode is on, attempt to pass the original 500 response (with stacktrace)
-          proxy_pass http://django;
-      }
+    proxy_set_header Connection '';
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Request-Id $request_id;
+    proxy_set_header Host $http_host;
 
-      # If debug mode is off, serve the custom error page
-      root /var/www/html/;
-      internal;
-      try_files /pages/500.html =404;
+    proxy_connect_timeout 5s;
+    proxy_read_timeout 300;
+    proxy_send_timeout 300;
+    proxy_redirect off;
+
+    # Check the debug_mode variable derived from the environment variable
+    if ($debug_mode = "on") {
+        # If debug mode is on, attempt to pass the original 500 response (with stacktrace)
+      proxy_pass http://django;
+    }
+
+    # If debug mode is off, serve the custom error page
+    root /var/www/html/;
+    internal;
+    try_files /pages/500.html =404;
   }
 
   location /storage-download/ {


### PR DESCRIPTION
Steps to reproduce:

1) Make a potential runtime error in the codebase, e.g. add to the Project.save something that raises an unhandled error, such as 1/0
2) Go to admin and try to save an existing/new instance of the Project model.
3) We would expect an error 500 to happen and override it with the 500.html template.
4) We experience CSRFToken failure instead.

What happens is that nginx detects the error 500, then it continues with error_page 500 501 505 = @handle_500_error;  which eventually proxies back to Django if in debug mode. But there were no proxy_set_* configurations, so basically django got a second request, which is HTTP 1.0 instead of HTTP 1.1 and missing all the X-Forwarded-*  headers. See the tcpflow attached for more info.

This second request is actually wrong, it should not happen and it is very dangerous, as error 500 might cause damage and sending a request twice might cause even bigger damage! Luckily this is only for debug mode, but we need another solution to get the original response from Django instead of the debug page.

| before | after |
|-|-|
| <img width="1742" height="465" alt="image" src="https://github.com/user-attachments/assets/b324639d-27d9-4d11-a235-17f54da5975e" /> | <img width="1742" height="465" alt="image" src="https://github.com/user-attachments/assets/3ef118d5-b4ad-465a-83f9-4a9ca3549e41" /> |

