### PR TITLE
[R&D] feat: add object storage cleaner script and testing

### DIFF
--- a/scripts/object_storage_cleaner/README.MD
+++ b/scripts/object_storage_cleaner/README.MD
@@ -1,0 +1,139 @@
+# Object Storage Cleaner
+
+A utility script to identify and clean "logically deleted" objects in S3-compatible object storage (e.g., AWS S3, MinIO) when bucket versioning is enabled.
+
+## The Problem
+
+When **Versioning** is enabled on an S3 bucket, deleting an object does not actually remove the data. Instead, S3 creates a **Delete Marker** as the latest version. The older versions (the actual data) remain in the bucket and continue to incur storage costs.
+
+A "logically deleted object" is an object where the current (latest) version is a Delete Marker. This means the object appears deleted to applications, but all its historical versions are still stored.
+
+This script helps you:
+1.  **Scan**: Find all objects that are logically deleted and calculate how much space they are wasting.
+2.  **Prune**: Permanently delete all versions of these objects (including the delete marker) to free up storage.
+
+> **Note**: This script specifically targets objects that are *currently deleted*. It does **not** touch objects that are still active (i.e., the latest version is a file, not a delete marker), even if they have old versions.
+
+## Requirements
+
+- Python 3.8+
+- `boto3` library
+
+Install dependencies:
+
+```bash
+pip install boto3
+```
+
+## Usage
+
+Run the script directly from the command line.
+
+### Basic Syntax
+
+```bash
+python storage_cleaner.py <bucket_name> [options]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `bucket_name` | The name of the target S3 bucket (Required). |
+| `--scan` | Only scan and report statistics (Default). |
+| `--prune` | Delete found objects. Requires confirmation unless `--noinput` is used. |
+| `--noinput` | Skip confirmation prompt (useful for automation). |
+| `--prefix <path>` | Limit scan to a specific prefix (folder). |
+| `--deleted-since <duration>` | Only process objects deleted within the last X time (e.g., `30d`, `2w`, `1h`). |
+| `--deleted-after <date>` | Only process objects deleted after a specific ISO 8601 date. |
+| `--endpoint-url <url>` | Custom endpoint URL (e.g., for MinIO or local testing). |
+| `--region <name>` | Object Storage (AWS) region name. |
+| `--profile <name>` | Object Storage (AWS) CLI profile to use. |
+| `--log-file <path>` | Write a detailed audit log to a file. |
+| `--debug` | Enable debug logging. |
+---
+By default the script uses the `default` S3 profile (default boto3 behavior)
+check [Configuration and credential file settings in the AWS CLI](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html)
+
+### Examples
+
+**1. Scan a bucket to see how much space can be freed:**
+
+```bash
+python storage_cleaner.py my-production-bucket --scan
+```
+
+**2. Scan a specific folder:**
+
+```bash
+python storage_cleaner.py my-production-bucket --prefix "logs/2023/" --scan
+```
+
+**3. Cleanup objects deleted more than 30 days ago:**
+
+*logic*: The script filters for objects deleted **after** a certain date/time (i.e., recently deleted).
+- `--deleted-since 30d`: Looks for objects deleted in the *last* 30 days.
+- `--deleted-after 2024-01-01`: Looks for objects deleted *after* Jan 1st, 2024.
+
+```bash
+# Find objects deleted in the last 7 days
+python storage_cleaner.py my-bucket --deleted-since 7d
+```
+
+**4. Permanently delete (prune) objects:**
+
+```bash
+python storage_cleaner.py my-bucket --prune
+# You will be prompted to confirm.
+```
+
+**5. Automated cleanup for MinIO (local/custom endpoint):**
+
+```bash
+python storage_cleaner.py test-bucket \
+  --endpoint-url http://localhost:9000 \
+  --prune --noinput
+```
+
+## Logging
+
+You can enable verbose logging to a file using the `--log-file` option. This will create a rotating log file that tracks all operations, including detailed traces of which versions were deleted (--prune) or can be deleted (--scan).
+
+Using `--debug` will allow you to check lower level details like connection parameters and bucket versioning status, this won't include logs coming from outside the script e.g boto3, urllib3, etc.
+
+```bash
+# Log to a specific file
+python storage_cleaner.py my-bucket --scan --log-file /var/log/s3-cleaner.log
+```
+
+## Running Tests
+
+The repository includes a test suite (`test.py`) that uses `pytest` and requires a running S3-compatible service (like MinIO).
+
+### Test Requirements
+- `pytest`
+- `boto3`
+- A local S3 service (e.g., MinIO) running. By default, tests expect it at `http://localhost:8009` (us-east-1).
+
+*you can also adjust the test file for your needs to connect to a remote object storage server to ru the tests*
+
+### Steps to Run Tests
+
+1.  **Start MinIO** (or ensure a mock S3 is running).
+    Example using Docker:
+    ```bash
+    docker run -d -p 8009:9000 --name minio-test \
+      -e "MINIO_ACCESS_KEY=access_key_xyz" \
+      -e "MINIO_SECRET_KEY=secret_key_xyz" \
+      minio/minio server /data
+    ```
+
+2.  **Configure Tests (Optional)**
+    If your local S3 is different from `http://localhost:8009`, update the `CONNECTION_CONFIG` dictionary in `test.py`.
+
+3.  **Run Pytest**
+    ```bash
+    pytest test.py
+    ```
+
+

--- a/scripts/object_storage_cleaner/README.MD
+++ b/scripts/object_storage_cleaner/README.MD
@@ -135,5 +135,3 @@ The repository includes a test suite (`test.py`) that uses `pytest` and requires
     ```bash
     pytest test.py
     ```
-
-

