### PR TITLE
Expose the file_storage_bytes attribute in the /api/v1/projects serializer

### DIFF
--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -174,6 +174,7 @@ class ProjectSerializer(serializers.ModelSerializer):
             "is_shared_datasets_project",
             "is_featured",
             "is_attachment_download_on_demand",
+            "file_storage_bytes",
         )
         read_only_fields = (
             "private",
@@ -188,6 +189,7 @@ class ProjectSerializer(serializers.ModelSerializer):
             "user_role",
             "user_role_origin",
             "is_attachment_download_on_demand",
+            "file_storage_bytes",
         )
         model = Project
 


### PR DESCRIPTION
@Rakanhf , as discussed during your flash presentation.

This will be super useful both for QField and QFieldSync.

<img width="1226" height="628" alt="image" src="https://github.com/user-attachments/assets/a82e9eef-6fc3-4dea-b0c9-e9be5c162435" />
