### PR TITLE
Change nginx resolver to docker internal DNS for storage-download redirects

### DIFF
--- a/docker-nginx/templates/default.conf.template
+++ b/docker-nginx/templates/default.conf.template
@@ -165,8 +165,8 @@ server {
     # if a Range header is provided
     set $file_range "$upstream_http_file_range";
 
-    # required DNS
-    resolver 8.8.8.8 ipv6=off;
+    # Add Docker's DNS resolver with IPv6 turned off
+    resolver 127.0.0.11 ipv6=off;
 
     # Stops the local disk from being written to (just forwards data through)
     proxy_max_temp_file_size 0;


### PR DESCRIPTION
Some QFieldCloud configurations may require resolving hosts not known by the 8.8.8.8 DNS servers, thus using the docker's internal DNS could help in such cases.

This initial `resolver 8.8.8.8` line in the nginx config was introduced by this commit : https://github.com/opengisch/QFieldCloud/commit/c3d978d2bb06472b35ae31f6b6a5a5abb10181f2, I don't see any reason why the internal DNS resolver could not be used, and this resolving config should maybe be handled by the host machine rather than the nginx IMHO.