--- a/scripts/object_storage_cleaner/storage_cleaner.py
+++ b/scripts/object_storage_cleaner/storage_cleaner.py
@@ -1,0 +1,550 @@
+import argparse
+import signal
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, Iterator, List, Optional, Tuple
+
+import boto3
+from botocore.client import BaseClient
+from botocore.exceptions import BotoCoreError, ClientError
+
+# Data classes
+
+
+@dataclass
+class VersionRef:
+    """Represents a single object version or delete marker.
+
+    Attributes:
+        key: Object key.
+        version_id: Version ID of this entry.
+        is_delete_marker: True if this entry is a delete marker.
+        size: Size in bytes for a normal version. For delete markers, this is 0.
+        last_modified: Timestamp when this version was created/modified.
+    """
+
+    key: str
+    version_id: str
+    is_delete_marker: bool
+    size: int
+    last_modified: datetime
+
+
+@dataclass
+class LogicallyDeletedObject:
+    """Aggregated info about a logically deleted object.
+
+    A logically deleted object is one whose latest version is a delete marker,
+    even though older versions still exist and consume storage.
+
+    Attributes:
+        key: Object key.
+        deleted_at: Timestamp of the delete marker (latest version).
+        total_size_bytes: Sum of sizes of all non-delete-marker versions.
+        versions_count: Number of non-delete-marker versions.
+    """
+
+    key: str
+    deleted_at: datetime
+    total_size_bytes: int
+    versions_count: int
+
+
+# Main class
+class ObjectStorageScanner:
+    BATCH_SIZE = 1000
+
+    def __init__(
+        self,
+        bucket: str,
+        region_name: Optional[str] = None,
+        profile: Optional[str] = None,
+        endpoint_url: Optional[str] = None,
+        access_key_id: Optional[str] = None,
+        secret_access_key: Optional[str] = None,
+        prefix: Optional[str] = None,
+        deleted_after: Optional[datetime] = None,
+    ):
+        self.bucket = bucket
+        self.prefix = prefix
+        self.deleted_after = deleted_after
+        self.region_name = region_name
+        self.profile = profile
+        self.endpoint_url = endpoint_url
+
+        # Metrics
+        self.scanned_count = 0
+
+        # Initialize client
+        self.s3_client = self._create_s3_client(
+            region_name, profile, endpoint_url, access_key_id, secret_access_key
+        )
+
+        # Validate bucket immediately
+        self._validate_bucket_versioning()
+
+    @staticmethod
+    def _format_bytes(num_bytes: int) -> str:
+        """Convert a byte count to a human-readable string."""
+        units = ["B", "KB", "MB", "GB", "TB", "PB"]
+        size = float(num_bytes)
+        for unit in units:
+            if size < 1024.0 or unit == units[-1]:
+                return f"{size:.2f} {unit}"
+
+            size /= 1024.0
+
+        return f"{size:.2f} PB"
+
+    def _create_s3_client(
+        self,
+        region: Optional[str],
+        profile: Optional[str],
+        endpoint: Optional[str],
+        key_id: Optional[str],
+        secret: Optional[str],
+    ) -> BaseClient:
+        """Create the Boto3 S3 client."""
+        session_kwargs = (
+            {"profile_name": profile}
+            if profile
+            else {
+                "aws_access_key_id": key_id,
+                "aws_secret_access_key": secret,
+                "region_name": region,
+            }
+        )
+
+        try:
+            # Filter None values to let boto3 use defaults
+            clean_session_kwargs = {
+                k: v for k, v in session_kwargs.items() if v is not None
+            }
+            session = boto3.Session(**clean_session_kwargs)
+
+            client_kwargs = {"endpoint_url": endpoint} if endpoint else {}
+            return session.client("s3", **client_kwargs)
+        except (BotoCoreError, ClientError) as e:
+            raise RuntimeError(f"Failed to initialize S3 client: {e}") from e
+
+    def _validate_bucket_versioning(self) -> bool:
+        """Ensure the bucket has versioning enabled or suspended."""
+        try:
+            response = self.s3_client.get_bucket_versioning(Bucket=self.bucket)
+            status = response.get("Status")
+            if status not in ("Enabled", "Suspended"):
+                raise RuntimeError(
+                    f"Bucket '{self.bucket}' does not have versioning history (Status: {status}). "
+                    "Nothing to clean."
+                )
+        except ClientError as e:
+            raise RuntimeError(
+                f"Could not check versioning status for '{self.bucket}': {e}"
+            ) from e
+
+        return status == "Enabled"
+
+    def _iter_all_versions(self) -> Iterator[VersionRef]:
+        """Low-level generator that yields all versions and delete markers, sorted by Key."""
+        paginator = self.s3_client.get_paginator("list_object_versions")
+        kwargs = {"Bucket": self.bucket, "MaxKeys": 10000}
+        if self.prefix:
+            kwargs["Prefix"] = self.prefix
+
+        for page in paginator.paginate(**kwargs):
+            items: List[VersionRef] = []
+
+            for v in page.get("Versions", []):
+                items.append(
+                    VersionRef(
+                        key=v["Key"],
+                        version_id=v["VersionId"],
+                        is_delete_marker=False,
+                        size=v["Size"],
+                        last_modified=v["LastModified"],
+                    )
+                )
+
+            for dm in page.get("DeleteMarkers", []):
+                items.append(
+                    VersionRef(
+                        key=dm["Key"],
+                        version_id=dm["VersionId"],
+                        is_delete_marker=True,
+                        size=0,
+                        last_modified=dm["LastModified"],
+                    )
+                )
+
+            # Sort by Key to keep versions of the same object together
+            items.sort(key=lambda x: x.key)
+
+            # Update scanned count
+            self.scanned_count += len(items)
+
+            yield from items
+
+    def _aggregate_versions(
+        self, key: str, versions: List[VersionRef]
+    ) -> Optional[Tuple[LogicallyDeletedObject, List[VersionRef]]]:
+        """Determine if a key is logically deleted and aggregate its stats."""
+        if not versions:
+            return None
+
+        # Sort by time descending (latest first)
+        versions.sort(key=lambda x: x.last_modified, reverse=True)
+        latest = versions[0]
+
+        # Criteria: Latest version must be a delete marker
+        if not latest.is_delete_marker:
+            return None
+
+        # Filter by deleted_after date if set
+        if self.deleted_after and latest.last_modified < self.deleted_after:
+            return None
+
+        total_size = sum(v.size for v in versions)
+        count = sum(
+            1 for v in versions if not v.is_delete_marker
+        )  # count actual data versions
+
+        aggregate = LogicallyDeletedObject(
+            key=key,
+            deleted_at=latest.last_modified,
+            total_size_bytes=total_size,
+            versions_count=count,
+        )
+        return aggregate, versions
+
+    def _delete_batch(self, versions: List[Dict[str, str]]) -> int:
+        """Helper to delete a batch of objects."""
+        if not versions:
+            return 0
+
+        try:
+            self.s3_client.delete_objects(
+                Bucket=self.bucket, Delete={"Objects": versions, "Quiet": True}
+            )
+
+            return len(versions)
+        except ClientError as e:
+            print(f"Failed to delete batch: {e}")
+            return 0
+
+    def get_bucket_info(self):
+        """Display bucket and connection information."""
+
+        print("\nBucket Information:")
+        print("-" * 80)
+        print(f"Bucket:            {self.bucket}")
+        print("Versioning Status: Enabled")
+        print(f"Region:            {self.s3_client.meta.region_name}")
+        print(f"Endpoint URL:      {self.s3_client.meta.endpoint_url}")
+        print(f"Prefix Filter:     {self.prefix or 'No prefix specified'}")
+        print(
+            f"Deleted After:     {self.deleted_after.isoformat() if self.deleted_after else 'No deleted after date specified'}"
+        )
+        print("-" * 80)
+        print("✓ Connection successful.")
+        print("✓ Bucket is accessible.")
+        print("\nUse --scan to find logically deleted objects.")
+
+    def _find_logically_deleted(
+        self,
+    ) -> Iterator[Tuple[LogicallyDeletedObject, List[VersionRef]]]:
+        """Yields logically deleted objects."""
+        current_key: Optional[str] = None
+        current_versions: List[VersionRef] = []
+
+        for item in self._iter_all_versions():
+            if item.key != current_key:
+                if current_key is not None:
+                    result = self._aggregate_versions(current_key, current_versions)
+                    if result:
+                        yield result
+
+                current_key = item.key
+                current_versions = []
+
+            current_versions.append(item)
+
+        # Process the final key
+        if current_key is not None:
+            result = self._aggregate_versions(current_key, current_versions)
+            if result:
+                yield result
+
+    def scan(self) -> Tuple[int, int, int]:
+        """Scan and print report of logically deleted objects."""
+        # Reset metrics
+        self.scanned_count = 0
+
+        # Print filters
+        print(f"\nScanning bucket: '{self.bucket}'")
+        if self.prefix:
+            print(f"  Prefix filter: {self.prefix}")
+
+        if self.deleted_after:
+            print(
+                f"  Date filter:   Objects deleted after {self.deleted_after.isoformat()}"
+            )
+
+        print()
+
+        # Print table header
+        print("-" * 100)
+        print(f"{'Size':>9}  {'Versions':>10}  {'Deleted At':<33}  Key")
+        print("-" * 100)
+
+        stats_keys = 0
+        stats_versions = 0
+        stats_bytes = 0
+
+        # Iterate
+        for aggregate, _ in self._find_logically_deleted():
+            stats_keys += 1
+            stats_versions += aggregate.versions_count + 1
+            stats_bytes += aggregate.total_size_bytes
+
+            # Print row if <= 10
+            if stats_keys <= 10:
+                deleted_at_iso = aggregate.deleted_at.astimezone(
+                    timezone.utc
+                ).isoformat()
+                print(
+                    f"{self._format_bytes(aggregate.total_size_bytes):>12}  "
+                    f"{aggregate.versions_count:>8}  "
+                    f"{deleted_at_iso:<25}  "
+                    f"{aggregate.key}"
+                )
+
+            elif stats_keys == 11:
+                # Clear previous progress line
+                print(" " * 100, end="\r")
+                # Print aligned continuation markers (matches table columns)
+                print(f"{'....':>9}  {'....':>11}  {'....':<32}  ....")
+                # Add blank vertical space
+                print()
+
+            # Dynamic progress
+            print(
+                f"Scanned {self.scanned_count} versions | Found {stats_keys} keys | Deletable: {stats_versions} versions ({self._format_bytes(stats_bytes)})"
+                + " " * 20,
+                end="\r",
+            )
+
+        # Clear progress line
+        print(" " * 100, end="\r")
+
+        print("-" * 100)
+        if stats_keys == 0:
+            print("\nNo logically deleted objects found.")
+        else:
+            print("\nSummary:")
+            print(f"  Total logically deleted keys: {stats_keys}")
+            print(f"  Total versions to delete: {stats_versions}")
+            print(f"  Total storage to free: {self._format_bytes(stats_bytes)}")
+
+        return stats_keys, stats_versions, stats_bytes
+
+    def clean(self) -> Tuple[int, int, int]:
+        """Scan and delete logically deleted objects."""
+        # Reset metrics
+        self.scanned_count = 0
+
+        # Print filters
+        print(f"\nScanning bucket: '{self.bucket}'")
+        if self.prefix:
+            print(f"  Prefix filter: {self.prefix}")
+
+        if self.deleted_after:
+            print(
+                f"  Date filter:   Objects deleted after {self.deleted_after.isoformat()}"
+            )
+
+        print()
+
+        batch: List[Dict[str, str]] = []
+
+        stats_keys = 0
+        stats_deleted_versions = 0
+        stats_bytes = 0
+
+        # Iterate
+        for aggregate, versions in self._find_logically_deleted():
+            stats_keys += 1
+            stats_bytes += aggregate.total_size_bytes
+
+            for v in versions:
+                batch.append({"Key": v.key, "VersionId": v.version_id})
+                if len(batch) >= self.BATCH_SIZE:
+                    stats_deleted_versions += self._delete_batch(batch)
+                    batch.clear()
+
+            # Dynamic progress
+            print(
+                f"Scanned {self.scanned_count} versions | Found {stats_keys} keys | Deleted {stats_deleted_versions} versions ({self._format_bytes(stats_bytes)})"
+                + " " * 20,
+                end="\r",
+            )
+
+        # Flush remaining
+        if batch:
+            stats_deleted_versions += self._delete_batch(batch)
+
+        # Clear progress line
+        print(" " * 100, end="\r")
+
+        if stats_keys == 0:
+            print("No logically deleted objects found.")
+        else:
+            print(
+                f"\nDone. Deleted {stats_deleted_versions} versions from {stats_keys} keys."
+            )
+            print(f"Freed {self._format_bytes(stats_bytes)}.")
+
+        return stats_keys, stats_deleted_versions, stats_bytes
+
+
+def parse_dt(value: str) -> datetime:
+    """Parse a datetime string from ISO 8601 format."""
+    if value:
+        try:
+            return datetime.fromisoformat(value).replace(tzinfo=timezone.utc)
+        except ValueError:
+            raise argparse.ArgumentTypeError(f"Invalid ISO 8601 date: '{value}'")
+    else:
+        return None
+
+
+def signal_handler(sig, frame):
+    print("\n\nScan interrupted by user. Cleaning up...")
+    sys.exit(0)
+
+
+signal.signal(signal.SIGINT, signal_handler)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Scan and clean logically deleted objects in S3.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+        Examples:
+        # Scan only (default)
+        %(prog)s my-bucket
+
+        # Scan with filters
+        %(prog)s my-bucket --prefix logs/ --deleted-after 2024-12-01
+
+        # Delete with confirmation prompt
+        %(prog)s my-bucket --purge
+
+        # Delete without confirmation (automation)
+        %(prog)s my-bucket --purge --noinput
+        """,
+    )
+
+    # Required
+    parser.add_argument("bucket", help="Target S3 bucket")
+
+    # Connection options
+    parser.add_argument("--prefix", help="Key prefix to scan")
+    parser.add_argument("--region", help="AWS region")
+    parser.add_argument("--profile", help="AWS profile")
+    parser.add_argument("--endpoint-url", help="Custom S3 endpoint URL")
+    parser.add_argument("--access-key-id", help="Access key ID")
+    parser.add_argument("--secret-access-key", help="Secret access key")
+
+    # Filter options
+    parser.add_argument(
+        "--deleted-after",
+        type=parse_dt,
+        help="Only process objects deleted after this date (ISO 8601 format)",
+    )
+
+    # Action flags
+    parser.add_argument(
+        "--info", action="store_true", help="Show bucket information (default behavior)"
+    )
+    parser.add_argument("--scan", action="store_true", help="Scan only")
+
+    parser.add_argument(
+        "--purge",
+        action="store_true",
+        help="Delete found objects (requires confirmation unless --noinput)",
+    )
+
+    parser.add_argument(
+        "--noinput",
+        action="store_true",
+        help="Skip confirmation prompt (use with --purge for automation)",
+    )
+
+    args = parser.parse_args()
+
+    # Create scanner
+    try:
+        cleaner = ObjectStorageScanner(
+            bucket=args.bucket,
+            region_name=args.region,
+            profile=args.profile,
+            endpoint_url=args.endpoint_url,
+            access_key_id=args.access_key_id,
+            secret_access_key=args.secret_access_key,
+            prefix=args.prefix,
+            deleted_after=args.deleted_after
+            if isinstance(args.deleted_after, datetime)
+            else parse_dt(args.deleted_after),
+        )
+    except RuntimeError as e:
+        print(f"ERROR: {e}")
+        return 1
+
+    if args.info:
+        cleaner.get_bucket_info()
+        return 0
+
+    # Mode: Scan only
+    elif args.scan:
+        cleaner.scan()
+        return 0
+
+    # Mode: Purge (with or without confirmation)
+    elif args.purge:
+        if not args.noinput:
+            print(f"\nTarget Bucket: {args.bucket}")
+            if args.prefix:
+                print(f"Prefix: {args.prefix}")
+
+            print(
+                "WARNING: You are about to permanently delete logically deleted objects. This action cannot be undone!"
+            )
+            confirm = input("Type 'yes' to confirm deletion: ").strip().lower()
+
+            if confirm != "yes":
+                print("Operation cancelled.")
+                return 0
+
+        # Execute deletion
+        if args.noinput:
+            print("\nDeleting...")
+        else:
+            print("\nStarting cleanup...")
+
+        cleaner.clean()
+
+    # Default fallback to info
+    else:
+        print("No action specified. Use --info, --scan, or --purge.")
+        print("Use --help for usage information.")
+        print("Defaulting to --info.")
+        cleaner.get_bucket_info()
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/object_storage_cleaner/storage_cleaner.py
+++ b/scripts/object_storage_cleaner/storage_cleaner.py
@@ -516,14 +516,14 @@ def main() -> int:
     parser.add_argument(
         "--deleted-after",
         type=datetime.fromisoformat,
-        help="Only process objects deleted after this date (ISO 8601 format, e.g. 2024-12-01:00:00:00)",
+        help="Only process objects deleted after this date (ISO 8601 format, e.g. 2024-12-01:00:00:00) Cannot be used with `--deleted-since.`",
     )
 
     parser.add_argument(
-        "--since",
+        "--deleted-since",
         type=parse_since_cutoff,
         metavar="DAYS",
-        help="Number of days ago (e.g. 3, 3d, '7 days')",
+        help="Number of days ago (e.g. 3, 3d, '7 days'). Cannot be used with `--deleted-after.`",
     )
 
     # Action flags
@@ -563,12 +563,12 @@ def main() -> int:
 
     deleted_after = None
 
-    if args.since and args.deleted_after:
+    if args.deleted_since and args.deleted_after:
         raise argparse.ArgumentTypeError(
-            "Cannot use --since and --deleted-after together"
+            "Cannot use --deleted-since and --deleted-after together"
         )
-    elif args.since:
-        deleted_after = args.since
+    elif args.deleted_since:
+        deleted_after = args.deleted_since
     elif args.deleted_after:
         deleted_after = args.deleted_after.replace(tzinfo=timezone.utc)
 

--- a/scripts/object_storage_cleaner/storage_cleaner.py
+++ b/scripts/object_storage_cleaner/storage_cleaner.py
@@ -457,25 +457,27 @@ def parse_since_cutoff(value: str) -> datetime:
     """
     value = value.strip().lower()
 
