### PR TITLE
feat: add `not-yet-packaged` CLI filter in file storage migration script

### DIFF
--- a/docker-app/qfieldcloud/filestorage/management/commands/migratefilestorage.py
+++ b/docker-app/qfieldcloud/filestorage/management/commands/migratefilestorage.py
@@ -107,7 +107,7 @@ class Command(BaseCommand):
                 )
 
             if advanced_filter:
-                if not updated_until and not only_community:
+                if not updated_until and not only_community and not not_yet_packaged:
                     logger.error(
                         "--advanced-filter set but mandatory options missing, aborting."
                     )


### PR DESCRIPTION
This PR intends to add a CLI filter to the `migratefilestorage` Django command, for also considering the filestorage migration of projects having a _NULL_ `data_last_packaged_at` value.

Usage :

```sh
docker compose run --rm app python manage.py migratefilestorage --all \
  --advanced-filter --not-yet-packaged [--only-community] [--no-raise]
````

Note that `--not-yet-packaged` can **not** be used together with `--updated-until YYYY-MM-DD`.