### PR TITLE
fix: enable signup using invitations when signup closed

### DIFF
--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -615,7 +615,8 @@ DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL")
 # https://github.com/bee-keeper/django-invitations#additional-configuration
 INVITATIONS_INVITATION_EXPIRY = 365  # integer in days, 0 disables invitations
 INVITATIONS_INVITATION_ONLY = False
-# INVITATIONS_ACCEPT_INVITE_AFTER_SIGNUP = True
+INVITATIONS_ACCEPT_INVITE_AFTER_SIGNUP = True
+INVITATIONS_ADAPTER = ACCOUNT_ADAPTER  # set if accepting an invite after signup
 INVITATIONS_GONE_ON_ACCEPT_ERROR = False
 
 TEST_RUNNER = "qfieldcloud.testing.QfcTestSuiteRunner"


### PR DESCRIPTION
When `AccountAdapterSignUpClosed` is set, Invitations don't work. They can be sent out but when the invited user is trying to access the link, they can't signup since it's closed

- Added a new validation to `AccountAdapterSignUpClosed` to allow signups on valid invitations
- Added `get_user_signed_up_signal` to `AccountAdapter` so invitations works properly
- Changed `INVITATIONS_ACCEPT_INVITE_AFTER_SIGNUP` setting to `True` to avoid invitation edge cases