### PR TITLE
Revert "chore: bump `boto3` related dependencies from `1.35.X` to `1.42.3`"

### DIFF
--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -1,5 +1,5 @@
-boto3-stubs==1.42.3
-boto3==1.42.3
+boto3-stubs==1.35.90
+boto3==1.35.90
 deprecated==1.3.1
 django-allauth[socialaccount]==65.13.1
 django-auditlog==3.4.0
@@ -36,7 +36,7 @@ djangorestframework==3.16.1
 djangorestframework-stubs==3.16.4
 drf-spectacular==0.29.0
 json-log-formatter==1.1.1
-mypy-boto3-s3==1.42.3
+mypy-boto3-s3==1.35.81
 phonenumbers==9.0.15
 Pillow==11.3.0
 psycopg2==2.9.11

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -16,11 +16,11 @@ attrs==25.3.0
     #   referencing
 beautifulsoup4==4.13.5
     # via django-bootstrap4
-boto3==1.42.3
+boto3==1.35.90
     # via -r /requirements/requirements.in
-boto3-stubs==1.42.3
+boto3-stubs==1.35.90
     # via -r /requirements/requirements.in
-botocore==1.42.5
+botocore==1.35.99
     # via
     #   boto3
     #   s3transfer
@@ -159,7 +159,7 @@ jsonschema==4.25.1
     # via drf-spectacular
 jsonschema-specifications==2025.4.1
     # via jsonschema
-mypy-boto3-s3==1.42.3
+mypy-boto3-s3==1.35.81
     # via -r /requirements/requirements.in
 oauthlib==3.3.1
     # via django-allauth
@@ -196,7 +196,7 @@ rpds-py==0.27.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.16.0
+s3transfer==0.10.4
     # via boto3
 sentry-sdk==2.47.0
     # via -r /requirements/requirements.in


### PR DESCRIPTION
This reverts a previous dependency bump commit : ca15c8b3e129b00c6ad6279f43f47498d40256a1.

Reason is that some S3 providers are not compatible yet with boto >= 1.37.0.