### PR TITLE
fix: allow social account linking only to useraccounts of type `PERSON`

### DIFF
--- a/docker-app/qfieldcloud/core/adapters.py
+++ b/docker-app/qfieldcloud/core/adapters.py
@@ -7,18 +7,21 @@ from typing import Literal
 from allauth.account import app_settings
 from allauth.account.adapter import DefaultAccountAdapter
 from allauth.account.models import EmailConfirmationHMAC
+from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
+from allauth.socialaccount.models import SocialLogin
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 from constance import config
 from django.contrib import messages
 from django.contrib.auth.models import AbstractUser
 from django.core.exceptions import ValidationError
 from django.http import HttpRequest
+from django.shortcuts import redirect
 from django.utils import timezone
 from invitations.adapters import BaseInvitationsAdapter
 
 from qfieldcloud.authentication.sso.provider_styles import SSOProviderStyles
-from qfieldcloud.core.models import Person
+from qfieldcloud.core.models import Person, User
 
 logger = logging.getLogger(__name__)
 
@@ -193,6 +196,47 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
 
     Logs stack trace and error details on 3rd party authentication errors.
     """
+
+    def pre_social_login(self, request: HttpRequest, sociallogin: SocialLogin) -> None:
+        """
+        Invoked just after a user successfully authenticates via a
+        social provider, but before the login is actually processed
+        (and before the pre_social_login signal is emitted).
+
+        This is a good hook to check that the user is of type `PERSON`,
+        and not of type `ORGANIZATION` or `TEAM`,
+        as SSO login should only be allowed for user accounts.
+        """
+
+        # check if allauth can find a useraccount with this email,
+        # meaning that the accounts would be linked and a social account created.
+        if sociallogin.is_existing:
+            # here we check that the user trying to login is of type `PERSON`.
+            user = sociallogin.user
+
+            if user.type != User.Type.PERSON:
+                # if the user is not of type `PERSON`,
+                # we try to find a user with the same email that is of type `PERSON`,
+                # and link the social account to that user instead.
+                # Otherwise we block the social account link to an Organization.
+
+                email = sociallogin.account.extra_data.get("email", "")
+
+                if not email:
+                    messages.error(
+                        request, "No email returned by the Identity Provider."
+                    )
+                    raise ImmediateHttpResponse(redirect("account_login"))
+
+                try:
+                    person_user = User.objects.get(email=email, type=User.Type.PERSON)
+                    sociallogin.user = person_user
+                except User.DoesNotExist:
+                    messages.error(
+                        request,
+                        "Can login via SSO only to user accounts, not organizations.",
+                    )
+                    raise ImmediateHttpResponse(redirect("account_login"))
 
     def on_authentication_error(
         self,

--- a/docker-app/qfieldcloud/core/apps.py
+++ b/docker-app/qfieldcloud/core/apps.py
@@ -6,3 +6,29 @@ class CoreConfig(AppConfig):
 
     def ready(self):
         from qfieldcloud.core import signals  # noqa
+
+        # patch allauth's filter_users_by_email to only return users of type PERSON,
+        # as QFC SSO doesn't support ORGANIZATION users.
+        from allauth.account import utils as allauth_utils
+        from allauth.account import forms as allauth_forms
+        from allauth.account import auth_backends as allauth_auth_backends
+        from allauth.socialaccount import models as allauth_socialaccount_models
+
+        orig_filter_users_by_email = allauth_utils.filter_users_by_email
+
+        def patched_filter_users_by_email(email, is_active=None, prefer_verified=False):
+            from qfieldcloud.core.models import User
+
+            users = orig_filter_users_by_email(
+                email, is_active=is_active, prefer_verified=prefer_verified
+            )
+            person_users = list(filter(lambda u: u.type == User.Type.PERSON, users))
+
+            return person_users
+
+        allauth_utils.filter_users_by_email = patched_filter_users_by_email
+        allauth_forms.filter_users_by_email = patched_filter_users_by_email
+        allauth_auth_backends.filter_users_by_email = patched_filter_users_by_email
+        allauth_socialaccount_models.filter_users_by_email = (
+            patched_filter_users_by_email
+        )


### PR DESCRIPTION
This PR intends to allow the creation of allauth's `SocialAccount` only to useraccount having the `PERSON` type. Thus disabling Social Accounts creation and SSO login for email addresses related to Organization.

It has been observed that if an Organization and a User have the same email address, login via SSO using this email address may result in being connected as the Organization, which is not alright. The meaning of this PR is also to avoid that.

## Steps to reproduce :

1. in Django Admin create an Organization `o` with email address `A`
2. in Django Admin create a People `p` with same email address `A`
3. login using a 3rd party IDP with this same email address `A`

-> without the changes brought by this PR, you are logged in as the Organization`o`, created at step 1.  
-> with the changes, you are logged in as the People `p`, created at step 2.

## Other cases covered by this PR :

### Login with 3rd party IDP with only the Organization having the `A` email address -> blocked

1. delete any `Social Account` related to the email address `A` mentioned above, in Django Admin
2. change the `p` People's email address
-> there is only the Organization `o` having the `A` email address
3. login using a 3rd party IDP with this same email address `A`
-> it fails, since SSO login for Organization is not allowed, with an error message displayed : `Can login via SSO only to user accounts, not organizations.`

### Login with 3rd party IDP with no `A` email address anywhere  -> new Social Account and new QFieldCloud user created

1. change the `o` Organization's email address
-> there is no more Organization neither People having this `A` email address
2. login using a 3rd party IDP with this same email address `A`
-> you're logged in as a new QFieldCloud user, that was created during the login and to which a new Social Account is binded (for this you need `QFIELDCLOUD_ACCOUNT_ADAPTER=qfieldcloud.core.adapters.AccountAdapterSignUpOpen` is the `.env` environment file)