### PR TITLE
chore: edit the way the boolean `CORS_ALLOW_CREDENTIALS` envvar is loaded

### DIFF
--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -1000,4 +1000,4 @@ CORS_URLS_REGEX = r"^/api/.*$"
 
 # Whether to include credentials (cookies, authorization headers) in
 # cross-origin requests. Required when clients send auth tokens.
-CORS_ALLOW_CREDENTIALS = bool(int(os.environ.get("CORS_ALLOW_CREDENTIALS", 0)))
+CORS_ALLOW_CREDENTIALS = bool(int(os.environ.get("CORS_ALLOW_CREDENTIALS") or 0))


### PR DESCRIPTION
Follow-up of #1487 :)

If somehow the new CORS-related env var is not there or commented, the default value would not be applied and the app would not boot, with this log :

```
CORS_ALLOW_CREDENTIALS = bool(int(os.environ.get("CORS_ALLOW_CREDENTIALS", 0)))
app-1  | ValueError: invalid literal for int() with base 10: ''
```