-    pattern = r"^(\d+)\s*(s|sec|secs|seconds|min|minute|minutes|h|hour|hours|d|day|days|w|week|weeks)$"
+    pattern = (
+        r"^(\d+)\s*(second|seconds|minute|minutes|hour|hours|day|days|week|weeks)$"
+    )
     match = re.match(pattern, value)
     if not match:
         raise argparse.ArgumentTypeError(
-            "Invalid duration. Use: '3s', '10h', '15min', '30d', '2w' (or words like '3 days')"
+            "Invalid duration. Use: '3 seconds', '10 hours', '15 minutes', '30 days', '2 weeks'"
         )
 
     amount = int(match.group(1))
     unit = match.group(2)
 
-    if unit in ("s", "sec", "secs", "seconds"):
+    if unit in ("second", "seconds"):
         delta = timedelta(seconds=amount)
-    elif unit in ("min", "minute", "minutes"):
+    elif unit in ("minute", "minutes"):
         delta = timedelta(minutes=amount)
-    elif unit in ("h", "hour", "hours"):
+    elif unit in ("hour", "hours"):
         delta = timedelta(hours=amount)
-    elif unit in ("d", "day", "days"):
+    elif unit in ("day", "days"):
         delta = timedelta(days=amount)
-    elif unit in ("w", "week", "weeks"):
+    elif unit in ("week", "weeks"):
         delta = timedelta(weeks=amount)
     else:
         raise argparse.ArgumentTypeError(f"Unsupported time unit: {unit}")
