### PR TITLE
feat: add whitelabelling

### DIFF
--- a/docker-app/qfieldcloud/core/staticfiles/css/qfieldcloud.css
+++ b/docker-app/qfieldcloud/core/staticfiles/css/qfieldcloud.css
@@ -40,8 +40,19 @@ h1, h2, h3, h4, h5, h6 {
   margin-left: 1rem;
 }
 
+.qfc-logo-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 15rem;
+  padding: 1rem 0;
+}
+
 .qfc-main-logo {
-  height: 15rem;
+  max-width: 100%;
+  max-height: 15rem;
+  width: auto;
+  height: auto;
 }
 
 .ml-5rem {

--- a/docker-app/qfieldcloud/core/templates/account/base.html
+++ b/docker-app/qfieldcloud/core/templates/account/base.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark light">
 
   {% sri_static 'css/vendor.css' %}
-  {% sri_static whitelabel.custom_css %}
+  {% sri_static 'css/qfieldcloud.css' %}
   <link rel="shortcut icon" type="image/x-icon" href="{% static whitelabel.favicon %}" />
 
   <title>
@@ -37,9 +37,9 @@
       <div class="flex-shrink-0 col-12">
         <div class="row">
           <div class="col-lg-6 offset-lg-3">
-            <p class="text-center">
+            <div class="qfc-logo-wrapper">
               <img src="{% static whitelabel.logo_main %}" alt="{{ whitelabel.logo_alt }}" class="qfc-main-logo">
-            </p>
+            </div>
 
             {% block content %}{% endblock content %}
 

--- a/docker-app/qfieldcloud/core/whitelabel.py
+++ b/docker-app/qfieldcloud/core/whitelabel.py
@@ -13,8 +13,6 @@ DEFAULT_WHITELABEL = {
     "logo_navbar": "logo_sidetext_white.svg",
     "logo_main": "logo_undertext.svg",
     "favicon": "favicon.ico",
-    # Styling
-    "custom_css": "css/qfieldcloud.css",
 }
 
 

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -881,5 +881,4 @@ JAZZMIN_SETTINGS = {
 #     "logo_main": "path/to/logo_main.svg",
 #     "logo_alt": "Your logo description",
 #     "favicon": "path/to/favicon.ico",
-#     "custom_css": "path/to/custom.css",
 # }


### PR DESCRIPTION
Adding a new feature that makes whitelabelling possible especially for dedicated instances

- Added `whitelabel.py` with default branding configuration and context processor
- Added `whitelabel()` context processor with translation support for user-facing strings
- Updated `base.html` to utilize whitelabel settings and added some style tweaks
- Adjusted `qfieldcloud.css` to decouple `base.html` from styles so it's easier to override
- Added whitelabel configuration dict in `settings.py`

Without Whitelabel :

<img width="1919" height="999" alt="Screenshot from 2025-12-02 18-20-46" src="https://github.com/user-attachments/assets/eafa435a-05fd-417f-9bc4-c5e35a3d8127" />

---

<img width="1919" height="999" alt="image" src="https://github.com/user-attachments/assets/65e14770-d768-4829-ac5a-89517679146a" />

---

With Whitelabel :

<img width="1919" height="999" alt="Screenshot from 2025-12-02 18-26-16" src="https://github.com/user-attachments/assets/ee0920f6-9116-49e9-9d33-368b6c513e11" />

---

<img width="1919" height="999" alt="image" src="https://github.com/user-attachments/assets/9b636e65-dc64-44d7-83e8-fa9d85838518" />

---

Settings : 

```
WHITELABEL = {
    "site_title": "Company ipsum dolor sit amet",
    "logo_navbar": "whitelabel/logoipsum-385.svg",
    "logo_main": "whitelabel/logoipsum-367.png",
    "logo_alt": "Company ipsum dolor sit amet Logo",
    "favicon": "whitelabel/logoipsum-386.ico",
}
```
