### PR TITLE
fix(ofelia): disable accidental cronjob run in the worker_wrapper by `ofelia`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,6 +172,8 @@ services:
     logging: *default-logging
     scale: ${QFIELDCLOUD_WORKER_REPLICAS}
     stop_grace_period: 15m
+    labels:
+      ofelia.enabled: "false"
 
   ofelia:
     image: mcuadros/ofelia:v0.3.4


### PR DESCRIPTION
Ofelia should run in app container, since worker_wrapper inherits app labels, cronjobs might falsely end up running in worker_wrapper.