@@ -522,8 +524,8 @@ def main() -> int:
     parser.add_argument(
         "--deleted-since",
         type=parse_since_cutoff,
-        metavar="DAYS",
-        help="Number of days ago (e.g. 3, 3d, '7 days'). Cannot be used with `--deleted-after.`",
+        metavar="DURATION",
+        help="Time duration ago (e.g. '3 days', '2 weeks'). Cannot be used with `--deleted-after.`",
     )
 
     # Action flags

--- a/scripts/object_storage_cleaner/storage_cleaner.py
+++ b/scripts/object_storage_cleaner/storage_cleaner.py
@@ -415,7 +415,13 @@ signal.signal(signal.SIGINT, _handle_sigint)
 
 def setup_logging(debug: bool = False, log_file: str | None = None) -> None:
     """Setup logging for the script."""
-    level = TRACE_LEVEL if log_file else (logging.DEBUG if debug else logging.INFO)
+    level = logging.INFO
+
+    if log_file:
+        level = TRACE_LEVEL
+    elif debug:
+        level = logging.DEBUG
+
     logger.setLevel(level)
     logger.handlers.clear()
     logger.propagate = False

--- a/scripts/object_storage_cleaner/storage_cleaner.py
+++ b/scripts/object_storage_cleaner/storage_cleaner.py
@@ -197,15 +197,16 @@ class ObjectStorageScanner:
             return None
 
         total_size = sum(v.size for v in versions)
