### PR TITLE
fix: update signup_closed template to use blocktrans with about_url variable

### DIFF
--- a/docker-app/qfieldcloud/core/templates/account/signup_closed.html
+++ b/docker-app/qfieldcloud/core/templates/account/signup_closed.html
@@ -22,8 +22,8 @@
       {% endblocktrans %}
     </p>
     <p class="card-text">
-      {% blocktrans %}
-      No account yet? Then please <a href="{{ config.ABOUT_QFIELDCLOUD_URL }}#register">join the waiting list</a>.
+      {% blocktrans with about_url=config.ABOUT_QFIELDCLOUD_URL %}
+      No account yet? Then please <a href="{{ about_url }}#register">join the waiting list</a>.
       {% endblocktrans %}
     </p>
   </div>


### PR DESCRIPTION
Href for "join the waiting list" was not being rendered correctly. 

I also suggest that we can either remove it or create a new contance for it.