### PR TITLE
feat: disable `.qgs` for `shared_datasets` Project

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -49,6 +49,7 @@ from rest_framework.authtoken.models import TokenProxy
 
 from qfieldcloud.core import exceptions
 from qfieldcloud.core.models import (
+    SHARED_DATASETS_PROJECT_NAME,
     ApplyJob,
     ApplyJobDelta,
     Delta,
@@ -883,6 +884,26 @@ class ProjectForm(ModelForm):
             )
 
         return value
+
+    def clean(self):
+        cleaned_data = super().clean()
+        name = cleaned_data.get("name")
+
+        if name and name.lower() == SHARED_DATASETS_PROJECT_NAME:
+            if (
+                self.instance.pk
+                and self.instance.name.lower() == SHARED_DATASETS_PROJECT_NAME
+            ):
+                pass
+
+            elif self.instance.has_the_qgis_file:
+                raise ValidationError(
+                    _(
+                        "Cannot rename project to '{}' because it contains a QGIS project file."
+                    ).format(name)
+                )
+
+        return cleaned_data
 
 
 class ProjectAdmin(QFieldCloudModelAdmin):

--- a/docker-app/qfieldcloud/core/exceptions.py
+++ b/docker-app/qfieldcloud/core/exceptions.py
@@ -200,3 +200,12 @@ class InvalidRangeError(QFieldCloudException):
     code = "invalid_http_range"
     message = "The provided HTTP range header is invalid."
     status_code = status.HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE
+
+
+class QGISProjectFileNotAllowedError(QFieldCloudException):
+    """Raised when a QGIS project file is uploaded to a project that does not allow it
+    (e.g. shared datasets project)"""
+
+    code = "qgis_project_file_not_allowed"
+    message = "QGIS project files are not allowed in this project."
+    status_code = status.HTTP_400_BAD_REQUEST

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1635,6 +1635,21 @@ class Project(models.Model):
 
         # Check if localized datasets project, then skip the rest of the checks as they are not applicable
         if self.name == SHARED_DATASETS_PROJECT_NAME:
+            if self.has_the_qgis_file:
+                problems.append(
+                    {
+                        "layer": None,
+                        "level": "error",
+                        "code": "qgis_project_file_not_allowed",
+                        "description": _(
+                            "Shared datasets projects cannot contain QGIS project files (.qgs/.qgz)."
+                        ),
+                        "solution": _(
+                            "Remove the QGIS project file (.qgs/.qgz) or rename the project to use it normally."
+                        ),
+                    }
+                )
+
             return problems
 
         if not self.has_the_qgis_file:
@@ -1759,7 +1774,9 @@ class Project(models.Model):
             max_premium_collaborators_per_private_project = self.owner.useraccount.current_subscription.plan.max_premium_collaborators_per_private_project
 
             # TODO use self.problems to get if there are project problems
-            if not self.has_the_qgis_file or not self.project_details:
+            if (
+                not self.has_the_qgis_file or not self.project_details
+            ) and not self.is_shared_datasets_project:
                 status = Project.Status.FAILED
                 status_code = Project.StatusCode.FAILED_PROCESS_PROJECTFILE
             elif (

--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -11,6 +11,7 @@ from rest_framework.request import Request
 from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core import exceptions
 from qfieldcloud.core.models import (
+    SHARED_DATASETS_PROJECT_NAME,
     ApplyJob,
     Delta,
     Job,
@@ -123,6 +124,18 @@ class ProjectSerializer(serializers.ModelSerializer):
 
             if matching_projects != 0:
                 raise exceptions.ProjectAlreadyExistsError()
+
+            if data["name"].lower() == SHARED_DATASETS_PROJECT_NAME:
+                if (
+                    self.instance
+                    and self.instance.name.lower() == SHARED_DATASETS_PROJECT_NAME
+                ):
+                    pass
+
+                elif self.instance and self.instance.has_the_qgis_file:
+                    raise exceptions.QGISProjectFileNotAllowedError(
+                        "QGIS project files are not allowed in shared datasets projects."
+                    )
 
         return data
 

--- a/docker-app/qfieldcloud/core/views/files_views.py
+++ b/docker-app/qfieldcloud/core/views/files_views.py
@@ -269,6 +269,11 @@ class DownloadPushDeleteFileView(views.APIView):
 
         is_the_qgis_file = utils.is_the_qgis_file(filename)
 
+        if is_the_qgis_file and project.is_shared_datasets_project:
+            raise exceptions.QGISProjectFileNotAllowedError(
+                "QGIS project files are not allowed in shared datasets projects."
+            )
+
         # check if the project restricts qgs/qgz file modification to admins
         if is_the_qgis_file and not permissions_utils.can_modify_qgis_projectfile(
             request.user, project

--- a/docker-app/qfieldcloud/filestorage/view_helpers.py
+++ b/docker-app/qfieldcloud/filestorage/view_helpers.py
@@ -91,6 +91,11 @@ def upload_project_file_version(
 
     is_qgis_file = is_qgis_project_file(filename)
 
+    if is_qgis_file and project.is_shared_datasets_project:
+        raise exceptions.ValidationError(
+            "QGIS project files are not allowed in shared datasets projects."
+        )
+
     # check only one qgs/qgz file per project for project files
     if (
         file_type == File.FileType.PROJECT_FILE


### PR DESCRIPTION
In the past all projects on QFC required a .qgs project file. In shared_datasets  it is actually the opposite. we should never add a QGIS project there.

- Added validation in `admin` and `serializers` to prevent renaming projects to the shared datasets name if they contain a QGIS project file.
- Fix project status logic to account for shared datasets projects.
- Add warning message for QGIS project files in shared dataset (to warn pre-existing Projects that violates this Rule)
- Added checks to disallow QGIS project files in shared datasets during file uploads.

**Notes to handle pre-existing Projects that violate this Rule** (Project name "shared_datasets" and has QGIS Project files): 
* The Upload / Sync for QGIS will raise an error. but It will work just fine on other file types despite the Project violating the Rule.

---

<img width="1028" height="346" alt="image" src="https://github.com/user-attachments/assets/b997bcaf-9c70-4b85-bc28-2d46cfe1d890" />

---

<img width="1033" height="225" alt="image" src="https://github.com/user-attachments/assets/41ef91a3-b9bc-4b0a-98d2-d51b2658a1aa" />


---

<img width="1091" height="654" alt="image" src="https://github.com/user-attachments/assets/b09dd4c8-6f85-44ec-a5d7-a9f425dfa82b" />
