### PR TITLE
chore: update urllib3 version to `2.6.3`

### DIFF
--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -237,7 +237,7 @@ typing-extensions==4.14.1
     #   referencing
 uritemplate==4.2.0
     # via drf-spectacular
-urllib3==2.5.0
+urllib3==2.6.3
     # via
     #   botocore
     #   requests

--- a/docker-app/requirements/requirements_test.txt
+++ b/docker-app/requirements/requirements_test.txt
@@ -75,7 +75,7 @@ typing-extensions==4.14.1
     # via
     #   exceptiongroup
     #   selenium
-urllib3[socks]==2.5.0
+urllib3[socks]==2.6.3
     # via
     #   requests
     #   selenium

--- a/docker-app/requirements/requirements_worker_wrapper.txt
+++ b/docker-app/requirements/requirements_worker_wrapper.txt
@@ -16,7 +16,7 @@ requests==2.32.5
     # via docker
 tenacity==9.1.2
     # via -r /requirements/requirements_worker_wrapper.in
-urllib3==2.5.0
+urllib3==2.6.3
     # via
     #   docker
     #   requests

--- a/docker-qgis/requirements.txt
+++ b/docker-qgis/requirements.txt
@@ -51,7 +51,7 @@ tqdm==4.66.5
     # via qfieldcloud-sdk
 typing-extensions==4.14.1
     # via -r requirements.in
-urllib3==2.5.0
+urllib3==2.6.3
     # via
     #   qfieldcloud-sdk
     #   requests


### PR DESCRIPTION
Bump `urllib3` to **v2.6.3**

References:
* [Changelog](https://urllib3.readthedocs.io/en/2.6.3/changelog.html)