### PR TITLE
feat: add session_role to a postgis layer if configured, during deltas apply

### DIFF
--- a/docker-qgis/requirements_libqfieldsync.txt
+++ b/docker-qgis/requirements_libqfieldsync.txt
@@ -1,1 +1,1 @@
-libqfieldsync @ git+https://github.com/opengisch/libqfieldsync@62853968a3cc98953ff7f41f8770a7f9d1b6a80e
+libqfieldsync @ git+https://github.com/opengisch/libqfieldsync@043fe5ae4d9904dbba7ef6605f30f62e229b0f73


### PR DESCRIPTION
Sister PR of : https://github.com/opengisch/libqfieldsync/pull/132

This one focuses on setting the `session_role` when committing the data, during a Delta Apply Job.