### PR TITLE
Bump `django` from `4.2.24` to `4.2.25`

### DIFF
--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -29,7 +29,7 @@ django-sri==0.8.0
 django-storages==1.14.6
 django-tables2==2.7.5
 django-timezone-field==7.1
-django==4.2.24
+django==4.2.25
 django-stubs==5.2.5
 djangorestframework==3.16.1
 djangorestframework-stubs==3.16.3

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -41,7 +41,7 @@ cryptography==45.0.6
     #   pyjwt
 deprecated==1.2.18
     # via -r /requirements/requirements.in
-django==4.2.24
+django==4.2.25
     # via
     #   -r /requirements/requirements.in
     #   django-allauth


### PR DESCRIPTION
Changelog: https://docs.djangoproject.com/en/dev/releases/4.2.25/
Changes: https://github.com/django/django/compare/4.2.24...4.2.25

The bot in https://github.com/opengisch/QFieldCloud/pull/1374 is changing too many things.