### PR TITLE
DRY up docker-compose env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,6 +171,7 @@ services:
       - transformation_grids:/transformation_grids
       - /var/run/docker.sock:/var/run/docker.sock
       - custom_ca_certificates:/etc/ssl/certs/:ro
+      - ${TMP_DIRECTORY}:/tmp
     environment:
       <<: *django-env
       TMP_DIRECTORY: ${TMP_DIRECTORY}


### PR DESCRIPTION
Found two TODOs in docker-compose.yml and addressed both of them.

The volumes `static_volume`, `media_volume` and the shared environment variables are extracted into YAML anchors so they are defined once and reused across app and worker_wrapper.

Edit: shared volumes part is moved to #1516 as suggested by @suricactus

NOTE: I am not a YAML expert! Happy to get feedback on the anchor approach if there's a cleaner way.
