### PR TITLE
Add SSO branding for login with Microsoft Entra ID.

### DIFF
--- a/docker-app/qfieldcloud/core/staticfiles/sso/microsoft.svg
+++ b/docker-app/qfieldcloud/core/staticfiles/sso/microsoft.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="21" height="21" viewBox="0 0 21 21"><title>MS-SymbolLockup</title><rect x="1" y="1" width="9" height="9" fill="#f25022"/><rect x="1" y="11" width="9" height="9" fill="#00a4ef"/><rect x="11" y="1" width="9" height="9" fill="#7fba00"/><rect x="11" y="11" width="9" height="9" fill="#ffb900"/></svg>

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -539,6 +539,22 @@ QFIELDCLOUD_SSO_PROVIDER_STYLES = {
             "color_text": "#E3E3E3",
         },
     },
+    "entra": {
+        # https://learn.microsoft.com/en-us/entra/identity-platform/howto-add-branding-in-apps
+        "required": True,
+        "light": {
+            "logo": "sso/microsoft.svg",
+            "color_fill": "#FFFFFF",
+            "color_stroke": "#8C8C8C",
+            "color_text": "#5E5E5E",
+        },
+        "dark": {
+            "logo": "sso/microsoft.svg",
+            "color_fill": "#2F2F2F",
+            "color_stroke": "#2F2F2F",
+            "color_text": "#FFFFFF",
+        },
+    },
 }
 
 # Django axes configuration


### PR DESCRIPTION
This adds a base configuration for styling the login button when login with Microsoft Entra ID is configured.

The provider is expected to be called `entra` by default.

---

<img width="560" height="168" alt="Screenshot 2025-11-24 at 08 19 19" src="https://github.com/user-attachments/assets/276dbaae-0261-4158-8d1e-19a20aecfbf7" />
