### PR TITLE
Fix flaky files API tests

### DIFF
--- a/docker-app/qfieldcloud/filestorage/tests/test_files_api.py
+++ b/docker-app/qfieldcloud/filestorage/tests/test_files_api.py
@@ -16,7 +16,6 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.test import APITransactionTestCase
 
-from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core.models import (
     Organization,
     OrganizationMember,
@@ -41,7 +40,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
 
         # Create a user
         self.u1 = Person.objects.create_user(username="u1", password="abc123")
-        self.t1 = AuthToken.objects.get_or_create(user=self.u1)[0]
+        self.t1 = self._get_token_for_user(self.u1)
         self.p1 = Project.objects.create(
             owner=self.u1,
             name="p1",


### PR DESCRIPTION
Some of these tests occasionally failed in a flaky way:

```
======================================================================
ERROR: test_delete_all_file_versions_fails (qfieldcloud.filestorage.tests.test_files_api.QfcTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/src/app/qfieldcloud/filestorage/tests/test_files_api.py", line 727, in test_delete_all_file_versions_fails
    response = self._delete_file(
  File "/usr/src/app/qfieldcloud/core/tests/mixins.py", line 115, in _delete_file
    token = AuthToken.objects.get_or_create(user=user)[0]
  File "/usr/local/lib/python3.10/site-packages/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/django/db/models/query.py", line 916, in get_or_create
    return self.get(**kwargs), False
  File "/usr/local/lib/python3.10/site-packages/django/db/models/query.py", line 640, in get
    raise self.model.MultipleObjectsReturned(
qfieldcloud.authentication.models.AuthToken.MultipleObjectsReturned: get() returned more than one AuthToken -- it returned 2!
```

 The reason was that methods in `QfcFilesTestCaseMixin` created AuthTokens using this pattern:

```python
AuthToken.objects.get_or_create(user=user)
```

This created a token for the user, with the client type `UNKNOWN`, because a user agent is never set in tests. This worked, unless during a test a worker job was triggered as a side effect.

Then the worker wrapper would issue a token for the same user, but with client_type `WORKER`. This would then cause `get_or_create(user=user)` to fail, because ([as per docs](https://docs.djangoproject.com/en/5.2/ref/models/querysets/#get-or-create)) it assumes that its keyword arguments act as a unique constraint for the object to be fetched.

Further discriminating the `get_or_create()` call by the `client_type` addresses this issue.