### PR TITLE
chore: bump `django` dependency to `4.2.28`

### DIFF
--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -29,7 +29,7 @@ django-sri==0.8.0
 django-storages==1.14.6
 django-tables2==2.8.0
 django-timezone-field==7.1
-django==4.2.26
+django==4.2.28
 django-stubs==5.2.7
 django-stubs-ext==5.2.7
 djangorestframework==3.16.1

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -40,7 +40,7 @@ cryptography==45.0.6
     #   pyjwt
 deprecated==1.3.1
     # via -r /requirements/requirements.in
-django==4.2.26
+django==4.2.28
     # via
     #   -r /requirements/requirements.in
     #   django-allauth


### PR DESCRIPTION
See release notes : https://docs.djangoproject.com/en/6.0/releases/4.2.28/