### PR TITLE
fix: do not check missing Sha256sum key when checking if file exists on legacy S3 during fs migration

### DIFF
--- a/docker-app/qfieldcloud/core/utils.py
+++ b/docker-app/qfieldcloud/core/utils.py
@@ -329,6 +329,29 @@ def get_qgis_project_file(project_id: str) -> str | None:
     return None
 
 
+def check_legacy_s3_file_exists(key: str, should_raise: bool = True) -> bool:
+    """Check to see if an object exists on S3.
+
+    Todo:
+        * Delete with QF-4963 Drop support for legacy storage
+    """
+    client = get_s3_client()
+    try:
+        client.head_object(
+            Bucket=get_legacy_s3_credentials()["OPTIONS"]["bucket_name"],
+            Key=key,
+        )
+        return True
+    except ClientError as e:
+        if e.response.get("ResponseMetadata", {}).get("HTTPStatusCode") == 404:
+            return False
+        else:
+            if should_raise:
+                raise e
+            else:
+                return False
+
+
 def check_s3_key(key: str) -> str | None:
     """Check to see if an object exists on S3. It it exists, the function
     returns the sha256 of the file from the metadata

--- a/docker-app/qfieldcloud/filestorage/migrate_project_storage.py
+++ b/docker-app/qfieldcloud/filestorage/migrate_project_storage.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 
 from qfieldcloud.core.models import Job, Project
 from qfieldcloud.core.utils import (
-    check_s3_key,
+    check_legacy_s3_file_exists,
     get_project_files_with_versions,
     get_project_package_files,
 )
@@ -240,7 +240,7 @@ def migrate_project_storage(
                 f'Migrate project "{project.name}" ({str(project.id)}) thumbnail "{project.legacy_thumbnail_uri}"...'
             )
 
-            if not check_s3_key(project.legacy_thumbnail_uri):
+            if not check_legacy_s3_file_exists(project.legacy_thumbnail_uri):
                 logger.warning(
                     f"Thumbnail '{project.legacy_thumbnail_uri}' does not exist in legacy storage, skip thumbnail migration!"
                 )


### PR DESCRIPTION
Boto3 S3 storage response may not provide a `Sha256sum` key in the metadata, when checking if a project `legacy_thumbnail_uri` exists.  
Before this PR, this was made using the `check_s3_key` function, which is looking for this `Sha256sum` key in metadata and raises a `KeyError` if not present.

Thus introducing a new `check_legacy_s3_file_exists` function to simply check if the file is there on legacy s3, without trying to get the `Sha256sum` metadata, which is not needed during the filestorage migration anyway when checking if a project's `legacy_thumbnail_uri`  file exists.
