### PR TITLE
refactor: remove margin-left from header logo in CSS

### DIFF
--- a/docker-app/qfieldcloud/core/staticfiles/css/qfieldcloud.css
+++ b/docker-app/qfieldcloud/core/staticfiles/css/qfieldcloud.css
@@ -37,7 +37,6 @@ h1, h2, h3, h4, h5, h6 {
 
 .qfc-header-logo {
   height: 1.5rem;
-  margin-left: 1rem;
 }
 
 .qfc-logo-wrapper {


### PR DESCRIPTION
Remove `margin-left` form `.qfc-header-logo`, since it was not intended