### PR TITLE
tests: Make volume name for test DB respect COMPOSE_PROJECT_NAME

### DIFF
--- a/docker-compose.override.test.yml
+++ b/docker-compose.override.test.yml
@@ -42,4 +42,4 @@ volumes:
   # We use a different volume, just so that the test_ database
   # gets created in the entrypoint.
   postgres_data:
-    name: qfieldcloud_postgres_data_test
+    name: ${COMPOSE_PROJECT_NAME}_postgres_data_test


### PR DESCRIPTION
The volume name for the test DB was previously hard coded to `qfieldcloud_postgres_data_test`. This worked as long as the `COMPOSE_PROJECT_NAME` was left at the default of `qfieldcloud`, which is common for developers that only ever work in one source checkout.

But if you use multiple source checkouts, each with their own `COMPOSE_PROJECT_NAME` to isolate docker resources, that isolation broke for the test DB - it was accidentally shared between different compose projects when it shouldn't have been.

Changing the volume name to `${COMPOSE_PROJECT_NAME}_postgres_data_test` fixes this, and should have no effect for the existing environments of developers that never changed `COMPOSE_PROJECT_NAME` to anything other than `qfieldcloud`.