### PR TITLE
feat: add simple object storage cleaner script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,6 +127,17 @@ jobs:
         run: |
           docker compose run app python manage.py test --keepdb -v2 --tag="flaky" qfieldcloud
 
+      - name: Run Object Storage Cleaner tests
+        if: matrix.django_app == 'filestorage' && matrix.storage == 'default'
+        run: |
+          docker compose run --rm \
+            -e AWS_ACCESS_KEY_ID=minioadmin \
+            -e AWS_SECRET_ACCESS_KEY=minioadmin \
+            -e AWS_ENDPOINT_URL=http://172.17.0.1:8009 \
+            -e AWS_DEFAULT_REGION=us-east-1 \
+            -v ${{ github.workspace }}/scripts:/usr/src/scripts \
+            app python /usr/src/scripts/object_storage_cleaner/test.py
+
       - name: "failure logs"
         if: failure()
         run: |

--- a/scripts/object_storage_cleaner/README.MD
+++ b/scripts/object_storage_cleaner/README.MD
@@ -1,0 +1,119 @@
+# Object Storage Cleaner
+
+A utility script to identify and clean "logically deleted" objects in S3-compatible object storage (e.g., AWS S3, MinIO) when bucket versioning is enabled.
+
+## The Problem
+
+When **Versioning** is enabled on an S3 bucket, deleting an object does not actually remove the data. Instead, S3 creates a **Delete Marker** as the latest version. The older versions (the actual data) remain in the bucket and continue to incur storage costs.
+
+A "logically deleted object" is an object where the current (latest) version is a Delete Marker. This means the object appears deleted to applications, but all its historical versions are still stored.
+
+This script helps you:
+1.  **Scan**: Find all objects that are logically deleted and calculate how much space they are wasting.
+2.  **Permanently Delete Versions**: Permanently delete all versions of these objects (including the delete marker) to free up storage.
+
+> **Note**: This script specifically targets objects that are *currently deleted*. It does **not** touch objects that are still active (i.e., the latest version is a file, not a delete marker), even if they have old versions.
+
+## Requirements
+
+- Python 3.8+
+- `boto3` library
+
+1. Create a virtual environment
+
+2. Install dependencies:
+
+```bash
+pip install boto3
+
+# Optional
+pip install mypy-boto3-s3 # for type hinting
+```
+
+## Usage
+
+Run the script directly from the command line.
+
+### Basic Syntax
+
+```bash
+python purge_deleted_objects.py <bucket_name> --retention-period "30 days" [options]
+```
+
+### Options
+
+Run the script with `--help` to see all available options.
+
+---
+By default the script uses the `default` S3 profile (default `boto3` behavior)
+check [Configuration and credential file settings in the AWS CLI](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html)
+
+### Examples
+
+**1. Scan a bucket to see how much space can be freed:**
+
+```bash
+python purge_deleted_objects.py my-production-bucket --retention-period "30 days" --dry-run
+```
+
+**2. Scan a specific folder:**
+
+```bash
+python purge_deleted_objects.py my-production-bucket --retention-period "30 days" --dry-run --prefix "logs/2023/"
+```
+
+**3. Cleanup objects deleted more than 30 days ago (Retention Policy):**
+
+- `--retention-period '30 days'`: Only selects objects that were deleted **more than 30 days ago**. Objects deleted recently (within the last 30 days) are preserved to allow for restoration.
+
+```bash
+# Clean objects deleted OLDER than 30 days
+python purge_deleted_objects.py my-bucket --retention-period '30 days'
+```
+
+**4. Permanently delete objects:**
+
+```bash
+python purge_deleted_objects.py my-bucket --retention-period "30 days"
+# You will be prompted to confirm.
+```
+
+**5. Automated cleanup for MinIO (local/custom endpoint):**
+
+```bash
+python purge_deleted_objects.py test-bucket --retention-period "30 days" --force
+```
+
+## Running Tests
+
+The repository includes a test suite (`test.py`) that uses `unittest` and requires a running S3-compatible service (like MinIO).
+
+### Test Requirements
+- `boto3`
+- S3 service (e.g., MinIO) running.
+
+### Steps to Run Tests
+
+1.  **Start MinIO** (or ensure a mock S3 is running).
+    Example using Docker:
+    ```bash
+    docker run -d -p 8009:9000 --name minio-test \
+      -e "MINIO_ACCESS_KEY=access_key_xyz" \
+      -e "MINIO_SECRET_KEY=secret_key_xyz" \
+      minio/minio server /data
+    ```
+
+2.  **Configure Environment Variables**
+    Export the following variables to configure `boto3` to talk to your local MinIO instance (matching the credentials above):
+
+    ```bash
+    export AWS_ACCESS_KEY_ID=access_key_xyz
+    export AWS_SECRET_ACCESS_KEY=secret_key_xyz
+    export AWS_ENDPOINT_URL=http://localhost:8009
+    export AWS_DEFAULT_REGION=us-east-1
+    ```
+
+3.  **Run Tests**
+    ```bash
+    python test.py
+    ```

