### PR TITLE
Make it flexible when showing person's subscriptions directly from the Person admin

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -589,8 +589,10 @@ class PersonAdmin(QFieldCloudModelAdmin):
         # Add the subscription model is editable flag to the extra context
         extra_context = extra_context or {}
 
-        extra_context["is_frontend_user_editable"] = (
-            get_subscription_model().is_frontend_user_editable
+        extra_context.update(
+            {
+                "subscription_model": get_subscription_model(),
+            }
         )
 
         return super().change_view(

--- a/docker-app/qfieldcloud/core/templates/admin/person_change_form.html
+++ b/docker-app/qfieldcloud/core/templates/admin/person_change_form.html
@@ -13,11 +13,9 @@
     |
     <a href="{% url 'admin:core_organization_changelist' %}?q=owner:{{original.username}}">{% trans 'Owned organizations' %}</a>
     |
-    {% if is_frontend_user_editable %}
-      <a href="{% url 'admin:billing_billingsubscription_changelist' %}?q={{ original.username }}">{% trans 'Billing' %}</a>
-    {% else %}
-      <a href="{% url 'admin:subscription_subscription_changelist' %}?q={{ original.username }}">{% trans 'Subscription' %}</a>
-    {% endif %}
+    {% with subscription_model.get_admin_url_prefix|add:"_changelist" as admin_view_name %}
+      <a href="{% url admin_view_name %}?q={{ original.username }}">{% trans 'Subscriptions' %}</a>
+    {% endwith %}
     |
     <a href="{% url 'admin:core_organization_changelist' %}?q=member:{{original.username}}">{% trans 'Organization memberships' %}</a>
     |

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -942,6 +942,9 @@ class AbstractSubscription(models.Model):
         self.clean()
         super().save(*args, **kwargs)
 
+    def get_admin_url_prefix(self) -> str:
+        return f"admin:{self._meta.app_label}_{self._meta.model_name}"
+
     def __str__(self):
         active_storage_total_mb = (
             self.active_storage_package_mb if hasattr(self, "packages") else 0


### PR DESCRIPTION
Pretty much the title, no matter what is the current configuration of `SUBSCRIPTION_MODEL` you always land on the correct page.