### PR TITLE
Bump postgis image version to 17 in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -449,8 +449,8 @@ SMTP4DEV_IMAP_PORT=143
 # see this gist: https://gist.github.com/gounux/2c0779fcb22e512cbdc613eb78200571
 # Migration to a newer database version is a risky operation to your data, so prepare and test the backup of the `postgres_data` volume.
 # NOTE: Ignored if `db` is not used.
-# DEFAULT: 13-3.1-alpine
-POSTGIS_IMAGE_VERSION=13-3.1-alpine
+# DEFAULT: 17-3.5-alpine
+POSTGIS_IMAGE_VERSION=17-3.5-alpine
 
 # Local admin username configuration for minio storage in local and standalone instances.
 # NOTE: Ignored if `minio` is not used.


### PR DESCRIPTION
Bump the `postgis` image that is used in `.env.example` to `17-3.5-alpine` (PostgreSQL 17, PostGIS 3.5).

This brings that version in line with what is currently used to run `app.qfield.cloud`.
