### PR TITLE
fix(admin): the FaultyDelta admin was taking forever to open

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -1628,7 +1628,7 @@ class FaultyDeltaFilesAdmin(QFieldCloudModelAdmin):
         "user_agent",
     )
 
-    list_filter = ("project", "project__owner__username", "created_at")
+    list_filter = ("created_at",)
 
     list_select_related = ("project", "project__owner")
 


### PR DESCRIPTION
Faulty delta admin was optimistically listing the available projects and owners, which can be hundreds of thousands.

| before | after |
|-|-|
| <img width="2065" height="605" alt="image" src="https://github.com/user-attachments/assets/e19ad72c-339d-4d4e-9431-82f5167513a5" /> | <img width="2065" height="605" alt="image" src="https://github.com/user-attachments/assets/45f1a45d-217c-4a30-9371-0adb73665cc3" /> |