### PR TITLE
feat: add qfieldcloud version to admin panel

### DIFF
--- a/docker-app/qfieldcloud/core/templates/admin/base.html
+++ b/docker-app/qfieldcloud/core/templates/admin/base.html
@@ -1,0 +1,19 @@
+{% extends "admin/base.html" %}
+{% load i18n jazzmin version %}
+
+{% block footer %}
+    {% if not is_popup %}
+        <footer class="main-footer {{ jazzmin_ui.footer_classes }}">
+            <div class="float-right d-none d-sm-inline">
+                <b>{% trans 'Jazzmin version' %}</b> {% get_jazzmin_version %} |
+                <b>{% trans 'QFieldCloud version' %}</b> {% get_qfieldcloud_version %}
+            </div>
+            {% autoescape off %}
+                <strong>{% trans 'Copyright' %} &copy; {% now 'Y' %} {{ jazzmin_settings.copyright }}.</strong> {% trans 'All rights reserved.' %}
+            {% endautoescape %}
+        </footer>
+        {% if jazzmin_settings.show_ui_builder %}
+            {% include 'jazzmin/includes/ui_builder_panel.html' %}
+        {% endif %}
+    {% endif %}
+{% endblock %}

--- a/docker-app/qfieldcloud/core/templatetags/version.py
+++ b/docker-app/qfieldcloud/core/templatetags/version.py
@@ -1,0 +1,12 @@
+from django import template
+from django.conf import settings
+
+register = template.Library()
+
+
+@register.simple_tag
+def get_qfieldcloud_version() -> str:
+    """
+    Get the QFieldCloud version
+    """
+    return settings.SENTRY_RELEASE

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -353,6 +353,7 @@ LOGIN_REDIRECT_URL = "index"
 
 # Sentry configuration
 SENTRY_DSN = os.environ.get("SENTRY_DSN", "")
+SENTRY_RELEASE = os.environ.get("SENTRY_RELEASE", "dev")
 if SENTRY_DSN:
     SENTRY_SAMPLE_RATE = float(os.environ.get("SENTRY_SAMPLE_RATE", 1))
 


### PR DESCRIPTION
QFieldCloud Version added to the admin panel, to show the users the current version

- Add `SENTRY_RELEASE` in settings.py with a default value of "dev".
- Created a new template tag to retrieve the QFieldCloud version for use in templates.
- Override a new base.html template for admin with footer information including version details. [jazzmin admin Source Code](https://github.com/farridav/django-jazzmin/blob/main/jazzmin/templates/admin/base.html)

Before:
<img width="1843" height="710" alt="image" src="https://github.com/user-attachments/assets/570e1303-c3ec-436e-bf5f-35435106507c" />


---

After: 
<img width="1843" height="710" alt="image" src="https://github.com/user-attachments/assets/66b68360-4c3f-4d16-83e2-b220ddfd9b3c" />
