### PR TITLE
feat: Add externally accessible API for user creation POST /users

### DIFF
--- a/docker-app/qfieldcloud/core/permissions_utils.py
+++ b/docker-app/qfieldcloud/core/permissions_utils.py
@@ -541,6 +541,15 @@ def can_list_users_organizations(user: QfcUser) -> bool:
     return True
 
 
+def can_create_user(user: QfcUser) -> bool:
+    """Return True if the user can create new QFieldCloud accounts.
+
+    Restricted to staff so only service accounts and admins can provision
+    users programmatically via the API.
+    """
+    return user.is_staff
+
+
 def can_create_organizations(user: QfcUser) -> bool:
     return user.is_authenticated
 

--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -283,6 +283,14 @@ class CreateUserSerializer(serializers.ModelSerializer):
             "last_name": {"required": False, "default": ""},
         }
 
+    def validate_email(self, value):
+        if Person.objects.filter(email__iexact=value).exists():
+            raise serializers.ValidationError(
+                _("This email is already taken by another user!")
+            )
+
+        return value
+
     def create(self, validated_data):
         return Person.objects.create_user(
             has_accepted_tos=False,

--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -19,6 +19,7 @@ from qfieldcloud.core.models import (
     Organization,
     OrganizationMember,
     PackageJob,
+    Person,
     ProcessProjectfileJob,
     Project,
     ProjectCollaborator,
@@ -266,6 +267,36 @@ class CompleteUserSerializer(serializers.ModelSerializer):
             "last_name",
         )
         read_only_fields = ("full_name", "avatar_url")
+
+
+class CreateUserSerializer(serializers.Serializer):
+    """Serializer for programmatic Person account creation.
+
+    Intentionally does *not* validate username uniqueness here so that the view
+    can return HTTP 409 Conflict (rather than 400) when the username is taken.
+    """
+
+    username = serializers.RegexField(
+        r"^[-a-zA-Z0-9_]+$",
+        max_length=150,
+        min_length=3,
+        error_messages={
+            "invalid": _(
+                "Enter a valid username. This value may contain only letters, "
+                "numbers, and -/_ characters."
+            )
+        },
+    )
+    password = serializers.CharField(write_only=True, style={"input_type": "password"})
+    email = serializers.EmailField(required=True)
+
+    def create(self, validated_data):
+        return Person.objects.create_user(
+            username=validated_data["username"],
+            password=validated_data["password"],
+            email=validated_data["email"],
+            has_accepted_tos=True,
+        )
 
 
 class PublicInfoUserSerializer(serializers.ModelSerializer):

--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -276,25 +276,22 @@ class CreateUserSerializer(serializers.Serializer):
     can return HTTP 409 Conflict (rather than 400) when the username is taken.
     """
 
-    username = serializers.RegexField(
-        r"^[-a-zA-Z0-9_]+$",
+    username = serializers.CharField(
         max_length=150,
-        min_length=3,
-        error_messages={
-            "invalid": _(
-                "Enter a valid username. This value may contain only letters, "
-                "numbers, and -/_ characters."
-            )
-        },
+        validators=User._meta.get_field("username").validators,
     )
     password = serializers.CharField(write_only=True, style={"input_type": "password"})
     email = serializers.EmailField(required=True)
+    first_name = serializers.CharField(max_length=150, required=False, default="")
+    last_name = serializers.CharField(max_length=150, required=False, default="")
 
     def create(self, validated_data):
         return Person.objects.create_user(
             username=validated_data["username"],
             password=validated_data["password"],
             email=validated_data["email"],
+            first_name=validated_data["first_name"],
+            last_name=validated_data["last_name"],
             has_accepted_tos=False,
         )
 

--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -295,7 +295,7 @@ class CreateUserSerializer(serializers.Serializer):
             username=validated_data["username"],
             password=validated_data["password"],
             email=validated_data["email"],
-            has_accepted_tos=True,
+            has_accepted_tos=False,
         )
 
 

--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -269,30 +269,24 @@ class CompleteUserSerializer(serializers.ModelSerializer):
         read_only_fields = ("full_name", "avatar_url")
 
 
-class CreateUserSerializer(serializers.Serializer):
-    """Serializer for programmatic Person account creation.
+class CreateUserSerializer(serializers.ModelSerializer):
+    """Serializer for programmatic Person account creation."""
 
-    Intentionally does *not* validate username uniqueness here so that the view
-    can return HTTP 409 Conflict (rather than 400) when the username is taken.
-    """
-
-    username = serializers.CharField(
-        max_length=150,
-        validators=User._meta.get_field("username").validators,
-    )
     password = serializers.CharField(write_only=True, style={"input_type": "password"})
-    email = serializers.EmailField(required=True)
-    first_name = serializers.CharField(max_length=150, required=False, default="")
-    last_name = serializers.CharField(max_length=150, required=False, default="")
+
+    class Meta:
+        model = Person
+        fields = ("username", "password", "email", "first_name", "last_name")
+        extra_kwargs = {
+            "email": {"required": True},
+            "first_name": {"required": False, "default": ""},
+            "last_name": {"required": False, "default": ""},
+        }
 
     def create(self, validated_data):
         return Person.objects.create_user(
-            username=validated_data["username"],
-            password=validated_data["password"],
-            email=validated_data["email"],
-            first_name=validated_data["first_name"],
-            last_name=validated_data["last_name"],
             has_accepted_tos=False,
+            **validated_data,
         )
 
 

--- a/docker-app/qfieldcloud/core/tests/test_user.py
+++ b/docker-app/qfieldcloud/core/tests/test_user.py
@@ -402,7 +402,7 @@ class CreatePersonAPITestCase(APITestCase):
         )
         self.assertFalse(Person.objects.get(username="tosuser").has_accepted_tos)
 
-    def test_duplicate_username_returns_409(self):
+    def test_duplicate_username_returns_400(self):
         Person.objects.create_user(username="existing", password="abc123")
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.staff_token.key)
         response = self.client.post(
@@ -413,7 +413,7 @@ class CreatePersonAPITestCase(APITestCase):
                 "email": "existing@example.com",
             },
         )
-        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_non_staff_forbidden(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.regular_token.key)

--- a/docker-app/qfieldcloud/core/tests/test_user.py
+++ b/docker-app/qfieldcloud/core/tests/test_user.py
@@ -394,13 +394,13 @@ class CreatePersonAPITestCase(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_create_person_sets_has_accepted_tos(self):
+    def test_create_person_has_accepted_tos_false(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.staff_token.key)
         self.client.post(
             self._url(),
             {"username": "tosuser", "password": "pass", "email": "tos@example.com"},
         )
-        self.assertTrue(Person.objects.get(username="tosuser").has_accepted_tos)
+        self.assertFalse(Person.objects.get(username="tosuser").has_accepted_tos)
 
     def test_duplicate_username_returns_409(self):
         Person.objects.create_user(username="existing", password="abc123")

--- a/docker-app/qfieldcloud/core/tests/test_user.py
+++ b/docker-app/qfieldcloud/core/tests/test_user.py
@@ -473,6 +473,22 @@ class CreatePersonAPITestCase(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_duplicate_email_returns_400(self):
+        Person.objects.create_user(
+            username="emailowner", password="abc123", email="taken@example.com"
+        )
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.staff_token.key)
+        response = self.client.post(
+            self._url(),
+            {
+                "username": "newuser",
+                "password": "abc123",
+                "email": "taken@example.com",
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("email", response.data)
+
     def test_list_still_works_for_staff(self):
         """GET /api/v1/users/ must still function after adding POST support."""
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.staff_token.key)

--- a/docker-app/qfieldcloud/core/tests/test_user.py
+++ b/docker-app/qfieldcloud/core/tests/test_user.py
@@ -326,3 +326,126 @@ class QfcTestCase(APITestCase):
             Person.objects.create_user(
                 username="u2", password="abc123", email="same@example.com"
             )
+
+
+class CreatePersonAPITestCase(APITestCase):
+    """Tests for POST /api/v1/users/ (staff-only)."""
+
+    def setUp(self):
+        setup_subscription_plans()
+
+        self.staff_user = Person.objects.create_user(
+            username="staffuser",
+            password="abc123",
+            email="staff@example.com",
+            is_staff=True,
+        )
+        self.staff_token = AuthToken.objects.get_or_create(
+            user=self.staff_user,
+            client_type=AuthToken.ClientType.QFIELD,
+            user_agent="qfield|dev",
+        )[0]
+
+        self.regular_user = Person.objects.create_user(
+            username="regularuser",
+            password="abc123",
+            email="regular@example.com",
+        )
+        self.regular_token = AuthToken.objects.get_or_create(
+            user=self.regular_user,
+            client_type=AuthToken.ClientType.QFIELD,
+            user_agent="qfield|dev",
+        )[0]
+
+        set_subscription((self.staff_user, self.regular_user), "default_user")
+
+    def _url(self):
+        return "/api/v1/users/"
+
+    def test_staff_can_create_user(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.staff_token.key)
+        response = self.client.post(
+            self._url(),
+            {
+                "username": "newmapper",
+                "password": "securepass123",
+                "email": "newmapper@example.com",
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["username"], "newmapper")
+        self.assertTrue(Person.objects.filter(username="newmapper").exists())
+
+    def test_create_person_with_email(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.staff_token.key)
+        response = self.client.post(
+            self._url(),
+            {"username": "newmapper2", "password": "pass", "email": "m@example.com"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(
+            Person.objects.get(username="newmapper2").email, "m@example.com"
+        )
+
+    def test_email_required(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.staff_token.key)
+        response = self.client.post(
+            self._url(), {"username": "nomailuser", "password": "pass"}
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_person_sets_has_accepted_tos(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.staff_token.key)
+        self.client.post(
+            self._url(),
+            {"username": "tosuser", "password": "pass", "email": "tos@example.com"},
+        )
+        self.assertTrue(Person.objects.get(username="tosuser").has_accepted_tos)
+
+    def test_duplicate_username_returns_409(self):
+        Person.objects.create_user(username="existing", password="abc123")
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.staff_token.key)
+        response = self.client.post(
+            self._url(),
+            {
+                "username": "existing",
+                "password": "pass",
+                "email": "existing@example.com",
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+    def test_non_staff_forbidden(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.regular_token.key)
+        response = self.client.post(
+            self._url(), {"username": "shouldfail", "password": "pass"}
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_unauthenticated_rejected(self):
+        response = self.client.post(
+            self._url(), {"username": "anon", "password": "pass"}
+        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_invalid_username_rejected(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.staff_token.key)
+        response = self.client.post(
+            self._url(),
+            {"username": "bad username!", "password": "pass", "email": "m@example.com"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_username_too_short_rejected(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.staff_token.key)
+        response = self.client.post(
+            self._url(),
+            {"username": "ab", "password": "pass", "email": "m@example.com"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_list_still_works_for_staff(self):
+        """GET /api/v1/users/ must still function after adding POST support."""
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.staff_token.key)
+        response = self.client.get(self._url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/docker-app/qfieldcloud/core/tests/test_user.py
+++ b/docker-app/qfieldcloud/core/tests/test_user.py
@@ -440,7 +440,36 @@ class CreatePersonAPITestCase(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.staff_token.key)
         response = self.client.post(
             self._url(),
-            {"username": "ab", "password": "pass", "email": "m@example.com"},
+            {"username": "ab", "password": "abc123", "email": "shortuser@example.com"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_person_with_names(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.staff_token.key)
+        response = self.client.post(
+            self._url(),
+            {
+                "username": "nameduser",
+                "password": "abc123",
+                "email": "nameduser@example.com",
+                "first_name": "Jane",
+                "last_name": "Doe",
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        person = Person.objects.get(username="nameduser")
+        self.assertEqual(person.first_name, "Jane")
+        self.assertEqual(person.last_name, "Doe")
+
+    def test_username_must_begin_with_letter(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.staff_token.key)
+        response = self.client.post(
+            self._url(),
+            {
+                "username": "1badname",
+                "password": "abc123",
+                "email": "user1@example.com",
+            },
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 

--- a/docker-app/qfieldcloud/core/tests/test_user.py
+++ b/docker-app/qfieldcloud/core/tests/test_user.py
@@ -487,7 +487,7 @@ class CreatePersonAPITestCase(APITestCase):
             },
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("email", response.data)
+        self.assertFalse(Person.objects.filter(username="newuser").exists())
 
     def test_list_still_works_for_staff(self):
         """GET /api/v1/users/ must still function after adding POST support."""

--- a/docker-app/qfieldcloud/core/urls.py
+++ b/docker-app/qfieldcloud/core/urls.py
@@ -48,7 +48,7 @@ urlpatterns = [
     *subscription_urlpatterns,
     path("projects/public/", projects_views.PublicProjectsListView.as_view()),
     path("", include(router.urls)),
-    path("users/", users_views.ListUsersView.as_view()),
+    path("users/", users_views.ListCreateUsersView.as_view()),
     path(
         "users/<str:username>/organizations/",
         users_views.ListUserOrganizationsView.as_view(),

--- a/docker-app/qfieldcloud/core/views/users_views.py
+++ b/docker-app/qfieldcloud/core/views/users_views.py
@@ -1,30 +1,36 @@
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
+from django.db import IntegrityError
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from qfieldcloud.core import pagination, permissions_utils, querysets_utils
 from qfieldcloud.core.models import Organization, Project
 from qfieldcloud.core.serializers import (
     CompleteUserSerializer,
+    CreateUserSerializer,
     OrganizationSerializer,
     PublicInfoUserSerializer,
 )
-from rest_framework import generics, permissions
+from rest_framework import generics, permissions, status
 from rest_framework.response import Response
 
 User = get_user_model()
 
 
-class ListUsersViewPermissions(permissions.BasePermission):
+class ListCreateUsersViewPermissions(permissions.BasePermission):
     def has_permission(self, request, view):
+        if request.method == "POST":
+            return permissions_utils.can_create_user(request.user)
+
         return permissions_utils.can_list_users_organizations(request.user)
 
 
 @extend_schema_view(
     get=extend_schema(description="List users and/or organizations"),
+    post=extend_schema(description="Create a new user account (staff only)"),
 )
-class ListUsersView(generics.ListAPIView):
+class ListCreateUsersView(generics.ListCreateAPIView):
     serializer_class = PublicInfoUserSerializer
-    permission_classes = [permissions.IsAuthenticated, ListUsersViewPermissions]
+    permission_classes = [permissions.IsAuthenticated, ListCreateUsersViewPermissions]
     pagination_class = pagination.QfcLimitOffsetPagination()
 
     def get_queryset(self):
@@ -60,6 +66,22 @@ class ListUsersView(generics.ListAPIView):
             exclude_organizations=exclude_organizations,
             exclude_teams=exclude_teams,
             invert=invert,
+        )
+
+    def post(self, request):
+        serializer = CreateUserSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        try:
+            user = serializer.save()
+        except IntegrityError:
+            return Response(
+                {"username": ["A user with this username already exists."]},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        return Response(
+            PublicInfoUserSerializer(user).data,
+            status=status.HTTP_201_CREATED,
         )
 
 

--- a/docker-app/qfieldcloud/core/views/users_views.py
+++ b/docker-app/qfieldcloud/core/views/users_views.py
@@ -1,6 +1,5 @@
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
-from django.db import IntegrityError
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from qfieldcloud.core import pagination, permissions_utils, querysets_utils
 from qfieldcloud.core.models import Organization, Project
@@ -71,13 +70,7 @@ class ListCreateUsersView(generics.ListCreateAPIView):
     def post(self, request):
         serializer = CreateUserSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        try:
-            user = serializer.save()
-        except IntegrityError:
-            return Response(
-                {"username": ["A user with this username already exists."]},
-                status=status.HTTP_409_CONFLICT,
-            )
+        user = serializer.save()
 
         return Response(
             PublicInfoUserSerializer(user).data,


### PR DESCRIPTION
### Why did I make this PR?

- I have been developing an application that uses QFieldCloud underneath to manage projects, then the QField mobile app for mapping.
- As part of the project creation process, I want to create a new user account that I can give to the user of my app.
- This way they don't need to be given QFC admin credentials linked to my app, or pre-configured accounts - we can do it programmatically.
- Once the user has an account, they can log in and manage the project as needed (adding new users to it mainly).

> [!NOTE]
> I only realised very recently that the UI at app.qfield.cloud isn't part of the OSS self-host solution (which is perfectly fine), but that does mean this API is mostly useful for creators of external apps, that wish to use the official app.qfield.cloud instance (so they can log in with the newly created user and manage).
>
> As a result, I will create a tiny wrapper around qfieldcloud-sdk-python as a backend to manage users, with a small frontend to manage this. The user logs in and can add new users to the project - that's about it.

### What's included

- Adds a simple POST request option to the existing `/users` route, that requires `is_staff=true` (instance admin) for the user.
- Standard users probably shouldn't be allowed to create new users (at least for now / until discussed how).

Request body:

```json
 {
    "username": "newmapper",
    "password": "securepass123",
    "email": "newmapper@example.com"
  }
```

Success response (201 Created):

```json
  {
    "username": "newmapper",
    "type": 1, # a 'person'
    "full_name": "",
    "avatar_url": null,
    "username_display": "newmapper"
  }
```

Error responses:

  - 400 Bad Request: invalid payload (e.g. bad username format / too short / user already exists)
  - 401 Unauthorized: no auth token
  - 403 Forbidden: authenticated but not staff

### How did I verify

- Added a bunch of extra tests.
- Confirmed all tests pass `docker compose run --rm -e ENVIRONMENT=test app python manage.py test --keepdb -v2 --exclude-tag="flaky" qfieldcloud.core.tests.test_user.CreatePersonAPITestCase`
- Ran all pre-commit hooks.
- Non-breaking change - additive only).
- No db migration needed.

Disclaimer: I used Opus 4.6 to better target where changes should be made & for assisting with test creation.

Also, I was writing this code to solve **my** problems and totally understand if it's not in the roadmap to be accepted. I thought I may as well PR it, as it was written anyway!
