### PR TITLE
Bump `django-stubs` from `5.2.2` to `5.2.5`

### DIFF
--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -30,7 +30,7 @@ django-storages==1.14.6
 django-tables2==2.7.5
 django-timezone-field==7.1
 django==4.2.24
-django-stubs==5.2.2
+django-stubs==5.2.5
 djangorestframework==3.16.1
 djangorestframework-stubs==3.16.2
 drf-spectacular==0.28.0

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -130,11 +130,11 @@ django-sri==0.8.0
     # via -r /requirements/requirements.in
 django-storages==1.14.6
     # via -r /requirements/requirements.in
-django-stubs==5.2.2
+django-stubs==5.2.5
     # via
     #   -r /requirements/requirements.in
     #   djangorestframework-stubs
-django-stubs-ext==5.2.2
+django-stubs-ext==5.2.5
     # via django-stubs
 django-tables2==2.7.5
     # via -r /requirements/requirements.in


### PR DESCRIPTION
Changelog: https://github.com/typeddjango/django-stubs/releases/tag/5.2.5

Changes: https://github.com/typeddjango/django-stubs/compare/5.2.3...5.2.5