### PR TITLE
fix(admin): add unregistered admins

### DIFF
--- a/docker-app/qfieldcloud/authentication/admin.py
+++ b/docker-app/qfieldcloud/authentication/admin.py
@@ -1,10 +1,11 @@
 from typing import TYPE_CHECKING
 
 from django.contrib import admin
-from django.contrib.admin import register
 from django.db.models import Q, QuerySet
 from django.http import HttpRequest
 from django.utils import timezone
+
+from qfieldcloud.core.admin import qfc_admin_site
 
 from .models import AuthToken
 
@@ -54,7 +55,6 @@ class AuthTokenClientTypeFilter(admin.SimpleListFilter):
         return queryset.filter(Q(client_type=value))
 
 
-@register(AuthToken)
 class AuthTokenAdmin(admin.ModelAdmin):
     list_display = ("user", "created_at", "expires_at", "last_used_at", "client_type")
     readonly_fields = (
@@ -83,3 +83,6 @@ class AuthTokenAdmin(admin.ModelAdmin):
         """
         now = timezone.now()
         queryset.filter(Q(expires_at__gt=now)).update(expires_at=now)
+
+
+qfc_admin_site.register(AuthToken, AuthTokenAdmin)

--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -22,6 +22,7 @@ from django.contrib import admin, messages
 from django.contrib.admin.sites import AdminSite
 from django.contrib.admin.templatetags.admin_urls import admin_urlname
 from django.contrib.admin.views.main import ChangeList
+from django.contrib.auth.models import Group
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db.models import Q, QuerySet
 from django.db.models.fields.json import JSONField
@@ -1692,6 +1693,7 @@ qfc_admin_site.register(Delta, DeltaAdmin)
 qfc_admin_site.register(Job, JobAdmin)
 qfc_admin_site.register(LogEntry, LogEntryAdmin)
 qfc_admin_site.register(FaultyDeltaFile, FaultyDeltaFilesAdmin)
+qfc_admin_site.register(Group)
 
 # The sole purpose of the `User` and `UserAccount` admin modules is only to support autocomplete fields in Django admin
 qfc_admin_site.register(User, UserAdmin)


### PR DESCRIPTION
The `Tokens` and `Groups` admins to be registered again in Django Admin :

<img width="244" height="170" alt="image" src="https://github.com/user-attachments/assets/193a8995-9af7-4d82-8bd2-11a9f5583200" />
