### PR TITLE
feat: do not repeat the same log twice for libqfieldsync

### DIFF
--- a/docker-qgis/Dockerfile
+++ b/docker-qgis/Dockerfile
@@ -81,6 +81,10 @@ ENV XDG_RUNTIME_DIR=/root
 ENV PYTHONPATH=/libqfieldsync
 ENV PYTHONPATH=/qfieldcloud-sdk-python:${PYTHONPATH}
 
+# QFC specific variables
+# Controls whether libqfiedlsync should log also to the QGIS message log
+ENV IS_WITHIN_QFC_WORKER=1
+
 # Install debugpy for local development and debuggability
 ARG DEBUG_BUILD
 RUN if [ "$DEBUG_BUILD" = "1" ]; then pip3 install --break-system-packages debugpy; fi

--- a/docker-qgis/requirements_libqfieldsync.txt
+++ b/docker-qgis/requirements_libqfieldsync.txt
@@ -1,1 +1,1 @@
-libqfieldsync @ git+https://github.com/opengisch/libqfieldsync@043fe5ae4d9904dbba7ef6605f30f62e229b0f73
+libqfieldsync @ git+https://github.com/opengisch/libqfieldsync@6eeff164d28b899b997b0dcee14977781b6a0e7e


### PR DESCRIPTION
By introducing `IS_WITHIN_QFC_WORKER` we are going to instruct `libqfieldsync` to not redirect logs to the `QgsMessageLog`, therefore avoiding repetitions such as:

```
14:22:54.842 QGSMSGLOG INFO     Layer "list_salutation" will use attribute "fid" as a primary key.
14:22:54.842 libqfieldsync INFO     Layer "list_salutation" will use attribute "fid" as a primary key.
```

We still want to pipe all the info from `QgsMessageLog` to the loggers, because there might be valuable debugging information for QFC project administrators.

See https://github.com/opengisch/libqfieldsync/pull/133/