### PR TITLE
Remove hardcoding of the third-party auth related headers

### DIFF
--- a/docker-app/qfieldcloud/authentication/tests/test_list_auth_providers.py
+++ b/docker-app/qfieldcloud/authentication/tests/test_list_auth_providers.py
@@ -4,6 +4,7 @@ import requests_mock
 from allauth.socialaccount.models import SocialApp
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 from allauth.socialaccount.providers.oauth2.views import OAuth2Adapter
+from django.conf import settings
 from django.http import HttpRequest
 from django.test import override_settings
 from rest_framework.test import APITestCase
@@ -141,7 +142,8 @@ class QfcTestCase(APITestCase):
                 "redirect_port": 7070,
                 "redirect_url": "",
                 "client_id": "keycloak-client-id",
-                "extra_tokens": {"id_token": "X-QFC-ID-Token"},
+                "extra_tokens": {"id_token": settings.QFIELDCLOUD_ID_TOKEN_HEADER_NAME},
+                "idp_id_header": settings.QFIELDCLOUD_IDP_ID_HEADER_NAME,
                 "styles": {},
             },
         ]

--- a/docker-app/qfieldcloud/authentication/views.py
+++ b/docker-app/qfieldcloud/authentication/views.py
@@ -189,7 +189,8 @@ class ListProvidersView(APIView):
             "redirect_port": self.QGIS_REDIRECT_PORT,
             "redirect_url": self.QGIS_REDIRECT_URL,
             "client_id": provider.app.client_id,
-            "extra_tokens": {"id_token": "X-QFC-ID-Token"},
+            "extra_tokens": {"id_token": settings.QFIELDCLOUD_ID_TOKEN_HEADER_NAME},
+            "idp_id_header": settings.QFIELDCLOUD_IDP_ID_HEADER_NAME,
             "styles": SSOProviderStyles(request).get(provider_id),
         }
         return provider_data

--- a/docker-app/qfieldcloud/core/middleware/qgis_auth.py
+++ b/docker-app/qfieldcloud/core/middleware/qgis_auth.py
@@ -3,6 +3,7 @@ import logging
 from allauth.socialaccount.adapter import get_adapter
 from allauth.socialaccount.helpers import complete_social_login
 from allauth.socialaccount.models import SocialToken
+from django.conf import settings
 from django.http import HttpRequest
 
 logger = logging.getLogger(__name__)
@@ -73,7 +74,7 @@ class QGISAuthenticationMiddleware:
             return self.get_response(request)
 
         # Require QFC clients to send a header to explicitly specify the IDP
-        idp_id = request.headers.get("X-QFC-IDP-ID")
+        idp_id = request.headers.get(settings.QFIELDCLOUD_IDP_ID_HEADER_NAME)
         if not idp_id:
             return self.get_response(request)
 
@@ -109,7 +110,7 @@ class QGISAuthenticationMiddleware:
         return self.get_response(request)
 
     def get_id_token(self, request: HttpRequest):
-        return request.headers.get("X-QFC-ID-Token")
+        return request.headers.get(settings.QFIELDCLOUD_ID_TOKEN_HEADER_NAME)
 
     def get_access_token(self, request: HttpRequest):
         auth_header = request.headers.get("Authorization")

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -464,6 +464,14 @@ SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT = True
 SOCIALACCOUNT_LOGIN_ON_GET = True
 SOCIALACCOUNT_PROVIDERS = get_socialaccount_providers_config()
 
+# Third-party auth header names configuration
+QFIELDCLOUD_IDP_ID_HEADER_NAME = os.environ.get(
+    "QFIELDCLOUD_IDP_ID_HEADER_NAME", "X-QFC-IDP-ID"
+)
+QFIELDCLOUD_ID_TOKEN_HEADER_NAME = os.environ.get(
+    "QFIELDCLOUD_ID_TOKEN_HEADER_NAME", "X-QFC-ID-Token"
+)
+
 #########################
 # /Django allauth settings
 #########################


### PR DESCRIPTION
This PR makes the former hard-coded `X-QFC-IDP-ID` and `X-QFC-ID-Token` third-party auth related header names configurable in the settings.