### PR TITLE
feat: allow social signup even if the closed signup adapter is used

### DIFF
--- a/docker-app/qfieldcloud/core/adapters.py
+++ b/docker-app/qfieldcloud/core/adapters.py
@@ -8,6 +8,7 @@ from allauth.account import app_settings
 from allauth.account.adapter import DefaultAccountAdapter
 from allauth.account.models import EmailConfirmationHMAC
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
+from allauth.socialaccount.models import SocialLogin
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 from constance import config
 from django.contrib import messages
@@ -235,3 +236,9 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
             provider.styles = SSOProviderStyles(request).get(provider.sub_id)
 
         return providers
+
+    def is_open_for_signup(
+        self, request: HttpRequest, sociallogin: SocialLogin
+    ) -> Literal[True]:
+        """Allow social signup for all users."""
+        return True


### PR DESCRIPTION
This PR intends to allow 3rd party social signup, when "regular" registration is closed.

Steps to test :

1. set `QFIELDCLOUD_ACCOUNT_ADAPTER=qfieldcloud.core.adapters.AccountAdapterSignUpClosed` in your `.env` file
2. login using 3rd party IDP, using an email address that is not in use on the instance
3. a new QFieldCloud user is created, linked to a new Social Account

:eyes: See [django-allauth's `DefaultSocialAccountAdapter`'s `is_open_for_signup` implementation](https://github.com/pennersr/django-allauth/blob/d729357926074a1af64a4b881afac45db305aa16/allauth/socialaccount/adapter.py#L156-L163), which normally calls the configured adapter's `is_open_for_signup` method.  
We can not rely on that, since it will avoid any registration, the social ones included.

This way we decouple the `AccountAdapterSignUpClosed` from the `SocialAccountAdapter`, allowing to block regular signup but allowing social signup. Open to discuss the approach,