### PR TITLE
feat: implement thumbnail upload functionality from sdk

### DIFF
--- a/docker-qgis/qfc_worker/utils.py
+++ b/docker-qgis/qfc_worker/utils.py
@@ -12,6 +12,7 @@ import xml.etree.ElementTree as ET
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, NamedTuple, TypedDict, cast
+from uuid import UUID
 
 from libqfieldsync.layer import LayerSource
 from libqfieldsync.utils.bad_layer_handler import (
@@ -478,6 +479,19 @@ def upload_project(project_id: str, project_dir: Path) -> None:
     )
 
     logging.info("Uploading packaged project files finished!")
+
+
+def upload_project_thumbnail(project_id: UUID, thumbnail_filename: Path | None) -> None:
+    """Upload the generated thumbnail to QFieldCloud via the SDK."""
+
+    if thumbnail_filename is None:
+        logging.warning("No thumbnail was generated, skipping upload.")
+        return
+
+    client = sdk.Client()
+    client.upload_project_thumbnail(str(project_id), str(thumbnail_filename))
+
+    logging.info("Project thumbnail uploaded!")
 
 
 def list_local_files(project_id: str, project_dir: Path):

--- a/docker-qgis/requirements.in
+++ b/docker-qgis/requirements.in
@@ -2,4 +2,4 @@ jsonschema==4.25.1
 typing-extensions==4.14.1
 tabulate==v0.9.0
 requests==2.32.5
-qfieldcloud-sdk==0.11.0
+qfieldcloud-sdk==0.13.0

--- a/docker-qgis/requirements.txt
+++ b/docker-qgis/requirements.txt
@@ -28,7 +28,7 @@ jsonschema-specifications==2023.12.1
     # via jsonschema
 pathvalidate==3.3.1
     # via qfieldcloud-sdk
-qfieldcloud-sdk==0.11.0
+qfieldcloud-sdk==0.13.0
     # via -r requirements.in
 referencing==0.35.1
     # via


### PR DESCRIPTION
Creating a thumbnail should not block successfully using the QGIS project on QField. Instead of worker wrapper directly looking for a thumbnail.png  file via a shared volume we better send the file using the SDK within the worker.

- Removed thumbnail saving from `after_docker_run`
- Add `upload_thumbnail` step at `ProcessProjectfileCommand`
- Add `upload_project_thumbnail` function to upload thumbnail using the sdk

In order for these changes to function properly, we need to resolve these PRs first 
* [PR-1476](https://github.com/opengisch/QFieldCloud/pull/1476) ✅
* [PR-94](https://github.com/opengisch/qfieldcloud-sdk-python/pull/94) ✅

~~Then we should update `qfieldcloud-sdk==0.11.0` to the latest version when PR-94 is released~~