### PR TITLE
Fix unnecessary creation of storage_package as `PackageType`

### DIFF
--- a/docker-app/qfieldcloud/subscription/migrations/0003_auto_20221028_1901.py
+++ b/docker-app/qfieldcloud/subscription/migrations/0003_auto_20221028_1901.py
@@ -11,6 +11,7 @@ def replace_with_single_storage_package_type(apps, schema_editor):
         id=1,
         code="storage",
         display_name="Additional storage",
+        type="storage",
         is_public=True,
         unit_amount=1000,
         unit_label="MB",

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -310,12 +310,14 @@ class PackageType(models.Model):
             return cls.objects.get(type=cls.Type.STORAGE)
         except cls.DoesNotExist:
             return cls.objects.create(
-                code="storage_package",
+                code="storage",
+                display_name="Additional storage",
+                is_public=True,
                 type=cls.Type.STORAGE,
                 unit_amount=1000,
                 unit_label="MB",
                 min_quantity=0,
-                max_quantity=100,
+                max_quantity=50,
             )
 
 


### PR DESCRIPTION
At some point storage_package `PackageType` was renamed to `storage` but the auto creation of it was never updated.

steps to reproduce
1. fresh install
2. `manage.py migrate`
3. created a super user `manage.py createsuperuser`

Now we see an extra package type which has `code = storage_package`, it caused issues when syncing with stripe and when deleting in admin panel