### PR TITLE
feat: add 'created_at' to readonly and list display fields in SecretAdmin

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -763,9 +763,10 @@ class SecretAdmin(QFieldCloudModelAdmin):
         "project",
         "organization",
         "created_by",
+        "created_at",
         "value",
     )
-    readonly_fields = ("created_by",)
+    readonly_fields = ("created_by", "created_at")
     list_display = (
         "name",
         "type",
@@ -773,6 +774,7 @@ class SecretAdmin(QFieldCloudModelAdmin):
         "project__name",
         "organization",
         "created_by__link",
+        "created_at",
     )
     autocomplete_fields = ("project",)
 


### PR DESCRIPTION
When investigating Secrets, I think it could be interesting to have the creation date displayed in the UIs. It could also help people doing support, since ATM the way to get this info is Django shell_plus.

- Add `created_at` to Secrets change, list admin pages

<img width="1032" height="391" alt="image" src="https://github.com/user-attachments/assets/9c16ee3f-6a99-4672-9665-e451aaa38de8" />

---
<img width="748" height="657" alt="image" src="https://github.com/user-attachments/assets/89d60f82-0c83-44d9-82f1-64b62d80a5c1" />
