### PR TITLE
feat: Add server info endpoint

### DIFF
--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Any
 
+from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from django_stubs_ext import StrOrPromise
@@ -672,3 +673,25 @@ class TeamMemberSerializer(serializers.ModelSerializer):
     class Meta:
         model = TeamMember
         fields = ("member",)
+
+
+class WhitelabelSerializer(serializers.Serializer):
+    site_title = serializers.CharField(help_text="The title of the site.")
+    logo_navbar = serializers.URLField(help_text="The URL of the navigation bar logo.")
+    logo_main = serializers.URLField(help_text="The URL of the main logo.")
+    favicon = serializers.URLField(help_text="The URL of the favicon.")
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        request = self.context.get("request")
+        if request:
+            for key in ("logo_navbar", "logo_main", "favicon"):
+                value = data.get(key)
+                if value:
+                    data[key] = request.build_absolute_uri(static(value))
+
+        return data
+
+
+class ServerInfoSerializer(serializers.Serializer):
+    whitelabel = WhitelabelSerializer()

--- a/docker-app/qfieldcloud/core/tests/test_server_views.py
+++ b/docker-app/qfieldcloud/core/tests/test_server_views.py
@@ -1,0 +1,64 @@
+from django.core.cache import cache
+from django.templatetags.static import static
+from django.test import override_settings
+from rest_framework.test import APITransactionTestCase
+
+from qfieldcloud.core.whitelabel import get_whitelabel_settings
+
+
+class QfcTestCase(APITransactionTestCase):
+    def setUp(self):
+        # Clear the cache before each test to prevent cached responses
+        cache.clear()
+        self.whitelabel_settings = get_whitelabel_settings()
+        super().setUp()
+
+    def test_server_info_default_settings(self):
+        """Test that the endpoint returns the correct default whitelabel settings"""
+        response = self.client.get("/api/v1/server/info/")
+        data = response.json()
+
+        self.assertTrue("whitelabel" in data)
+
+        system_info = data["whitelabel"]
+
+        # Check title
+        self.assertEqual(
+            system_info["site_title"], self.whitelabel_settings["site_title"]
+        )
+
+        # Check that the URLs have been transformed to absolute URLs properly
+        self.assertTrue(system_info["logo_navbar"].startswith("http"))
+        self.assertTrue(
+            system_info["logo_navbar"].endswith(
+                static(self.whitelabel_settings["logo_navbar"])
+            )
+        )
+
+        self.assertTrue(system_info["logo_main"].startswith("http"))
+        self.assertTrue(
+            system_info["logo_main"].endswith(
+                static(self.whitelabel_settings["logo_main"])
+            )
+        )
+
+        self.assertTrue(system_info["favicon"].startswith("http"))
+        self.assertTrue(
+            system_info["favicon"].endswith(static(self.whitelabel_settings["favicon"]))
+        )
+
+    @override_settings(
+        WHITELABEL={
+            "site_title": "My Custom Title",
+        }
+    )
+    def test_server_info_custom_whitelabel_settings(self):
+        """Test that the endpoint correctly reflects custom WHITELABEL settings from settings.py"""
+        response = self.client.get("/api/v1/server/info/")
+        data = response.json()
+
+        self.assertTrue("whitelabel" in data)
+
+        system_info = data["whitelabel"]
+
+        self.assertEqual(system_info["site_title"], "My Custom Title")

--- a/docker-app/qfieldcloud/core/urls.py
+++ b/docker-app/qfieldcloud/core/urls.py
@@ -8,6 +8,7 @@ from qfieldcloud.core.views import (
     members_views,
     package_views,
     projects_views,
+    server_views,
     status_views,
     teams_views,
     users_views,
@@ -104,4 +105,5 @@ urlpatterns = [
         name="team_member_destroy",
     ),
     path("resend-confirmation/", resend_confirmation_email, name="resend_confirmation"),
+    path("server/info/", server_views.ServerInfoView.as_view(), name="server_info"),
 ]

--- a/docker-app/qfieldcloud/core/views/server_views.py
+++ b/docker-app/qfieldcloud/core/views/server_views.py
@@ -1,0 +1,28 @@
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
+from drf_spectacular.utils import extend_schema, extend_schema_view
+from qfieldcloud.core.serializers import ServerInfoSerializer
+from qfieldcloud.core.whitelabel import get_whitelabel_settings
+from rest_framework import status, views
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+
+@extend_schema_view(
+    get=extend_schema(description="Get server information"),
+)
+class ServerInfoView(views.APIView):
+    permission_classes = [AllowAny]
+    serializer_class = ServerInfoSerializer
+
+    @method_decorator(cache_page(60))
+    def get(self, request: Request) -> Response:
+        results = self.serializer_class(
+            {
+                "whitelabel": get_whitelabel_settings(),
+            },
+            context={"request": request},
+        )
+
+        return Response(results.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
For now we return information about the whitelabeling, but in the future we can add more and more, as `auth/providers` is already a good candidate to join.


```
$ curl https://localhost:8002/api/v1/server/info/ | jq
{
    "whitelabel": {
        "site_title": "QFieldCloud",
        "logo_navbar": "https://localhost/staticfiles/logo_sidetext_white.svg",
        "logo_main": "https://localhost/staticfiles/logo_undertext.svg",
        "favicon": "https://localhost/staticfiles/favicon.ico"
    }
}
```