### PR TITLE
fix: add `additional_storage_quantity` missing field to Admin and fix save function

### DIFF
--- a/docker-app/qfieldcloud/subscription/admin.py
+++ b/docker-app/qfieldcloud/subscription/admin.py
@@ -104,7 +104,8 @@ class SubscriptionModelForm(forms.ModelForm):
         )
 
         if (
-            not hasattr(self.instance, "active_storage_package_quantity")
+            not self.instance.pk
+            or not hasattr(self.instance, "active_storage_package_quantity")
             or additional_storage_quantity
             == self.instance.active_storage_package_quantity
         ):
@@ -125,6 +126,7 @@ class SubscriptionAdmin(QFieldCloudModelAdmin):
         "account",
         "status",
         "active_since",
+        "additional_storage_quantity",
         "active_until",
         "billing_cycle_anchor_at",
         "current_period_since",


### PR DESCRIPTION
When you try to create or modify a Subscription from the admin panel you will get an error : 

<img width="1158" height="422" alt="image" src="https://github.com/user-attachments/assets/8ebeb9d4-baf5-49ca-a6b1-95cc20967372" />

----

- Added missing `additional_storage_quantity` field to `SubscriptionAdmin`
- Fixed save if condition