### PR TITLE
test: add coverage reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,17 @@ Don't forget to update the `port` value in [`[test.localhost.qfield.cloud]` in y
 
 </details>
 
+
+#### Test coverage
+
+To get information about the current test coverage, run:
+
+```
+docker compose exec app coverage run manage.py test --keepdb
+docker compose exec app coverage report
+```
+
+
 ### Debugging
 
 > [!NOTE]

--- a/docker-app/.coveragerc
+++ b/docker-app/.coveragerc
@@ -3,10 +3,9 @@ branch = True
 source =
     qfieldcloud
 omit =
-    **migrations*
-    **tests*
-    **/admin.py
-    **/wsgi.py
+    */tests/*
+    */migrations/*
+    */wsgi.py
 
 [report]
 precision = 2
@@ -19,6 +18,3 @@ exclude_lines =
     raise NotImplementedError
     if 0:
     if __name__ == .__main__.:
-
-[html]
-directory = .htmlcov

--- a/docker-app/requirements/requirements_test.in
+++ b/docker-app/requirements/requirements_test.in
@@ -3,3 +3,4 @@ imageio==2.*
 requests-mock==1.*
 selenium==4.*
 shapely==2.*
+coverage==7.11.0

--- a/docker-app/requirements/requirements_test.txt
+++ b/docker-app/requirements/requirements_test.txt
@@ -25,6 +25,8 @@ click-plugins==1.1.1.2
     # via fiona
 cligj==0.7.2
     # via fiona
+coverage==7.11.0
+    # via -r /requirements/requirements_test.in
 exceptiongroup==1.3.0
     # via
     #   trio


### PR DESCRIPTION
In case there is a standalone compose:

$ docker compose --env-file .env.test exec app coverage run manage.py test --keepdb qfieldcloud.authentication
$ docker compose --env-file .env.test exec app coverage report