-        count = sum(
-            1 for v in versions if not v.is_delete_marker
-        )  # count actual data versions
+
+        actual_versions_count = len(
+            list(filter(lambda v: not v.is_delete_marker, versions))
+        )
 
         aggregate = LogicallyDeletedObject(
             key=key,
             deleted_at=latest.last_modified,
             total_size_bytes=total_size,
-            versions_count=count,
+            versions_count=actual_versions_count,
         )
         return aggregate, versions
 

--- a/scripts/object_storage_cleaner/storage_cleaner.py
+++ b/scripts/object_storage_cleaner/storage_cleaner.py
@@ -198,7 +198,11 @@ class ObjectStorageCleaner:
     ) -> Iterator[VersionRef]:
         """Low-level generator that yields all versions and delete markers, sorted by Key."""
         paginator = self.s3_client.get_paginator("list_object_versions")
-        kwargs = {"Bucket": self.bucket, "MaxKeys": 10000}
+        kwargs = {
+            "Bucket": self.bucket,
+            "MaxKeys": 1000,
+        }
+
         if self.prefix:
             kwargs["Prefix"] = self.prefix
 
@@ -284,6 +288,7 @@ class ObjectStorageCleaner:
                 )
 
         try:
+            # Quiet=True returns only errors (no success details)
             self.s3_client.delete_objects(
                 Bucket=self.bucket, Delete={"Objects": versions, "Quiet": True}
             )

--- a/scripts/object_storage_cleaner/storage_cleaner.py
+++ b/scripts/object_storage_cleaner/storage_cleaner.py
@@ -9,9 +9,8 @@ import boto3
 from botocore.client import BaseClient
 from botocore.exceptions import BotoCoreError, ClientError
 
+
 # Data classes
