### PR TITLE
UPDATE Readme: Give context to pre-commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Now connecting with `curl` should fail with a similar error:
 
 ## Code style
 
-Code style done with [`pre-commit`](https://pre-commit.com):
+This project uses [`pre-commit`](https://pre-commit.com) to automatically run linters and formatters before each commit.
 
     pip install pre-commit
     # install pre-commit hook


### PR DESCRIPTION
## Expand pre-commit documentation in README

The existing "Code style" section only listed the install commands without much context. This update expands it to be a little  more helpful for new contributors like me :)

No code changes — documentation only.