--- a/scripts/object_storage_cleaner/purge_deleted_objects.py
+++ b/scripts/object_storage_cleaner/purge_deleted_objects.py
@@ -1,0 +1,519 @@
+"""
+Object Storage Logically Deleted Object Cleaner
+
+This script scans an object storage bucket for "logically deleted" objects (objects where the
+latest version is a Delete Marker) and optionally permanently deletes all versions
+of those objects to reclaim storage space.
+
+Usage:
+    python purge_deleted_objects.py <bucket> --retention-period "30 days" [options]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import signal
+import sys
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any, Literal
+
+import boto3
+from botocore.client import BaseClient
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+# AWS S3 limit for delete objects batch up to 1000 keys (https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/delete_objects.html)
+DELETE_BATCH_SIZE = 1000
+
+# AWS S3 limit for list object versions max keys up to 1000 (https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/list_object_versions.html)
+LIST_OBJECT_VERSIONS_MAX_KEYS = 1000
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3.type_defs import (
+        DeleteObjectsOutputTypeDef,
+        ListObjectVersionsOutputTypeDef,
+        ObjectVersionTypeDef,
+    )
+
+    class QfcObjectVersionTypeDef(ObjectVersionTypeDef):
+        IsDeleteMarker: Literal[False]
+
+    class QfcDeleteMarkerEntryTypeDef(ObjectVersionTypeDef):
+        IsDeleteMarker: Literal[True]
+
+    ObjectVersionOrDeleteMarker = QfcObjectVersionTypeDef | QfcDeleteMarkerEntryTypeDef
+
+
+@dataclass
+class LogicallyDeletedObject:
+    key: str
+    deleted_at: datetime
+    total_size_bytes: int
+    versions_count: int
+    versions: list[dict[str, Any]]
+
+
+def format_bytes(num_bytes: int) -> str:
+    """Convert a byte count to a human-readable string."""
+    units = ["B", "KB", "MB", "GB", "TB", "PB"]
+
+    if num_bytes == 0:
+        return "0 B"
+
+    size = float(num_bytes)
+    for unit in units:
+        if size < 1024.0 or unit == units[-1]:
+            return f"{size:.2f} {unit}"
+
+        size /= 1024.0
+
+    return f"{size:.2f} PB"
+
+
+def iter_all_versions(
+    s3_client: BaseClient, bucket: str, prefix: str | None = None
+) -> Iterator[ObjectVersionOrDeleteMarker]:
+    """
+    Iterate over all object versions and delete markers from object storage, paginated.
+
+    Object storage's `list_object_versions` returns `Versions` and `DeleteMarkers` as separate
+    lists within each page. This function merges and sorts them by Key locally
+    to ensure that all history (versions + markers) for a specific Key is yielded
+    contiguously before the iterator moves to the next Key.
+
+    Args:
+        s3_client: The configured boto3 object storage client.
+        bucket: The bucket name.
+        prefix: Optional key prefix to limit the scan.
+
+    Yields:
+        ObjectVersionOrDeleteMarker: A dictionary representing either a Version or a Delete Marker.
+    """
+    paginator = s3_client.get_paginator("list_object_versions")
+    paginate_kwargs = {
+        "Bucket": bucket,
+        "MaxKeys": LIST_OBJECT_VERSIONS_MAX_KEYS,
+    }
+    if prefix:
+        paginate_kwargs["Prefix"] = prefix
+
+    for page in paginator.paginate(**paginate_kwargs):
+        # Type from mypy_boto3_s3.type_defs
+        page: ListObjectVersionsOutputTypeDef
+        versions: list[ObjectVersionOrDeleteMarker] = []
+
+        # Yield Versions
+        for version in page.get("Versions", []):
+            version: QfcObjectVersionTypeDef
+            version["IsDeleteMarker"] = False
+            versions.append(version)
+
+        # Yield Delete Markers
+        for delete_marker in page.get("DeleteMarkers", []):
+            delete_marker: QfcDeleteMarkerEntryTypeDef
+            delete_marker["IsDeleteMarker"] = True
+            versions.append(delete_marker)
+
+        # Sort by Key to keep versions of the same object together
+        versions.sort(key=lambda v: (v["Key"], v["LastModified"]), reverse=True)
+
+        yield from versions
+
+
+def analyze_key_history(
+    key: str,
+    versions: list[ObjectVersionOrDeleteMarker],
+    retention_cutoff_ts: datetime | None,
+) -> LogicallyDeletedObject | None:
+    """
+    Analyze a list of versions for a single key to see if it's logically deleted
+    and return a LogicallyDeletedObject if it is, otherwise None.
+
+    Args:
+        key: The key of the object.
+        versions: The list of versions.
+        retention_cutoff_ts: Optional cutoff timestamp. If provided, the object is only returned if it was deleted *before* this timestamp. Recent deletions are ignored.
+
+    Returns:
+        A LogicallyDeletedObject if the key is logically deleted, None otherwise.
+    """
+    if not versions:
+        return None
+
+    latest_version = versions[0]
+
+    # Criteria: Latest version must be a delete marker
+    if not latest_version["IsDeleteMarker"]:
+        return None
+
+    # Filter by time
+    # If the delete marker is NEWER than the retention cutoff, skip it (retain it)
+    if retention_cutoff_ts and latest_version["LastModified"] > retention_cutoff_ts:
+        return None
+
+    # Calculate stats efficiently
+    # Note: latest is size 0 (delete marker), so we can just sum all
+    total_size = 0
+
+    for v in versions:
+        if v["IsDeleteMarker"]:
+            # Delete markers have no size
+            continue
+        # Versions have a size
+        total_size += v["Size"]
+
+    return LogicallyDeletedObject(
+        key=key,
+        deleted_at=latest_version["LastModified"],
+        total_size_bytes=total_size,
+        versions_count=len(versions),
+        versions=versions,
+    )
+
+
+def delete_versions_batch(
+    s3_client: BaseClient, bucket: str, versions: list[ObjectVersionOrDeleteMarker]
+) -> None:
+    """
+    Delete a batch of versions, up to 1000 versions per batch.
+
+    Args:
+        s3_client: The configured S3 client.
+        bucket: The bucket name.
+        versions: The list of versions to delete.
+    """
+    if not versions:
+        return
+
+    assert len(versions) <= DELETE_BATCH_SIZE
+
+    # Transform to boto3 format
+    objects: list[ObjectVersionOrDeleteMarker] = []
+    for v in versions:
+        objects.append(
+            {
+                "Key": v["Key"],
+                "VersionId": v["VersionId"],
+            }
+        )
+
+    try:
+        # Quiet=False returns success details and errors for logging
+        response: DeleteObjectsOutputTypeDef = s3_client.delete_objects(
+            Bucket=bucket,
+            Delete={
+                "Objects": objects,
+                "Quiet": False,
+            },
+        )
+
+        # Log successes
+        for success in response.get("Deleted", []):
+            logger.info(
+                f"Permanently deleted: {success['Key']} (VersionId: {success.get('VersionId')})"
+            )
+
+        # Log errors
+        for error in response.get("Errors", []):
+            logger.error(
+                f"Failed to delete: {error['Key']} (VersionId: {error.get('VersionId')}) | "
+                f"Code: {error.get('Code')} | Message: {error.get('Message')}"
+            )
+
+    except ClientError as err:
+        logger.error(f"Failed to delete versions batch: {err}")
+
+
+def iter_logically_deleted(
+    version_iterator: Iterator[ObjectVersionOrDeleteMarker],
+    retention_cutoff_ts: datetime | None = None,
+) -> Iterator[LogicallyDeletedObject]:
+    """
+    Consumes an iterator of all object versions and yields ONLY the objects that are logically deleted.
+
+    This function relies on the input iterator being pre-sorted by `key`. It groups all versions
+    belonging to the same key into a list, and then passes that complete history to
+    `analyze_key_history` to determine if the object is currently in a deleted state.
+
+    Args:
+        version_iterator: An iterator of version dictionaries, MUST be sorted by `key`.
+        retention_cutoff_ts: Optional cutoff timestamp. If provided, the object is only returned if it was deleted *before* this timestamp. Recent deletions are ignored.
+
+    Yields:
+        LogicallyDeletedObject: A summary object for every key that is currently deleted.
+    """
+    # We maintain a buffer of versions for the "current" key we are processing.
+    # Since the input iterator is sorted, all versions for "Key A" will arrive sequentially
+    # before any version for "Key B" appears, so we can group them together.
+    current_key: str | None = None
+    current_versions: list[ObjectVersionOrDeleteMarker] = []
+
+    for version in version_iterator:
+        # Case 1: First item in the entire iterator
+        if current_key is None:
+            current_key = version["Key"]
+            current_versions.append(version)
+            continue
+
+        # Case 2: Same key as before -> Add to buffer
+        if version["Key"] == current_key:
+            current_versions.append(version)
+
+        # Case 3: New key detected -> Process the previous buffer
+        else:
+            # We have collected all versions for 'current_key'. Now analyze it.
+            result = analyze_key_history(
+                current_key, current_versions, retention_cutoff_ts
+            )
+            if result:
+                yield result
+
+            # Reset buffer for the new key
+            current_key = version["Key"]
+            current_versions = [version]
+
+    # Case 4: End of iterator -> Process the final buffer remaining in memory
+    if current_key and current_versions:
+        result = analyze_key_history(current_key, current_versions, retention_cutoff_ts)
+        if result:
+            yield result
+
+
+def action_scan(objects_iterator: Iterable[LogicallyDeletedObject]) -> None:
+    """
+    Consume an iterator of logically deleted objects and log the details.
+
+    Args:
+        objects_iterator: The iterator of logically deleted objects.
+    """
+    logger.info("Scanning for logically deleted objects...")
+
+    # Counters for summary logging
+    key_count = 0
+    total_size_bytes = 0
+    total_versions_count = 0
+
+    for obj in objects_iterator:
+        # Update counters
+        key_count += 1
+        total_size_bytes += obj.total_size_bytes
+        total_versions_count += obj.versions_count
+
+        # Log details for each key
+        logger.info(
+            f"Found: {obj.key} | Deleted At: {obj.deleted_at} | "
+            f"Wasted Size: {format_bytes(obj.total_size_bytes)} | {obj.versions_count} versions"
+        )
+
+    # Log summary
+    logger.info(f"Total deleted keys found: {key_count}")
+    logger.info(f"Total size wasted: {format_bytes(total_size_bytes)}")
+    logger.info(f"Total versions wasted: {total_versions_count}")
+
+
+def action_permanently_delete_versions(
+    s3_client: BaseClient,
+    bucket: str,
+    objects_iterator: Iterable[LogicallyDeletedObject],
+) -> None:
+    """
+    Consume an iterator of logically deleted objects and delete the versions in batches.
+
+    Args:
+        s3_client: The configured S3 client.
+        bucket: The bucket name.
+        objects_iterator: The iterator of logically deleted objects.
+    """
+    batch: list[ObjectVersionOrDeleteMarker] = []
+
+    for obj in objects_iterator:
+        for version in obj.versions:
+            batch.append(version)
+
+            # Flush batch if full
+            if len(batch) == DELETE_BATCH_SIZE:
+                delete_versions_batch(s3_client, bucket, batch)
+                batch.clear()
+
+    # Flush remaining
+    if batch:
+        delete_versions_batch(s3_client, bucket, batch)
+
+
+def get_s3_client(bucket: str, profile: str | None) -> BaseClient:
+    """
+    Create an object storage client and validate that the bucket has versioning enabled.
+
+    Args:
+        bucket: The name of the object storage bucket.
+        profile: Optional AWS profile name.
+
+    Returns:
+        A configured boto3 object storage client.
+    """
+
+    session_kwargs = {}
+    if profile:
+        session_kwargs["profile_name"] = profile
+
+    client = boto3.Session(**session_kwargs).client("s3")
+
+    # Validate bucket versioning is enabled
+    try:
+        response = client.get_bucket_versioning(Bucket=bucket)
+        status = response.get("Status")
+        if status != "Enabled":
+            raise RuntimeError(
+                f"Bucket '{bucket}' versioning is not Enabled (Status: {status})."
+            )
+    except ClientError as err:
+        raise RuntimeError(
+            f"Could not check versioning status for '{bucket}': {err}"
+        ) from err
+
+    return client
+
+
+def parse_retention_period(value: str) -> datetime:
+    """
+    Parse a duration string (e.g., '3 seconds', '30 days', '2 weeks') and return a datetime object.
+
+    Args:
+        value: The duration string to parse. Supports `seconds`, `minutes`, `hours`, `days`, and `weeks`.
+
+    Returns:
+        A UTC datetime equal to now minus the parsed duration.
+    """
+    # Handle None and non-string inputs
+    if value is None:
+        raise argparse.ArgumentTypeError("Duration cannot be None")
+
+    if not isinstance(value, str):
+        raise argparse.ArgumentTypeError(
+            f"Duration must be a string, got {type(value).__name__}"
+        )
+
+    value = value.strip().lower()
+
+    # Handle empty string after stripping
+    if not value:
+        raise argparse.ArgumentTypeError("Duration cannot be empty")
+
+    pattern = (
+        r"^(\d+)\s*(second|seconds|minute|minutes|hour|hours|day|days|week|weeks)$"
+    )
+    match = re.match(pattern, value)
+    if not match:
+        raise argparse.ArgumentTypeError(
+            "Invalid duration. Use: '3 seconds', '10 hours', '15 minutes', '30 days', '2 weeks'"
+        )
+
+    amount = int(match.group(1))
+    unit = match.group(2)
+
+    try:
+        if unit in ("second", "seconds"):
+            delta = timedelta(seconds=amount)
+        elif unit in ("minute", "minutes"):
+            delta = timedelta(minutes=amount)
+        elif unit in ("hour", "hours"):
+            delta = timedelta(hours=amount)
+        elif unit in ("day", "days"):
+            delta = timedelta(days=amount)
+        elif unit in ("week", "weeks"):
+            delta = timedelta(weeks=amount)
+        else:
+            raise argparse.ArgumentTypeError(f"Unsupported time unit: {unit}")
+    except OverflowError:
+        raise argparse.ArgumentTypeError("Duration is too large")
+
+    return datetime.now(timezone.utc) - delta
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Scan and clean logically deleted objects in object storage like S3."
+    )
+    parser.add_argument("bucket", help="Target Object Storage bucket")
+    parser.add_argument("--prefix", help="Filter by prefix")
+    parser.add_argument("--profile", help="Optional AWS Profile")
+    parser.add_argument(
+        "--retention-period",
+        type=parse_retention_period,
+        dest="retention_cutoff_ts",
+        required=True,
+        help="Only process objects deleted BEFORE this time interval (e.g. '30 days'). Recent deletions are preserved.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Scan for logically deleted objects without deleting them",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Skip permanently delete confirmation prompt",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Log level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=args.log_level,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        stream=sys.stdout,
+    )
+
+    try:
+        # 1. Setup Connection
+        client = get_s3_client(args.bucket, args.profile)
+
+        # 2. Build Pipeline
+        raw_iterator = iter_all_versions(client, args.bucket, args.prefix)
+
+        # Transform
+        clean_iterator = iter_logically_deleted(raw_iterator, args.retention_cutoff_ts)
+
+        # 3. Execute
+        if args.dry_run:
+            action_scan(clean_iterator)
+            return 0
+
+        else:
+            if not args.force:
+                confirmation_input = input(
+                    f"Permanently delete from '{args.bucket}'? (yes/no): "
+                ).lower()
+
+                if confirmation_input != "yes":
+                    return 0
+
+            action_permanently_delete_versions(client, args.bucket, clean_iterator)
+
+    except Exception as e:
+        logger.error(f"Error: {e}")
+
+        raise e
+
+    return 0
+
+
+def handle_sigint(sig: int, frame: object) -> None:
+    logger.info("\n\nScan interrupted by user.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGINT, handle_sigint)
+    raise SystemExit(main())

--- a/scripts/object_storage_cleaner/test.py
+++ b/scripts/object_storage_cleaner/test.py
@@ -1,0 +1,748 @@
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+import unittest
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+import boto3
+from purge_deleted_objects import parse_retention_period
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3.type_defs import (
+        DeleteMarkerEntryTypeDef,
+        ListObjectVersionsOutputTypeDef,
+        ObjectVersionTypeDef,
+    )
+
+
+class TestObjectStorageCleaner(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Creates a boto3 s3 client and ensures bucket exists."""
+        cls.s3_client = boto3.client("s3")
+        cls.bucket_name = f"test-bucket-{uuid.uuid4()}"
+        try:
+            cls.s3_client.create_bucket(Bucket=cls.bucket_name)
+        except cls.s3_client.exceptions.BucketAlreadyOwnedByYou:
+            pass
+        except cls.s3_client.exceptions.BucketAlreadyExists:
+            pass
+
+        # Enable versioning
+        cls.s3_client.put_bucket_versioning(
+            Bucket=cls.bucket_name, VersioningConfiguration={"Status": "Enabled"}
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        """Cleans up by emptying and deleting the test bucket."""
+        try:
+            # Empty the bucket (both versions and delete markers)
+            paginator = cls.s3_client.get_paginator("list_object_versions")
+            for page in paginator.paginate(Bucket=cls.bucket_name):
+                versions = page.get("Versions", []) + page.get("DeleteMarkers", [])
+                if versions:
+                    objects_to_delete = []
+                    for v in versions:
+                        objects_to_delete.append(
+                            {"Key": v["Key"], "VersionId": v["VersionId"]}
+                        )
+
+                    # Delete in batches of 1000 (S3 limit)
+                    for i in range(0, len(objects_to_delete), 1000):
+                        cls.s3_client.delete_objects(
+                            Bucket=cls.bucket_name,
+                            Delete={"Objects": objects_to_delete[i : i + 1000]},
+                        )
+
+            # Delete the bucket itself
+            cls.s3_client.delete_bucket(Bucket=cls.bucket_name)
+        except Exception as e:
+            raise Exception(f"Error cleaning up bucket {cls.bucket_name}: {e}") from e
+
+    def setUp(self):
+        """Generates a unique prefix for test isolation."""
+        self.unique_prefix = f"test-run-{uuid.uuid4()}/"
+
+    def run_script(self, args):
+        """Runs the purge_deleted_objects.py script as a subprocess."""
+        # Assume script is in the same directory as this test file
+        script_path = os.path.join(
+            os.path.dirname(__file__), "purge_deleted_objects.py"
+        )
+        cmd = [sys.executable, script_path, self.bucket_name] + args
+
+        result = subprocess.run(cmd, capture_output=True, text=True)
+
+        self.assertEqual(result.returncode, 0)
+
+        return result
+
+    def create_file(self, key: str, content: str = "test content") -> None:
+        # Get number of versions before creating the file
+        number_of_versions = len(self.list_versions(key))
+
+        # Create the file
+        self.s3_client.put_object(Bucket=self.bucket_name, Key=key, Body=content)
+
+        # Check that the number of versions has increased by 1
+        self.assertEqual(len(self.list_versions(key)), number_of_versions + 1)
+
+        # Check that the object exists
+        self.assertIsNotNone(
+            self.s3_client.head_object(Bucket=self.bucket_name, Key=key)
+        )
+
+        # Check content
+        file = (
+            self.s3_client.get_object(Bucket=self.bucket_name, Key=key)
+            .get("Body")
+            .read()
+            .decode("utf-8")
+        )
+        self.assertEqual(file, content)
+
+    def delete_file(self, key: str) -> None:
+        # Get number of versions before deleting the file
+        number_of_versions = len(self.list_versions(key))
+
+        # Delete the file
+        self.s3_client.delete_object(Bucket=self.bucket_name, Key=key)
+
+        # Check that the number of versions has increased by 1 (a delete marker is created)
+        self.assertEqual(len(self.list_versions(key)), number_of_versions + 1)
+
+        # Check that the object does not exist
+        with self.assertRaises(self.s3_client.exceptions.ClientError):
+            self.s3_client.get_object(Bucket=self.bucket_name, Key=key)
+
+    def list_versions(
+        self, prefix: str | None = None
+    ) -> list[DeleteMarkerEntryTypeDef | ObjectVersionTypeDef]:
+        versions: ListObjectVersionsOutputTypeDef = self.s3_client.list_object_versions(
+            Bucket=self.bucket_name, Prefix=prefix
+        )
+        all_versions = versions.get("Versions", []) + versions.get("DeleteMarkers", [])
+        return all_versions
+
+    def test_no_logically_deleted_files(self):
+        """
+        test that no logically deleted objects are found if there are no deleted files.
+        """
+        # 1. Upload a file
+        key = f"{self.unique_prefix}file1.txt"
+        self.create_file(key)
+
+        time.sleep(1)
+
+        # 2. Run scan
+        result = self.run_script(
+            [
+                "--dry-run",
+                "--prefix",
+                self.unique_prefix,
+                "--retention-period",
+                "1 second",
+            ]
+        )
+
+        # 3. Verify output
+        self.assertIn("Total deleted keys found: 0", result.stdout)
+        self.assertIn("Total size wasted: 0 B", result.stdout)
+        self.assertIn("Total versions wasted: 0", result.stdout)
+
+        # 4. Run without dry-run
+        self.run_script(
+            [
+                "--force",
+                "--prefix",
+                self.unique_prefix,
+                "--retention-period",
+                "1 second",
+            ]
+        )
+
+        # 5. Verify file is still there
+        versions = self.list_versions(self.unique_prefix)
+        self.assertEqual(len(versions), 1)
+
+    def test_restored_files_ignored(self):
+        """
+        test that a file is not found if it is restored after being deleted.
+        """
+        # 1. Upload file (v1)
+        key = f"{self.unique_prefix}file_restored.txt"
+        self.create_file(key, "v1")
+
+        # 2. Delete file (v2 - delete marker)
+        self.delete_file(key)
+
+        # 3. Restore file (v3 - new version)
+        self.create_file(key, "v3")
+
+        time.sleep(1)
+
+        # 4. Run scan
+        result = self.run_script(
+            [
+                "--dry-run",
+                "--prefix",
+                self.unique_prefix,
+                "--retention-period",
+                "1 second",
+            ]
+        )
+
+        # 5. Verify output - should not find it
+        self.assertIn("Total deleted keys found: 0", result.stdout)
+        self.assertIn("Total size wasted: 0 B", result.stdout)
+        self.assertIn("Total versions wasted: 0", result.stdout)
+
+        # 6. Run without dry-run
+        self.run_script(
+            [
+                "--force",
+                "--prefix",
+                self.unique_prefix,
+                "--retention-period",
+                "1 second",
+            ]
+        )
+
+        # 7. Verify that no versions are deleted
+        versions = self.list_versions(self.unique_prefix)
+        self.assertEqual(len(versions), 3)
+
+    def test_retention_period_filter(self):
+        """
+        Test that a file is NOT found if the retention period covers it (recent deletion).
+        And that a file IS found if the retention period has passed (old deletion).
+        """
+        key = f"{self.unique_prefix}file_date_test.txt"
+        self.create_file(key, "a" * 100)  # 100 bytes of content
+        self.delete_file(key)
+
+        # Wait 2 seconds to ensure clock skew isn't an issue if running locally fast
+        # This is to ensure the file is deleted before the scan is run
+        time.sleep(2)
+
+        # Retention period is SHORT (1 second).
+        # The file was deleted 2 seconds ago. 2s > 1s.
+        # So the file is OLDER than the retention period. It should be FOUND (not protected).
+        result_short_retention = self.run_script(
+            [
+                "--dry-run",
+                "--prefix",
+                self.unique_prefix,
+                "--retention-period",
+                "1 second",
+            ]
+        )
+
+        self.assertIn("Total deleted keys found: 1", result_short_retention.stdout)
+        self.assertIn("Total size wasted: 100.00 B", result_short_retention.stdout)
+        self.assertIn("Total versions wasted: 2", result_short_retention.stdout)
+
+        # Retention period is LONG (5 seconds).
+        # The file was deleted 2 seconds ago. 2s < 5s.
+        # So the file is NEWER than the retention period. It should be PROTECTED (skipped).
+        result_long_retention = self.run_script(
+            [
+                "--dry-run",
+                "--prefix",
+                self.unique_prefix,
+                "--retention-period",
+                "5 seconds",
+            ]
+        )
+
+        self.assertIn("Total deleted keys found: 0", result_long_retention.stdout)
+        self.assertIn("Total size wasted: 0 B", result_long_retention.stdout)
+        self.assertIn("Total versions wasted: 0", result_long_retention.stdout)
+
+        # Run without dry-run
+        result_long_retention = self.run_script(
+            [
+                "--force",
+                "--prefix",
+                self.unique_prefix,
+                "--retention-period",
+                "5 second",
+            ]
+        )
+
+        # Verify file is still there (long retention period should keep the file)
+        versions = self.list_versions(self.unique_prefix)
+        self.assertEqual(len(versions), 2)
+
+        # Run without dry-run (short retention period should delete the file)
+        result_short_retention = self.run_script(
+            [
+                "--force",
+                "--prefix",
+                self.unique_prefix,
+                "--retention-period",
+                "1 second",
+            ]
+        )
+
+        # Verify file is completely gone (no versions left)
+        versions = self.list_versions(self.unique_prefix)
+        self.assertEqual(len(versions), 0)
+
+    def test_stray_delete_marker(self):
+        """
+        test that a key exists only as a Delete Marker is identified and deleted.
+        """
+        key = f"{self.unique_prefix}stray_marker"
+
+        # 1. Create a file
+        self.create_file(key, "a" * 100)  # 100 bytes of content
+
+        # 2. Delete it (creates marker)
+        self.delete_file(key)
+
+        # 3. Manually delete the data version, leaving ONLY the marker
+        versions = self.list_versions(key)
+
+        # Find the data version
+        data_version = None
+        for v in versions:
+            if not v.get("IsDeleteMarker", False):
+                data_version = v
+                break
+
+        # Delete the data version
+        if data_version:
+            self.s3_client.delete_object(
+                Bucket=self.bucket_name, Key=key, VersionId=data_version["VersionId"]
+            )
+
+        time.sleep(1)
+
+        # 4. Run Scan
+        # The script should identify the stray marker and delete it
+        result = self.run_script(
+            [
+                "--dry-run",
+                "--prefix",
+                self.unique_prefix,
+                "--retention-period",
+                "1 second",
+            ]
+        )
+
+        self.assertIn("Total deleted keys found: 1", result.stdout)
+        # 0 bytes because it's a delete marker
+        self.assertIn("Total size wasted: 0 B", result.stdout)
+        self.assertIn("Total versions wasted: 1", result.stdout)
+
+        # 5. Run without dry-run
+        self.run_script(
+            [
+                "--force",
+                "--prefix",
+                self.unique_prefix,
+                "--retention-period",
+                "1 second",
+            ]
+        )
+
+        # 6. Verify file is completely gone (no versions left)
+        versions = self.list_versions(self.unique_prefix)
+        self.assertEqual(len(versions), 0)
+
+    def test_permanently_deleted(self):
+        """
+        test that a file is found if it is deleted and then permanently deleted.
+        """
+        # 1. Upload file
+        key = f"{self.unique_prefix}file_deleted.txt"
+        self.create_file(key, "a" * 100)
+
+        # 2. Delete file (creates delete marker)
+        self.delete_file(key)
+
+        time.sleep(1)
+
+        # 3. Run with dry-run
+        result = self.run_script(
+            [
+                "--dry-run",
+                "--prefix",
+                self.unique_prefix,
+                "--retention-period",
+                "1 second",
+            ]
+        )
+        self.assertIn("Total deleted keys found: 1", result.stdout)
+        self.assertIn("Total size wasted: 100.00 B", result.stdout)
+        self.assertIn("Total versions wasted: 2", result.stdout)
+
+        # 4. Run without dry-run
+        self.run_script(
+            [
+                "--force",
+                "--prefix",
+                self.unique_prefix,
+                "--retention-period",
+                "1 second",
+            ]
+        )
+
+        # 5. Verify file is completely gone (no versions left)
+        versions = self.list_versions(self.unique_prefix)
+        self.assertEqual(len(versions), 0)
+
+    def test_permanently_delete_complex_version_history(self):
+        """
+        test that all versions (history) are permanently deleted when the key is deleted.
+        """
+        key = f"{self.unique_prefix}complex_history.txt"
+
+        # 1. v1: Create
+        self.create_file(key, "a" * 100)
+        # 2. v2: Delete
+        self.delete_file(key)
+        # 3. v3: Re-create
+        self.create_file(key, "a" * 100)
+        # 4. v4: Delete again (Final state is deleted)
+        self.delete_file(key)
+
+        time.sleep(1)
+
+        # 5. Run with dry-run
+        result = self.run_script(
+            [
+                "--dry-run",
+                "--prefix",
+                self.unique_prefix,
+                "--retention-period",
+                "1 second",
+            ]
+        )
+        self.assertIn("Total deleted keys found: 1", result.stdout)
+        self.assertIn("Total size wasted: 200.00 B", result.stdout)
+        self.assertIn("Total versions wasted: 4", result.stdout)
+
+        # 6. Run without dry-run
+        self.run_script(
+            [
+                "--force",
+                "--prefix",
+                self.unique_prefix,
+                "--retention-period",
+                "1 second",
+            ]
+        )
+
+        # 7. Verify file is completely gone (no versions left)
+        versions = self.list_versions(self.unique_prefix)
+        self.assertEqual(len(versions), 0)
+
+    def test_permanently_delete_versions_large_data_complex_version_history(self):
+        """
+        test that all versions (history) are permanently deleted when the key is deleted with a large amount of data in an unordered way.
+        """
+        # Create key1
+        key1 = f"{self.unique_prefix}_SHOULD_BE_DELETED"
+        self.create_file(key1, "a" * 100)
+
+        # Create 100 files
+        for i in range(100):
+            self.create_file(
+                f"{self.unique_prefix}file_{i}.txt", str(i).ljust(100, "a")
+            )
+
+        # Delete key1
+        self.delete_file(key1)
+
+        # Create 100 files
+        for i in range(100):
+            self.create_file(
+                f"{self.unique_prefix}file_{i}_a.txt", str(i).ljust(100, "a")
+            )
+
+        # Restore key1
+        self.create_file(key1, "a" * 100)
+
+        time.sleep(1)
+
+        # 1. Run with dry-run
+        result = self.run_script(
+            [
+                "--dry-run",
+                "--prefix",
+                self.unique_prefix,
+                "--retention-period",
+                "1 second",
+            ]
+        )
+        self.assertIn("Total deleted keys found: 0", result.stdout)
+        self.assertIn("Total size wasted: 0 B", result.stdout)
+        self.assertIn("Total versions wasted: 0", result.stdout)
+
+        # 2. Run without dry-run
+        self.run_script(
+            [
+                "--force",
+                "--prefix",
+                self.unique_prefix,
+                "--retention-period",
+                "1 second",
+            ]
+        )
+
+        # 3. Verify file is completely gone (no versions left)
+        versions = self.list_versions(self.unique_prefix)
+        # 1 (key1) + 100 (files) + 1 (key1 deleted) + 100 (files) + 1 (key1 restored)
+        self.assertEqual(len(versions), 203)
+
+        # 4. delete the key A again
+        self.delete_file(key1)
+
+        time.sleep(1)
+
+        # 5. Run with dry-run
+        result = self.run_script(
+            [
+                "--dry-run",
+                "--prefix",
+                self.unique_prefix,
+                "--retention-period",
+                "1 second",
+            ]
+        )
+        self.assertIn("Total deleted keys found: 1", result.stdout)
+        self.assertIn("Total size wasted: 200.00 B", result.stdout)
+        self.assertIn("Total versions wasted: 4", result.stdout)
+
+        # 6. Run without dry-run
+        self.run_script(
+            [
+                "--force",
+                "--prefix",
+                self.unique_prefix,
+                "--retention-period",
+                "1 second",
+            ]
+        )
+
+        # 7. Verify file is completely gone (no versions left)
+        versions = self.list_versions(self.unique_prefix)
+        # 204 (203 + 1 delete marker version) - 4 (key1 versions)
+        self.assertEqual(len(versions), 200)
+
+    def test_permanently_delete_versions_high_frequency_updates(self):
+        """
+        test that a key with high frequency updates is identified and deleted.
+        """
+        key = f"{self.unique_prefix}fast_updates.txt"
+
+        # Create 20 versions as fast as possible
+        for i in range(20):
+            self.create_file(key, str(i).ljust(100, "a"))
+
+        # Delete at the end
+        self.delete_file(key)
+
+        time.sleep(1)
+
+        # 1. Run with dry-run
+        result = self.run_script(
+            [
+                "--dry-run",
+                "--prefix",
+                self.unique_prefix,
+                "--retention-period",
+                "1 second",
+            ]
+        )
+        self.assertIn("Total deleted keys found: 1", result.stdout)
+        self.assertIn("Total size wasted: 1.95 KB", result.stdout)
+        self.assertIn("Total versions wasted: 21", result.stdout)
+
+        # 2. Run without dry-run
+        self.run_script(
+            [
+                "--force",
+                "--prefix",
+                self.unique_prefix,
+                "--retention-period",
+                "1 second",
+            ]
+        )
+
+        # 3. Verify file is completely gone (no versions left)
+        versions = self.list_versions(key)
+        self.assertEqual(len(versions), 0)
+
+    def test_selective_retention_with_multiple_keys(self):
+        """
+        test that different keys are identified and deleted. With the same prefix but different keys.
+        """
+        keyA = f"{self.unique_prefix}keyA.txt"
+        keyB = f"{self.unique_prefix}keyB.txt"
+
+        self.create_file(keyA, "A" * 100)
+        self.delete_file(keyA)
+
+        time.sleep(2)
+
+        self.create_file(keyB, "B" * 100)
+        self.delete_file(keyB)
+
+        # 1. Run with dry-run
+        result = self.run_script(
+            [
+                "--dry-run",
+                "--prefix",
+                self.unique_prefix,
+                "--retention-period",
+                "2 second",
+            ]
+        )
+        self.assertIn("Total deleted keys found: 1", result.stdout)
+        self.assertIn("Total size wasted: 100.00 B", result.stdout)
+        self.assertIn("Total versions wasted: 2", result.stdout)
+
+        # 2. Run without dry-run
+        self.run_script(
+            [
+                "--force",
+                "--prefix",
+                self.unique_prefix,
+                "--retention-period",
+                "2 second",
+            ]
+        )
+
+        # 3. Verify that only A keys are deleted
+        versions = self.list_versions(self.unique_prefix)
+        self.assertEqual(len(versions), 2)
+
+        # 4. Verify that KeyB is not deleted
+        for version in versions:
+            self.assertEqual(version["Key"], keyB)
+
+    def test_selective_retention_with_multiple_keys_and_different_prefixes(self):
+        """
+        test that different keys with different prefixes are not identified and deleted.
+        """
+        prefixA = f"{self.unique_prefix}A/"
+        prefixB = f"{self.unique_prefix}B/"
+        keyA = f"{prefixA}keyA.txt"
+        keyB = f"{prefixB}keyB.txt"
+
+        self.create_file(keyA, "A" * 100)
+        self.delete_file(keyA)
+
+        self.create_file(keyB, "B" * 100)
+        self.delete_file(keyB)
+
+        time.sleep(2)
+
+        # 1. Run with dry-run
+        result = self.run_script(
+            [
+                "--dry-run",
+                "--prefix",
+                prefixA,
+                "--retention-period",
+                "2 second",
+            ]
+        )
+        self.assertIn("Total deleted keys found: 1", result.stdout)
+        self.assertIn("Total size wasted: 100.00 B", result.stdout)
+        self.assertIn("Total versions wasted: 2", result.stdout)
+
+        # 2. Run without dry-run
+        self.run_script(
+            [
+                "--force",
+                "--prefix",
+                prefixA,
+                "--retention-period",
+                "2 second",
+            ]
+        )
+
+        # 3. Verify that KeyB still exists
+        versions = self.list_versions(prefixB)
+        self.assertEqual(len(versions), 2)
+
+        # 4. Verify that KeyB is not deleted
+        for version in versions:
+            self.assertEqual(version["Key"], keyB)
+
+        # 5. Verify that KeyA is deleted
+        versions = self.list_versions(prefixA)
+        self.assertEqual(len(versions), 0)
+
+    def test_parse_retention_period_valid_inputs(self):
+        """Test that parse_retention_period correctly parses valid duration strings."""
+        # Test various valid formats
+        test_cases = [
+            ("1 second", 1, "seconds"),
+            ("10 seconds", 10, "seconds"),
+            ("5 minutes", 5, "minutes"),
+            ("2 hours", 2, "hours"),
+            ("30 days", 30, "days"),
+            ("2 weeks", 2, "weeks"),
+            ("1 week", 1, "weeks"),
+        ]
+
+        for duration_str, amount, unit in test_cases:
+            result = parse_retention_period(duration_str)
+
+            # Calculate expected datetime using dictionary unpacking
+            expected = datetime.now(timezone.utc) - timedelta(**{unit: amount})
+
+            # Allow 1 second tolerance for test execution time
+            self.assertAlmostEqual(
+                result.timestamp(),
+                expected.timestamp(),
+                delta=1,
+                msg=f"Failed for input: {duration_str}",
+            )
+
+    def test_parse_retention_period_invalid_inputs(self):
+        """Test that parse_retention_period raises ArgumentTypeError for invalid inputs."""
+        invalid_inputs = [
+            "invalid",  # No number
+            "10",  # No unit
+            "10 months",  # Unsupported unit
+            "-5 days",  # Negative number
+            "3.5 hours",  # Decimal number
+            "ten days",  # Word instead of number
+            "",  # Empty string
+            "days 10",  # Reversed order
+            "5 10 days",  # Multiple numbers
+            "5 days weeks",  # Multiple units
+            "1 day 2 hours",  # Compound duration
+            "9999999999 days",  # Too many days
+            "⑤ days",  # Unicode number
+            123,  # Int
+        ]
+
+        for invalid_input in invalid_inputs:
+            with self.assertRaises(
+                argparse.ArgumentTypeError,
+                msg=f"Should raise error for: {invalid_input}",
+            ):
+                parse_retention_period(invalid_input)
+
+    def test_parse_retention_period_returns_utc_timezone(self):
+        """Test that returned datetime is UTC timezone-aware."""
+        result = parse_retention_period("1 day")
+        self.assertEqual(result.tzinfo, timezone.utc)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Currently QFieldCloud keeps all project files using the non-legacy storage even if they are deleted by the user. This is due to enabled versioning on Exoscale and the lack of Exoscale mechanism to delete files after certain amount of time after they are deleted. This causes excessive file storage and therefore costs.

- Add `purge_deleted_objects.py` for scanning and deleting logically deleted objects in S3 compatable storages
- Add `test.py` for testing the script
- Add a `README.MD`

---
A small CLI to **analyze and clean logically deleted objects** in **versioned S3-compatible buckets**.

This script is **provider-agnostic** works with any S3-compatible service that supports versioning such as `MinIO`, etc.

It helps you to the following:
1. Detect whether a bucket has versioning configured.
2. Find keys whose **latest version is a delete marker** (logically deleted).
3. Report how much storage their historical versions consume.
4. **Deleting all versions** for those keys to free space.

#### Requirements
- boto3
- mypy-boto3-s3  _Optional for type hinting_


#### Usage

##### 1. Scanning for logically deleted objects
```
python purge_deleted_objects.py my-versioned-bucket-name --retention-period <time-interval> --dry-run
```
##### 2. Deleting logically deleted objects
```
python purge_deleted_objects.py my-versioned-bucket-name --retention-period <time-interval>
```

### Options

| Option | Description |
|--------|-------------|
| `bucket_name` | The name of the target S3 bucket (Required). |
| `--dry-run` | Only scan and report statistics without deleting. |
| `--force` | Skip confirmation prompt (useful for automation). |
| `--prefix <path>` | Limit scan to a specific prefix (folder). |
| `--retention-period <time-interval>` | Only process objects deleted BEFORE this duration (e.g., `7 days`, `30 minutes`, `1 hour`). Recent deletions are preserved. |
| `--log-level` | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). |