-
-
 @dataclass
 class VersionRef:
     """Represents a single object version or delete marker.
@@ -208,6 +207,7 @@ class ObjectStorageScanner:
             total_size_bytes=total_size,
             versions_count=actual_versions_count,
         )
+
         return aggregate, versions
 
     def _delete_batch(self, versions: list[dict[str, str]]) -> int:

--- a/scripts/object_storage_cleaner/storage_cleaner.py
+++ b/scripts/object_storage_cleaner/storage_cleaner.py
@@ -73,7 +73,7 @@ def format_bytes(num_bytes: int) -> str:
 
 
 # Main class
-class ObjectStorageScanner:
+class ObjectStorageCleaner:
     BATCH_SIZE = 1000
 
     def __init__(
@@ -572,9 +572,9 @@ def main() -> int:
     elif args.deleted_after:
         deleted_after = args.deleted_after.replace(tzinfo=timezone.utc)
 
-    # Create scanner
+    # Create cleaner
     try:
-        scanner = ObjectStorageScanner(
+        cleaner = ObjectStorageCleaner(
             bucket=args.bucket,
             region_name=args.region,
             profile=args.profile,
@@ -587,12 +587,12 @@ def main() -> int:
         return 1
 
     if args.info:
-        scanner.print_bucket_info()
+        cleaner.print_bucket_info()
         return 0
 
     # Mode: Scan only
     elif args.scan:
-        scanner.scan()
+        cleaner.scan()
         return 0
 
     # Mode: Prune (with or without confirmation)
@@ -611,12 +611,12 @@ def main() -> int:
                 logger.info("Operation cancelled.")
                 return 0
 
-        scanner.prune()
+        cleaner.prune()
 
     # Default fallback to info
     else:
         logger.info("No action specified. Defaulting to --info.")
-        scanner.print_bucket_info()
+        cleaner.print_bucket_info()
         return 0
 
     return 0

--- a/scripts/object_storage_cleaner/storage_cleaner.py
+++ b/scripts/object_storage_cleaner/storage_cleaner.py
@@ -251,16 +251,20 @@ class ObjectStorageScanner:
         current_versions: list[VersionRef] = []
 
         for item in self._iter_all_versions():
-            if item.key != current_key:
-                if current_key is not None:
-                    result = self._aggregate_versions(current_key, current_versions)
-                    if result:
-                        yield result
+            # Same key, just accumulate and continue
+            if item.key == current_key:
+                current_versions.append(item)
+                continue
 
-                current_key = item.key
-                current_versions = []
+            # Another key, process the previous key.
+            if current_key is not None:
+                result = self._aggregate_versions(current_key, current_versions)
+                if result:
+                    yield result
 
-            current_versions.append(item)
+            # Start a new batch for the new key
+            current_key = item.key
+            current_versions = [item]
 
         # Process the final key
         if current_key is not None:

--- a/scripts/object_storage_cleaner/test.py
+++ b/scripts/object_storage_cleaner/test.py
@@ -1,0 +1,217 @@
+import subprocess
+import sys
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import boto3
+import pytest
+
+# --- Configuration ---
+CONNECTION_CONFIG = {
+    "endpoint_url": "http://localhost:8009",
+    "aws_access_key_id": "XXXXXXXXX",
+    "aws_secret_access_key": "XXXXXXXXX",
+    "region_name": "us-east-1",
+}
+BUCKET_NAME = "test-bucket"
+
+# --- Fixtures ---
+
+
+@pytest.fixture(scope="session")
+def s3_client():
+    """Creates a boto3 s3 client."""
+    return boto3.client("s3", **CONNECTION_CONFIG)
+
+
+@pytest.fixture(scope="session")
+def ensure_bucket(s3_client):
+    """Ensures the test bucket exists and has versioning enabled."""
+    try:
+        s3_client.create_bucket(Bucket=BUCKET_NAME)
+    except s3_client.exceptions.BucketAlreadyOwnedByYou:
+        pass
+    except s3_client.exceptions.BucketAlreadyExists:
+        pass
+
+    # Enable versioning
+    s3_client.put_bucket_versioning(
+        Bucket=BUCKET_NAME, VersioningConfiguration={"Status": "Enabled"}
+    )
+    return BUCKET_NAME
+
+
+@pytest.fixture
+def unique_prefix(ensure_bucket):
+    """Generates a unique prefix for test isolation."""
+    return f"test-run-{uuid.uuid4()}/"
+
+
+# --- Helper Functions ---
+
+
+def run_script(args):
+    """Runs the storage_cleaner.py script as a subprocess."""
+    cmd = [sys.executable, "storage_cleaner.py", BUCKET_NAME] + args
+
+    # Add connection args
+    if "endpoint_url" in CONNECTION_CONFIG:
+        cmd.extend(["--endpoint-url", CONNECTION_CONFIG["endpoint_url"]])
+
+    if "aws_access_key_id" in CONNECTION_CONFIG:
+        cmd.extend(["--access-key-id", CONNECTION_CONFIG["aws_access_key_id"]])
+
+    if "aws_secret_access_key" in CONNECTION_CONFIG:
+        cmd.extend(["--secret-access-key", CONNECTION_CONFIG["aws_secret_access_key"]])
+
+    if "region_name" in CONNECTION_CONFIG:
+        cmd.extend(["--region", CONNECTION_CONFIG["region_name"]])
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return result
+
+
+def create_file(s3_client, bucket, key, content="test content"):
+    s3_client.put_object(Bucket=bucket, Key=key, Body=content)
+
+
+def delete_file(s3_client, bucket, key):
+    s3_client.delete_object(Bucket=bucket, Key=key)
+
+
+def list_versions(s3_client, bucket, prefix):
+    versions = s3_client.list_object_versions(Bucket=bucket, Prefix=prefix)
+    all_versions = versions.get("Versions", []) + versions.get("DeleteMarkers", [])
+    return all_versions
+
+
+# --- Tests ---
+
+
+def test_no_logically_deleted_files(s3_client, unique_prefix):
+    """
+    Upload files to object storage - no deleted files
+    (shouldn't find any logically deleted objects) -> Nothing deleted
+    """
+    # 1. Upload files
+    key = f"{unique_prefix}file1.txt"
+    create_file(s3_client, BUCKET_NAME, key)
+
+    # 2. Run scan
+    result = run_script(["--scan", "--prefix", unique_prefix])
+
+    # 3. Verify output
+    assert result.returncode == 0
+    assert "No logically deleted objects found" in result.stdout
+
+
+def test_logically_deleted_files_cleanup(s3_client, unique_prefix):
+    """
+    Upload files to object storage - delete some files
+    (should find logically deleted objects) -> Deleted files
+    """
+    # 1. Upload file
+    key = f"{unique_prefix}file_deleted.txt"
+    create_file(s3_client, BUCKET_NAME, key)
+
+    # 2. Delete file (creates delete marker)
+    delete_file(s3_client, BUCKET_NAME, key)
+
+    # 3. Run purge
+    result = run_script(["--purge", "--noinput", "--prefix", unique_prefix])
+
+    # 4. Verify output and state
+    assert result.returncode == 0
+    assert "Deleted" in result.stdout
+
+    # Verify file is completely gone (no versions left)
+    versions = list_versions(s3_client, BUCKET_NAME, unique_prefix)
+    assert len(versions) == 0
+
+
+def test_restored_files_ignored(s3_client, unique_prefix):
+    """
+    Upload files to object storage - delete some files - restore
+    (shouldn't find any logically deleted objects) -> Nothing deleted
+    """
+    # 1. Upload file (v1)
+    key = f"{unique_prefix}file_restored.txt"
+    create_file(s3_client, BUCKET_NAME, key, "v1")
+
+    # 2. Delete file (v2 - delete marker)
+    delete_file(s3_client, BUCKET_NAME, key)
+
+    # 3. Restore file (v3 - new version)
+    create_file(s3_client, BUCKET_NAME, key, "v3")
+
+    # 4. Run scan
+    result = run_script(["--scan", "--prefix", unique_prefix])
+
+    # 5. Verify output - should not find it
+    assert result.returncode == 0
+    assert "No logically deleted objects found" in result.stdout
+
+
+def test_deleted_after_filter(s3_client, unique_prefix):
+    """
+    Upload files, delete some, test deleted-after filter.
+    """
+    key = f"{unique_prefix}file_date_test.txt"
+    create_file(s3_client, BUCKET_NAME, key)
+    delete_file(s3_client, BUCKET_NAME, key)
+
+    # Wait a moment to ensure clock skew isn't an issue if running locally fast
+    time.sleep(1)
+
+    now = datetime.now(timezone.utc)
+    future_date = now + timedelta(days=30)
+    past_date = now - timedelta(days=30)
+
+    # Filter is in the FUTURE.
+
+    result_future = run_script(
+        [
+            "--scan",
+            "--prefix",
+            unique_prefix,
+            "--deleted-after",
+            future_date.isoformat(),
+        ]
+    )
+    assert "No logically deleted objects found" in result_future.stdout
+
+    # Filter is in the PAST.
+
+    result_past = run_script(
+        ["--scan", "--prefix", unique_prefix, "--deleted-after", past_date.isoformat()]
+    )
+    assert "No logically deleted objects found" not in result_past.stdout
+    assert "Total logically deleted keys: 1" in result_past.stdout
+
+
+def test_complex_version_history(s3_client, unique_prefix):
+    """
+    File created, deleted, created again, deleted again.
+    Ensure ALL versions (history) are cleaned up.
+    """
+    key = f"{unique_prefix}complex_history.txt"
+
+    # 1. v1: Create
+    create_file(s3_client, BUCKET_NAME, key, "v1")
+    # 2. v2: Delete
+    delete_file(s3_client, BUCKET_NAME, key)
+    # 3. v3: Re-create
+    create_file(s3_client, BUCKET_NAME, key, "v3")
+    # 4. v4: Delete again (Final state is deleted)
+    delete_file(s3_client, BUCKET_NAME, key)
+
+    # Run purge
+    result = run_script(["--purge", "--noinput", "--prefix", unique_prefix])
+
+    assert result.returncode == 0
+    assert "Deleted" in result.stdout
+
+    # Verify completely empty
+    versions = list_versions(s3_client, BUCKET_NAME, unique_prefix)
+    assert len(versions) == 0

--- a/scripts/object_storage_cleaner/test.py
+++ b/scripts/object_storage_cleaner/test.py
@@ -261,7 +261,7 @@ def test_large_data_complex_version_history(s3_client, unique_prefix):
     assert "Total versions deleted: 4" in result.stdout
 
 
-def test_since_filter(s3_client, unique_prefix):
+def test_deleted_since_filter(s3_client, unique_prefix):
     """
     Upload files, delete some, test since filter.
     """
@@ -281,14 +281,14 @@ def test_since_filter(s3_client, unique_prefix):
             "--scan",
             "--prefix",
             unique_prefix,
-            "--since",
+            "--deleted-since",
             "1s",
         ]
     )
     assert "Total logically deleted keys: 0" in result_future.stdout
 
     # Filter is in the PAST.
-    result = run_script(["--scan", "--prefix", unique_prefix, "--since", "5s"])
+    result = run_script(["--scan", "--prefix", unique_prefix, "--deleted-since", "5s"])
     assert "Total logically deleted keys: 1" in result.stdout
 
 

--- a/scripts/object_storage_cleaner/test.py
+++ b/scripts/object_storage_cleaner/test.py
@@ -282,13 +282,15 @@ def test_deleted_since_filter(s3_client, unique_prefix):
             "--prefix",
             unique_prefix,
             "--deleted-since",
-            "1s",
+            "1 second",
         ]
     )
     assert "Total logically deleted keys: 0" in result_future.stdout
 
     # Filter is in the PAST.
-    result = run_script(["--scan", "--prefix", unique_prefix, "--deleted-since", "5s"])
+    result = run_script(
+        ["--scan", "--prefix", unique_prefix, "--deleted-since", "5 seconds"]
+    )
     assert "Total logically deleted keys: 1" in result.stdout
 
 

--- a/scripts/object_storage_cleaner/test.py
+++ b/scripts/object_storage_cleaner/test.py
@@ -101,7 +101,7 @@ def test_no_logically_deleted_files(s3_client, unique_prefix):
 
     # 3. Verify output
     assert result.returncode == 0
-    assert "No logically deleted objects found" in result.stdout
+    assert "Total logically deleted keys: 0" in result.stdout
 
 
 def test_logically_deleted_files_cleanup(s3_client, unique_prefix):
@@ -121,7 +121,8 @@ def test_logically_deleted_files_cleanup(s3_client, unique_prefix):
 
     # 4. Verify output and state
     assert result.returncode == 0
-    assert "Deleted 2 versions from 1 keys" in result.stdout
+    assert "Total logically deleted keys: 1" in result.stdout
+    assert "Total versions deleted: 2" in result.stdout
 
     # Verify file is completely gone (no versions left)
     versions = list_versions(s3_client, BUCKET_NAME, unique_prefix)
@@ -148,7 +149,7 @@ def test_restored_files_ignored(s3_client, unique_prefix):
 
     # 5. Verify output - should not find it
     assert result.returncode == 0
-    assert "No logically deleted objects found" in result.stdout
+    assert "Total logically deleted keys: 0" in result.stdout
 
 
 def test_deleted_after_filter(s3_client, unique_prefix):
@@ -177,14 +178,13 @@ def test_deleted_after_filter(s3_client, unique_prefix):
             future_date.isoformat(),
         ]
     )
-    assert "No logically deleted objects found" in result_future.stdout
+    assert "Total logically deleted keys: 0" in result_future.stdout
 
     # Filter is in the PAST.
 
     result_past = run_script(
         ["--scan", "--prefix", unique_prefix, "--deleted-after", past_date.isoformat()]
     )
-    assert "No logically deleted objects found" not in result_past.stdout
     assert "Total logically deleted keys: 1" in result_past.stdout
 
 
@@ -208,7 +208,8 @@ def test_complex_version_history(s3_client, unique_prefix):
     result = run_script(["--purge", "--noinput", "--prefix", unique_prefix])
 
     assert result.returncode == 0
-    assert "Deleted 4 versions from 1 keys" in result.stdout
+    assert "Total logically deleted keys: 1" in result.stdout
+    assert "Total versions deleted: 4" in result.stdout
 
     # Verify completely empty
     versions = list_versions(s3_client, BUCKET_NAME, unique_prefix)
@@ -246,7 +247,7 @@ def test_large_data_complex_version_history(s3_client, unique_prefix):
 
     # Verify output (should not find any logically deleted objects)
     assert result.returncode == 0
-    assert "No logically deleted objects found" in result.stdout
+    assert "Total logically deleted keys: 0" in result.stdout
 
     # delete the key A again
     delete_file(s3_client, BUCKET_NAME, key1)
@@ -256,4 +257,5 @@ def test_large_data_complex_version_history(s3_client, unique_prefix):
 
     # Verify output (should find logically deleted objects)
     assert result.returncode == 0
-    assert "Deleted 4 versions from 1 keys" in result.stdout
+    assert "Total logically deleted keys: 1" in result.stdout
+    assert "Total versions deleted: 4" in result.stdout

--- a/scripts/object_storage_cleaner/test.py
+++ b/scripts/object_storage_cleaner/test.py
@@ -116,8 +116,8 @@ def test_logically_deleted_files_cleanup(s3_client, unique_prefix):
     # 2. Delete file (creates delete marker)
     delete_file(s3_client, BUCKET_NAME, key)
 
-    # 3. Run purge
-    result = run_script(["--purge", "--noinput", "--prefix", unique_prefix])
+    # 3. Run prune
+    result = run_script(["--prune", "--noinput", "--prefix", unique_prefix])
 
     # 4. Verify output and state
     assert result.returncode == 0
@@ -204,8 +204,8 @@ def test_complex_version_history(s3_client, unique_prefix):
     # 4. v4: Delete again (Final state is deleted)
     delete_file(s3_client, BUCKET_NAME, key)
 
-    # Run purge
-    result = run_script(["--purge", "--noinput", "--prefix", unique_prefix])
+    # Run prune
+    result = run_script(["--prune", "--noinput", "--prefix", unique_prefix])
 
     assert result.returncode == 0
     assert "Total logically deleted keys: 1" in result.stdout
@@ -242,8 +242,8 @@ def test_large_data_complex_version_history(s3_client, unique_prefix):
     # Restore key1
     create_file(s3_client, BUCKET_NAME, key1, "a" * 1000000)
 
-    # Run purge
-    result = run_script(["--purge", "--noinput", "--prefix", unique_prefix])
+    # Run prune
+    result = run_script(["--prune", "--noinput", "--prefix", unique_prefix])
 
     # Verify output (should not find any logically deleted objects)
     assert result.returncode == 0
@@ -252,8 +252,8 @@ def test_large_data_complex_version_history(s3_client, unique_prefix):
     # delete the key A again
     delete_file(s3_client, BUCKET_NAME, key1)
 
-    # Run purge
-    result = run_script(["--purge", "--noinput", "--prefix", unique_prefix])
+    # Run prune
+    result = run_script(["--prune", "--noinput", "--prefix", unique_prefix])
 
     # Verify output (should find logically deleted objects)
     assert result.returncode == 0


### PR DESCRIPTION
Currently QFieldCloud keeps all project files using the non-legacy storage even if they are deleted by the user. This is due to enabled versioning on Exoscale and the lack of Exoscale mechanism to delete files after certain amount of time after they are deleted. This causes excessive file storage and therefore costs.

- Add `storage_cleaner.py` for scanning and deleting logically deleted objects in S3 compatable storages
- Add `test.py` for testing the script
- Add a `README.MD`

---
A small CLI to **analyze and clean logically deleted objects** in **versioned S3-compatible buckets**.

This script is **provider-agnostic** works with any S3-compatible service that supports versioning such as `MinIO`, etc.

It helps you to the following:
1. Detect whether a bucket has versioning configured.
2. Find keys whose **latest version is a delete marker** (logically deleted).
3. Report how much storage their historical versions consume.
4. **Deleting all versions** for those keys to free space.

#### Requirements
- boto3
- pytest (just for testing)

#### Usage

##### 1. No action provided or `--info`
```
python storage_cleaner.py my-versioned-bucket-name
```
```
No action specified. Use --info, --scan, or --prune.
Use --help for usage information.
Defaulting to --info.

Bucket Information:
--------------------------------------------------------------------------------
Bucket:            my-versioned-bucket-name
Versioning Status: Enabled
Region:            us-east-1
Endpoint URL:      http://localhost:8009
Prefix Filter:     No prefix specified
Deleted After:     No deleted after date specified
--------------------------------------------------------------------------------
✓ Connection successful.
✓ Bucket is accessible.

Use --scan to find logically deleted objects.
```

##### 1. Scanning for logically deleted objects
```
python storage_cleaner.py my-versioned-bucket-name --scan
```
##### 1. Deleting logically deleted objects
```
python storage_cleaner.py my-versioned-bucket-name --prune
```

#### Arguments
1. `--noinput` Skip confirmation prompt (use with --purge for automation)
2. `--deleted-after` Only process objects deleted after this date (ISO 8601 format, e.g. 2024-12-01:00:00:00) Cannot be used with `--deleted-since.`
3. `--deleted-since` Time duration ago (e.g. '3 days', '2 weeks'). Cannot be used with `--deleted-after.`
4. `--prefix` Key prefix to scan
5. `--profile` Object storage profile
6. `--debug` Enable debug logging
7. `--log-file` Write a rotating logbook file (e.g. /tmp/s3-cleaner.log)
8. `--scan` Scan only
9. `--prune` Delete found logically deleted objects (requires confirmation unless --noinput)
10. `--info` Show bucket information (default behavior)

By default it will load the `default` local S3 configuration 


### Testing 
Added multiple test cases 
1. Upload files to object storage - no deleted files (shouldn't find any logically deleted objects) -> Nothing deleted
2. Upload files to object storage - delete some files (should find logically deleted objects) -> Deleted files
3. Upload files to object storage - delete some files - restore (shouldn't find any logically deleted objects) -> Nothing deleted
4. Upload files, delete some, test deleted-after filter.
11. File created, deleted, created again, deleted again. Ensure ALL versions (history) are cleaned up.


# Demo
#### Scan
![Screencast from 2025-12-25 00-35-29](https://github.com/user-attachments/assets/034de643-f837-4cac-a395-116fdb6907d1)

#### Prune
![Screencast from 2025-12-25 00-37-48](https://github.com/user-attachments/assets/1d3f758b-2e80-46fd-aa60-e8bea1e7e001)

