### PR TITLE
fix: use `the_qgis_file_name` in calcprojectstorage command

### DIFF
--- a/docker-app/qfieldcloud/core/management/commands/calcprojectstorage.py
+++ b/docker-app/qfieldcloud/core/management/commands/calcprojectstorage.py
@@ -25,7 +25,7 @@ class Command(BaseCommand):
             extra_filters["file_storage_bytes"] = 0
 
         projects_qs = Project.objects.filter(
-            the_qgis_filename__isnull=False,
+            the_qgis_file_name__isnull=False,
             **extra_filters,
         ).order_by("-updated_at")
         total_count = projects_qs.count()


### PR DESCRIPTION
Not much more than the title.