### PR TITLE
feat: make django's `USE_X_FORWARDED_HOST` configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -276,6 +276,12 @@ DJANGO_SETTINGS_MODULE=qfieldcloud.settings
 # DEFAULT: "localhost 127.0.0.1 0.0.0.0 app nginx
 DJANGO_ALLOWED_HOSTS="localhost 127.0.0.1 0.0.0.0 app nginx"
 
+# Whether to use `X-Forwarded-Host` header when getting the host of the requests.
+# This is required when QFieldCloud is behind a proxy that sets the `X-Forwarded-Host` header.
+# See https://docs.djangoproject.com/en/5.2/ref/settings/#use-x-forwarded-host
+# DEFAULT: 1
+DJANGO_USE_X_FORWARDED_HOST=1
+
 # Whether QFieldCloud should be translated in another language other than English. See  https://docs.djangoproject.com/en/4.2/ref/settings/#use-i18n
 # NOTE if there is no full translation in given language, QFieldCloud will be shown in mixture of English and the given language. Also installed Django modules have their own translations that might not be complete.
 # VALUES: 0 - English only; 1 - enable other languages

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -67,6 +67,8 @@ ALLOWED_HOSTS = parse_string_to_list(os.environ["DJANGO_ALLOWED_HOSTS"], delimit
 # Read more: https://docs.djangoproject.com/en/4.2/ref/settings/#secure-proxy-ssl-header
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
+USE_X_FORWARDED_HOST = parse_string_to_bool(os.environ["DJANGO_USE_X_FORWARDED_HOST"])
+
 AUTHENTICATION_BACKENDS = [
     "axes.backends.AxesBackend",
     # custom QFC backend that extends the `allauth` specific authentication methods

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - media_volume:/usr/src/app/mediafiles/
     environment:
       DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS}
+      DJANGO_USE_X_FORWARDED_HOST: ${DJANGO_USE_X_FORWARDED_HOST}
       DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE}
       SECRET_KEY: ${SECRET_KEY}
       SALT_KEY: ${SALT_KEY}


### PR DESCRIPTION
This PR intends to make the Django's `USE_X_FORWARDED_HOST` boolean value configurable.

In some configuration it might be needed, when QFieldCloud's nginx stands behind a 2nd reverse proxy.