### PR TITLE
fix: ensure there is some kind of extent when generating a thumbnail

### DIFF
--- a/docker-qgis/qfc_worker/commands/process_projectfile.py
+++ b/docker-qgis/qfc_worker/commands/process_projectfile.py
@@ -124,6 +124,22 @@ def _generate_thumbnail(
     tmp_project = tmp_project_details["project"]
     map_settings = tmp_project_details["map_settings"]
 
+    if map_settings.extent().isEmpty():
+        logger.warning(
+            "Project has empty extent, using the full extent for the thumbnail."
+        )
+
+        map_settings.setExtent(map_settings.fullExtent())
+
+    # NOTE when the extent is still empty, QGIS hangs forever, so we just skip thumbnail generation.
+    if map_settings.extent().isEmpty():
+        logger.warning("Project has empty extent, no thumbnail can be generated.")
+
+        # NOTE force delete the `QgsProject`, otherwise the `QgsApplication` might be deleted by the time the project is garbage collected.
+        del tmp_project
+
+        return
+
     img = QImage(map_settings.outputSize(), QImage.Format_ARGB32)
     painter = QPainter(img)
     job = QgsMapRendererCustomPainterJob(map_settings, painter)

--- a/docker-qgis/qfc_worker/utils.py
+++ b/docker-qgis/qfc_worker/utils.py
@@ -306,6 +306,10 @@ def open_qgis_project_temporarily(
             if layer_tree:
                 map_settings.setLayers(reversed(list(layer_tree.customLayerOrder())))
 
+            if map_settings.extent().isEmpty():
+                # set to full extent if empty
+                map_settings.setExtent(map_settings.fullExtent())
+
             details["background_color"] = background_color.name()
             details["extent"] = map_settings.extent().asWktPolygon()
             details["map_settings"] = map_settings


### PR DESCRIPTION
When creating a project with xlsform2qgis, it is possible that here is no project extent. In that case, the process proejct job just hangs forever.

FYI @nirvn 