### PR TITLE
Reduce default QGIS network timeout

### DIFF
--- a/docker-qgis/qfc_worker/utils.py
+++ b/docker-qgis/qfc_worker/utils.py
@@ -33,6 +33,7 @@ from qgis.core import (
     QgsProject,
     QgsProjectArchive,
     QgsProviderRegistry,
+    QgsSettings,
     QgsZipUtils,
 )
 from qgis.PyQt import QtCore, QtGui
@@ -40,6 +41,11 @@ from tabulate import tabulate
 
 # Get environment variables
 JOB_ID = os.environ.get("JOB_ID")
+
+# Network timeout for QGIS. Reduced from default 60 seconds to fail fast 
+# when layers are unreachable (e.g. network outage, blocked external access).
+# This prevents long blocking delays when loading project file.
+QGIS_NETWORK_TIMEOUT_MS = 5000
 
 qgs_stderr_logger = logging.getLogger("QGSSTDERR")
 qgs_stderr_logger.setLevel(logging.DEBUG)
@@ -173,6 +179,9 @@ def start_app() -> str:
 
         QtCore.qInstallMessageHandler(_qt_message_handler)
         QgsApplication.messageLog().messageReceived.connect(_write_log_message)
+
+        settings = QgsSettings()
+        settings.setValue("network/network-timeout", QGIS_NETWORK_TIMEOUT_MS)
 
         # make sure the app is closed, otherwise the container exists with non-zero
         @atexit.register


### PR DESCRIPTION
This PR changes the default QGIS network timeout from 60 seconds to 5 seconds.

The current default of 60 seconds feels a bit overkill when processing a project file that may contain invalid or unreachable layers (e.g. service down, network outage, DNS issues, etc.). This is especially problematic for layers that have QFieldSync `cloud_action` set to `remove` or `no_action`. In those situations, each failing layer can block processing unnecessary for up to a minute, which adds up quickly.

We initially ran into this issue in our self-hosted setup, where outbound network access outside the private network is blocked. Because of that, any external layer in the project would wait the full 60 seconds before failing, which in turn caused QFC jobs to time out. While this affected our environment, I think the upstream project could also benefit from this change as well.