### PR TITLE
feat: remove GET param to display third-party auth providers on login page

### DIFF
--- a/docker-app/qfieldcloud/core/templates/admin/login.html
+++ b/docker-app/qfieldcloud/core/templates/admin/login.html
@@ -3,7 +3,5 @@
 {% block content %}
     {{ block.super }}
     {% comment %}TODO add a configuration based mechanism to render the social login instead of depending on query param {% endcomment %}
-    {% if request.GET.sso %}
-        {% include "socialaccount/snippets/login.html" %}
-    {% endif %}
+    {% include "socialaccount/snippets/login.html" %}
 {% endblock %}


### PR DESCRIPTION
Not much more than the title, with this PR no need to add the GET param to display third-party providers login button.