### PR TITLE
chore: block unstyled allauth pages

### DIFF
--- a/docker-app/qfieldcloud/core/utils2/view_utils.py
+++ b/docker-app/qfieldcloud/core/utils2/view_utils.py
@@ -1,0 +1,7 @@
+from typing import Any
+
+from django.http import Http404, HttpRequest
+
+
+def blocked_view(request: HttpRequest, *args: Any, **kwargs: Any) -> None:
+    raise Http404

--- a/docker-app/qfieldcloud/urls.py
+++ b/docker-app/qfieldcloud/urls.py
@@ -33,6 +33,7 @@ from rest_framework import permissions
 
 from qfieldcloud.authentication import views as auth_views
 from qfieldcloud.core.admin import qfc_admin_site
+from qfieldcloud.core.utils2.view_utils import blocked_view
 from qfieldcloud.core.views.redirect_views import redirect_to_admin_project_view
 from qfieldcloud.filestorage.views import (
     compatibility_file_crud_view,
@@ -117,6 +118,10 @@ urlpatterns = [
         ),
     ),
     path("auth/", include("rest_framework.urls")),
+    # Block the unstyled pages - must be before the allauth URLs
+    path("accounts/3rdparty/", blocked_view),
+    path("accounts/email/", blocked_view),
+    path("accounts/password/change/", blocked_view),
     path("accounts/", include("allauth.urls")),
     path("invitations/", include("invitations.urls", namespace="invitations")),
     path("__debug__/", include("debug_toolbar.urls")),


### PR DESCRIPTION
There are a couple of pages that any qfc user can access which is the default pages related to allauth. These urls needs to be restricted, since it's un-styled and also redundant and can be found in account settings