### PR TITLE
fix: follow-up on wrongly hardcoded `Content-Type` header in non-nginx responses

### DIFF
--- a/docker-app/qfieldcloud/core/utils2/storage.py
+++ b/docker-app/qfieldcloud/core/utils2/storage.py
@@ -296,7 +296,6 @@ def file_response(
             return_file.open(),
             as_attachment=as_attachment,
             filename=filename,
-            content_type="text/html",
         )
 
     raise Exception(


### PR DESCRIPTION
Follow up for [PR 1406](https://github.com/opengisch/QFieldCloud/pull/1406)