### PR TITLE
chore: update django storage import from `s3boto3.S3Boto3Storage` to `s3.S3Storage`

### DIFF
--- a/docker-app/qfieldcloud/core/management/commands/extracts3data.py
+++ b/docker-app/qfieldcloud/core/management/commands/extracts3data.py
@@ -7,7 +7,7 @@ import mypy_boto3_s3
 from django.conf import settings
 from django.core.files.storage import storages
 from django.core.management.base import BaseCommand, CommandParser
-from storages.backends.s3boto3 import S3Boto3Storage
+from storages.backends.s3 import S3Storage
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +71,7 @@ class Command(BaseCommand):
     def get_s3_bucket(storage_name: str) -> mypy_boto3_s3.service_resource.Bucket:
         storage = storages[storage_name]
 
-        if not isinstance(storage, S3Boto3Storage):
+        if not isinstance(storage, S3Storage):
             raise NotImplementedError(
                 "Using the `extracts3data` command only supports S3 storages!"
             )
@@ -111,7 +111,7 @@ class Command(BaseCommand):
             storage = storages[storage_name]
 
             # currently we only support S3 storage
-            if not isinstance(storage, S3Boto3Storage):
+            if not isinstance(storage, S3Storage):
                 continue
 
             storage_names.append(storage_name)

--- a/docker-app/qfieldcloud/filestorage/backend.py
+++ b/docker-app/qfieldcloud/filestorage/backend.py
@@ -7,7 +7,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import ContentFile
 from django.core.files.storage import Storage
 from django.http import HttpResponse
-from storages.backends.s3boto3 import S3Boto3Storage
+from storages.backends.s3 import S3Storage
 
 
 class QfcBackendStorageMixin(ABC):
@@ -31,7 +31,7 @@ class QfcBackendStorageMixin(ABC):
         pass
 
 
-class QfcS3Boto3Storage(QfcBackendStorageMixin, S3Boto3Storage):
+class QfcS3Boto3Storage(QfcBackendStorageMixin, S3Storage):
     def check_status(self) -> bool:
         """Checks if the S3 bucket is reachable.
 


### PR DESCRIPTION
Since [v1.14](https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst#114-2023-09-04) of `django-storage` introduces a dependency import change :

```python
from storages.backends.s3boto3 import S3Boto3Storage
```

becomes

```python
from storages.backends.s3 import S3Storage
```