### PR TITLE
Manage CORS configuration via environment variables using django-cors-headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -526,6 +526,17 @@ WEBDAV_SERVER_NAMES="172.17.0.1,webdav"
 # DEFAULT: 5433
 HOST_POSTGRES_PORT=5433
 
+# Comma-separated list of origins allowed to make cross-origin requests to the API.
+# Example  "https://app.example.com,http://localhost:5173"
+# NOTE: Do NOT include trailing slashes.
+# DEFAULT: "https://docs.qfield.org"
+CORS_ALLOWED_ORIGINS=https://docs.qfield.org
+
+# Allow credentials (cookies, authorization headers) in cross-origin requests.
+# VALUES: 0 - do not allow credentials; 1 - allow clients to send authentication tokens or session cookies.
+# DEFAULT: 1
+CORS_ALLOW_CREDENTIALS=1
+
 
 ##################
 # Debug settings - development only

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -20,6 +20,7 @@ from .settings_utils import (
     ConfigValidationError,
     get_socialaccount_providers_config,
     get_storages_config,
+    parse_string_to_list,
 )
 
 # QFieldCloud specific configuration
@@ -137,12 +138,14 @@ INSTALLED_APPS = [
     "django_extensions",
     "bootstrap4",
     "sri",
+    "corsheaders",
     # To ensure that exceptions inside other apps' signal handlers do not affect the integrity of file deletions within transactions, `django_cleanup` should be placed last in `INSTALLED_APPS`. See https://github.com/un1t/django-cleanup#configuration
     "django_cleanup.apps.CleanupConfig",
 ]
 
 MIDDLEWARE = [
     "debug_toolbar.middleware.DebugToolbarMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.locale.LocaleMiddleware",
@@ -586,6 +589,7 @@ QFIELDCLOUD_SSO_PROVIDER_STYLES = {
     },
 }
 
+###########################
 # Django axes configuration
 # https://django-axes.readthedocs.io/en/latest/4_configuration.html
 ###########################
@@ -970,3 +974,24 @@ JAZZMIN_SETTINGS = {
 #     "logo_alt": "Your logo description",
 #     "favicon": "path/to/favicon.ico",
 # }
+
+
+###########################
+# CORS settings
+# Managed via django-cors-headers.
+# Origins and credentials are configured through environment variables,
+# so no nginx changes are needed when adding new clients.
+# https://github.com/adamchainz/django-cors-headers
+###########################
+
+# Comma-separated list of origins that are allowed to make cross-origin
+# requests. Do not include trailing slashes.
+# Example: CORS_ALLOWED_ORIGINS=https://app.example.com,http://localhost:5173
+CORS_ALLOWED_ORIGINS = parse_string_to_list(os.environ.get("CORS_ALLOWED_ORIGINS", ""))
+
+# Only allow CORS on API endpoints – static files and pages are unaffected.
+CORS_URLS_REGEX = r"^/api/.*$"
+
+# Whether to include credentials (cookies, authorization headers) in
+# cross-origin requests. Required when clients send auth tokens.
+CORS_ALLOW_CREDENTIALS = bool(int(os.environ.get("CORS_ALLOW_CREDENTIALS", 0)))

--- a/docker-app/qfieldcloud/settings_utils.py
+++ b/docker-app/qfieldcloud/settings_utils.py
@@ -116,3 +116,7 @@ def get_socialaccount_providers_config() -> dict:
         )
 
     return providers
+
+
+def parse_string_to_list(input_str: str) -> list[str]:
+    return [item.strip() for item in input_str.split(",") if item.strip()]

--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -7,6 +7,7 @@ django-axes==8.0.0
 django-bootstrap4==25.2
 django-classy-tags==4.1.0
 django-cleanup==9.0.0
+django-cors-headers==4.9.0
 django-common-helpers==0.9.2
 django-constance==4.3.2
 django-countries==8.2.0

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -9,6 +9,7 @@ asgiref==3.9.1
     #   django
     #   django-allauth
     #   django-axes
+    #   django-cors-headers
     #   django-countries
 attrs==25.3.0
     # via
@@ -49,6 +50,7 @@ django==4.2.28
     #   django-bootstrap4
     #   django-classy-tags
     #   django-common-helpers
+    #   django-cors-headers
     #   django-cron
     #   django-currentuser
     #   django-debug-toolbar
@@ -86,6 +88,8 @@ django-cleanup==9.0.0
 django-common-helpers==0.9.2
     # via -r /requirements/requirements.in
 django-constance==4.3.2
+    # via -r /requirements/requirements.in
+django-cors-headers==4.9.0
     # via -r /requirements/requirements.in
 django-countries==8.2.0
     # via -r /requirements/requirements.in

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,8 @@ services:
       EMAIL_HOST_USER: ${EMAIL_HOST_USER}
       EMAIL_HOST_PASSWORD: ${EMAIL_HOST_PASSWORD}
       DEFAULT_FROM_EMAIL: ${DEFAULT_FROM_EMAIL}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS}
+      CORS_ALLOW_CREDENTIALS: ${CORS_ALLOW_CREDENTIALS}
       # Settings below are specific to worker_wrapper
       # TODO : move this to the worker_wrapper service and keep things DRY (yaml syntax expert needed)
       TMP_DIRECTORY: ${TMP_DIRECTORY}

--- a/docker-nginx/templates/default.conf.template
+++ b/docker-nginx/templates/default.conf.template
@@ -150,7 +150,6 @@ server {
   }
 
   location /swagger.yaml {
-    add_header Access-Control-Allow-Origin https://docs.qfield.org;
     proxy_pass http://django;
   }
 


### PR DESCRIPTION
Hi there!

Previously, allowing cross-origin access to the API required manually adding `add_header` directives in the nginx configuration. This made it cumbersome for developers building custom frontends or apps against the QFieldCloud API.

This PR introduces django-cors-headers so that allowed origins can be managed entirely through environment variables:

```env
CORS_ALLOWED_ORIGINS=https://app.example.com,http://localhost:5173
CORS_ALLOW_CREDENTIALS=1
```

**Changes:**

- Added `django-cors-headers` as a dependency
- CORS middleware and settings configured in settings.py, driven by env vars
- CORS restricted to /api/ endpoints via CORS_URLS_REGEX
- Removed hardcoded `Access-Control-Allow-Origin` header from nginx (`/swagger.yaml`). https://docs.qfield.org should go into .env
- Passed `CORS_ALLOWED_ORIGINS` and `CORS_ALLOW_CREDENTIALS` through docker-compose.yml
- Updated .env.example with documentation

This allows developers to build their own frontends against the API by simply adding their origin to `CORS_ALLOWED_ORIGINS` — no nginx changes or container rebuilds required.



> Feature request https://ideas.qfield.org/qfieldcloud-feature-requests/p/enable-configurable-cors-via-environment-variables