### PR TITLE
Bump `libqfieldsync` to download only the needed subset of features that are filtered

### DIFF
--- a/docker-qgis/requirements_libqfieldsync.txt
+++ b/docker-qgis/requirements_libqfieldsync.txt
@@ -1,1 +1,1 @@
-libqfieldsync @ git+https://github.com/opengisch/libqfieldsync@6221ad54fda3d44c81c12ada441d6c73f888291c
+libqfieldsync @ git+https://github.com/opengisch/libqfieldsync@5eee86b0ce8b78657c53017c178a3599de8f6e56


### PR DESCRIPTION
See https://github.com/opengisch/libqfieldsync/pull/138#discussion_r2863221775

Note the failing linting CI has been fixed on master and it is no longer an issue.