### PR TITLE
Qf 7984 server info providers

### DIFF
--- a/docker-app/qfieldcloud/authentication/views.py
+++ b/docker-app/qfieldcloud/authentication/views.py
@@ -1,6 +1,3 @@
-from allauth.socialaccount.adapter import get_adapter
-from allauth.socialaccount.providers.base import Provider
-from allauth.socialaccount.providers.oauth2.views import OAuth2Adapter
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
@@ -9,6 +6,7 @@ from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
 from django.views.decorators.debug import sensitive_post_parameters
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import status
 from rest_framework.authtoken.views import ObtainAuthToken
 from rest_framework.generics import RetrieveAPIView
@@ -16,7 +14,7 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from qfieldcloud.authentication.sso.provider_styles import SSOProviderStyles
+from qfieldcloud.core.utils2.auth_providers import get_all_auth_providers
 
 from .authentication import create_token
 from .models import AuthToken
@@ -127,6 +125,12 @@ class UserView(RetrieveAPIView):
         return get_user_model().objects.none()
 
 
+@extend_schema_view(
+    get=extend_schema(
+        description="Lists the available authentication providers.",
+        deprecated=True,
+    ),
+)
 class ListProvidersView(APIView):
     """Lists the available authentication providers.
 
@@ -134,88 +138,9 @@ class ListProvidersView(APIView):
     username/password login.
     """
 
-    # These values are tied to the `GrantFlow` enum in QGIS:
-    # oauth2/core/qgsauthoauth2config.h: QgsAuthOAuth2Config::GrantFlow
-    FLOW_AUTHORIZATION_CODE = 0
-    FLOW_AUTHORIZATION_CODE_PKCE = 3
-
-    # Address at which QGIS should spawn its temporary webserver to catch
-    # the redirect. These mostly happen to match QGIS defaults, except we use
-    # localost instead of 127.0.0.1 because many OAuth2 apps don't allow IPs.
-    QGIS_REDIRECT_HOST = "localhost"
-    QGIS_REDIRECT_PORT = 7070
-    QGIS_REDIRECT_URL = ""
-
     permission_classes = (AllowAny,)
 
     def get(self, request: HttpRequest, *args, **kwargs) -> Response:
-        auth_providers = []
-
-        if settings.QFIELDCLOUD_PASSWORD_LOGIN_IS_ENABLED:
-            auth_providers.append(
-                {
-                    "type": "credentials",
-                    "id": "credentials",
-                    "name": "Username / Password",
-                }
-            )
-
-        social_account_adapter = get_adapter(request)
-        providers = social_account_adapter.list_providers(request)
-
-        for provider in providers:
-            auth_providers.append(self.get_provider_data(provider, request))
+        auth_providers = get_all_auth_providers(request)
 
         return Response(auth_providers)
-
-    def get_provider_data(self, provider: Provider, request: HttpRequest) -> dict:
-        oauth2_adapter = provider.get_oauth2_adapter(request)
-
-        # Support subproviders like 'keycloak'
-        # (which is a subprovider of the generic 'openid_connect' provider)
-        provider_id = provider.sub_id
-
-        provider_data = {
-            "type": "oauth2",
-            "id": provider_id,
-            "name": provider.name,
-            "grant_flow": self.get_flow_type(provider),
-            "scope": self.get_scope(provider, oauth2_adapter),
-            "pkce_enabled": self.is_pkce_enabled(provider),
-            "token_url": oauth2_adapter.access_token_url,
-            "refresh_token_url": oauth2_adapter.access_token_url,
-            "request_url": oauth2_adapter.authorize_url,
-            "redirect_host": self.QGIS_REDIRECT_HOST,
-            "redirect_port": self.QGIS_REDIRECT_PORT,
-            "redirect_url": self.QGIS_REDIRECT_URL,
-            "client_id": provider.app.client_id,
-            "extra_tokens": {"id_token": settings.QFIELDCLOUD_ID_TOKEN_HEADER_NAME},
-            "idp_id_header": settings.QFIELDCLOUD_IDP_ID_HEADER_NAME,
-            "styles": SSOProviderStyles(request).get(provider_id),
-        }
-        return provider_data
-
-    def get_scope(self, provider: Provider, oauth2_adapter: OAuth2Adapter) -> str:
-        scope = provider.get_scope()
-        if "openid" not in scope:
-            scope.insert(0, "openid")
-
-        scope = oauth2_adapter.scope_delimiter.join(scope)
-        return scope
-
-    def is_pkce_enabled(self, provider: Provider) -> bool:
-        pkce_enabled = False
-        pkce_enabled = provider.app.settings.get("oauth_pkce_enabled")
-        if pkce_enabled is None:
-            pkce_enabled = provider.get_settings().get(
-                "OAUTH_PKCE_ENABLED",
-                provider.pkce_enabled_default,
-            )
-
-        return pkce_enabled
-
-    def get_flow_type(self, provider: Provider) -> int:
-        if self.is_pkce_enabled(provider):
-            return self.FLOW_AUTHORIZATION_CODE_PKCE
-
-        return self.FLOW_AUTHORIZATION_CODE

--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -672,3 +672,34 @@ class TeamMemberSerializer(serializers.ModelSerializer):
     class Meta:
         model = TeamMember
         fields = ("member",)
+
+
+class ServerInfoSerializer(serializers.Serializer):
+    class SystemSerializer(serializers.Serializer):
+        site_title = serializers.CharField(help_text="The title of the site.")
+        logo_navbar = serializers.URLField(help_text="The URL of the navbar logo.")
+        logo_main = serializers.URLField(help_text="The URL of the main logo.")
+        favicon = serializers.URLField(help_text="The URL of the favicon.")
+
+    class AuthProviderSerializer(serializers.Serializer):
+        type = serializers.CharField(
+            help_text="Provider type: 'credentials' or 'oauth2'."
+        )
+        id = serializers.CharField(help_text="Provider identifier.")
+        name = serializers.CharField(help_text="Human-readable provider name.")
+        grant_flow = serializers.IntegerField(required=False)
+        scope = serializers.CharField(required=False)
+        pkce_enabled = serializers.BooleanField(required=False)
+        token_url = serializers.CharField(required=False)
+        refresh_token_url = serializers.CharField(required=False)
+        request_url = serializers.CharField(required=False)
+        redirect_host = serializers.CharField(required=False)
+        redirect_port = serializers.IntegerField(required=False)
+        redirect_url = serializers.CharField(required=False, allow_blank=True)
+        client_id = serializers.CharField(required=False)
+        extra_tokens = serializers.DictField(required=False)
+        idp_id_header = serializers.CharField(required=False)
+        styles = serializers.DictField(required=False)
+
+    system = SystemSerializer()
+    auth_providers = AuthProviderSerializer(many=True, required=False, default=list)

--- a/docker-app/qfieldcloud/core/tests/test_server_views.py
+++ b/docker-app/qfieldcloud/core/tests/test_server_views.py
@@ -1,0 +1,47 @@
+from django.core.cache import cache
+from django.templatetags.static import static
+from django.test import override_settings
+from rest_framework.test import APITransactionTestCase
+
+from qfieldcloud.core.whitelabel import DEFAULT_WHITELABEL
+
+
+class QfcTestCase(APITransactionTestCase):
+    def setUp(self):
+        # Clear the cache before each test to prevent cached responses
+        cache.clear()
+        super().setUp()
+
+    def test_server_info_default_settings(self):
+        """Test that the endpoint returns the correct default whitelabel settings"""
+        response = self.client.get("/api/v1/server/info/")
+        data = response.json()
+        system_info = data["system"]
+
+        # Check title
+        self.assertEqual(system_info["site_title"], DEFAULT_WHITELABEL["site_title"])
+
+        # Check that the URLs have been transformed to absolute URLs properly
+        self.assertTrue(system_info["logo_navbar"].startswith("http"))
+        self.assertIn(
+            static(DEFAULT_WHITELABEL["logo_navbar"]), system_info["logo_navbar"]
+        )
+
+        self.assertTrue(system_info["logo_main"].startswith("http"))
+        self.assertIn(static(DEFAULT_WHITELABEL["logo_main"]), system_info["logo_main"])
+
+        self.assertTrue(system_info["favicon"].startswith("http"))
+        self.assertIn(static(DEFAULT_WHITELABEL["favicon"]), system_info["favicon"])
+
+    @override_settings(
+        WHITELABEL={
+            "site_title": "My Custom Title",
+        }
+    )
+    def test_server_info_custom_whitelabel_settings(self):
+        """Test that the endpoint correctly reflects custom WHITELABEL settings from settings.py"""
+        response = self.client.get("/api/v1/server/info/")
+        data = response.json()
+        system_info = data["system"]
+
+        self.assertEqual(system_info["site_title"], "My Custom Title")

--- a/docker-app/qfieldcloud/core/utils2/auth_providers.py
+++ b/docker-app/qfieldcloud/core/utils2/auth_providers.py
@@ -1,0 +1,105 @@
+from typing import Optional
+
+from allauth.socialaccount.adapter import get_adapter
+from allauth.socialaccount.providers.base import Provider
+from allauth.socialaccount.providers.oauth2.views import OAuth2Adapter
+from django.conf import settings
+from django.http import HttpRequest
+
+from qfieldcloud.authentication.sso.provider_styles import SSOProviderStyles
+
+# These values are tied to the `GrantFlow` enum in QGIS:
+# oauth2/core/qgsauthoauth2config.h: QgsAuthOAuth2Config::GrantFlow
+FLOW_AUTHORIZATION_CODE = 0
+FLOW_AUTHORIZATION_CODE_PKCE = 3
+
+# Address at which QGIS should spawn its temporary webserver to catch
+# the redirect. These mostly happen to match QGIS defaults, except we use
+# localhost instead of 127.0.0.1 because many OAuth2 apps don't allow IPs.
+QGIS_REDIRECT_HOST = "localhost"
+QGIS_REDIRECT_PORT = 7070
+QGIS_REDIRECT_URL = ""
+
+
+def get_credentials_provider() -> dict:
+    return {
+        "type": "credentials",
+        "id": "credentials",
+        "name": "Username / Password",
+    }
+
+
+def get_oauth2_provider(
+    provider: Provider,
+    oauth2_adapter: OAuth2Adapter,
+    request: Optional[HttpRequest] = None,
+) -> dict:
+    provider_id = getattr(provider, "sub_id", provider.id)
+
+    # Allow styles to be pre-attached to the provider (used in serializers) or fetched via request (used in views)
+    styles = getattr(provider, "styles", None)
+    if styles is None and request is not None:
+        styles = SSOProviderStyles(request).get(provider_id)
+
+    return {
+        "type": "oauth2",
+        "id": provider_id,
+        "name": provider.name,
+        "grant_flow": get_flow_type(provider),
+        "scope": get_scope(provider, oauth2_adapter),
+        "pkce_enabled": is_pkce_enabled(provider),
+        "token_url": oauth2_adapter.access_token_url,
+        "refresh_token_url": oauth2_adapter.access_token_url,
+        "request_url": oauth2_adapter.authorize_url,
+        "redirect_host": QGIS_REDIRECT_HOST,
+        "redirect_port": QGIS_REDIRECT_PORT,
+        "redirect_url": QGIS_REDIRECT_URL,
+        "client_id": provider.app.client_id,
+        "extra_tokens": {"id_token": settings.QFIELDCLOUD_ID_TOKEN_HEADER_NAME},
+        "idp_id_header": settings.QFIELDCLOUD_IDP_ID_HEADER_NAME,
+        "styles": styles,
+    }
+
+
+def get_scope(provider: Provider, oauth2_adapter: OAuth2Adapter) -> str:
+    scope = provider.get_scope()
+    if "openid" not in scope:
+        scope.insert(0, "openid")
+
+    return oauth2_adapter.scope_delimiter.join(scope)
+
+
+def is_pkce_enabled(provider: Provider) -> bool:
+    pkce_enabled = provider.app.settings.get("oauth_pkce_enabled")
+    if pkce_enabled is None:
+        pkce_enabled = provider.get_settings().get(
+            "OAUTH_PKCE_ENABLED",
+            provider.pkce_enabled_default,
+        )
+
+    return pkce_enabled
+
+
+def get_flow_type(provider: Provider) -> int:
+    if is_pkce_enabled(provider):
+        return FLOW_AUTHORIZATION_CODE_PKCE
+
+    return FLOW_AUTHORIZATION_CODE
+
+
+def get_all_auth_providers(request: HttpRequest) -> list[dict]:
+    """Generates the full list of formatted auth providers."""
+    auth_providers = []
+
+    if settings.QFIELDCLOUD_PASSWORD_LOGIN_IS_ENABLED:
+        auth_providers.append(get_credentials_provider())
+
+    social_account_adapter = get_adapter(request)
+    for provider in social_account_adapter.list_providers(request):
+        if hasattr(provider, "get_oauth2_adapter"):
+            oauth2_adapter = provider.get_oauth2_adapter(request)
+            auth_providers.append(
+                get_oauth2_provider(provider, oauth2_adapter, request)
+            )
+
+    return auth_providers

--- a/docker-app/qfieldcloud/core/views/server_views.py
+++ b/docker-app/qfieldcloud/core/views/server_views.py
@@ -1,37 +1,39 @@
-from django.contrib.auth import get_user_model
-from django.http import HttpRequest
 from django.templatetags.static import static
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from drf_spectacular.utils import extend_schema, extend_schema_view
+from qfieldcloud.core.serializers import ServerInfoSerializer
+from qfieldcloud.core.utils2.auth_providers import get_all_auth_providers
 from qfieldcloud.core.whitelabel import get_whitelabel_settings
 from rest_framework import status, views
 from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
 from rest_framework.response import Response
-
-User = get_user_model()
 
 
 @extend_schema_view(
-    get=extend_schema(description="Get the current status of the API"),
+    get=extend_schema(description="Get server information"),
 )
 class ServerInfoView(views.APIView):
     permission_classes = [AllowAny]
+    serializer_class = ServerInfoSerializer
 
     @method_decorator(cache_page(60))
-    def get(self, request: HttpRequest) -> Response:
+    def get(self, request: Request) -> Response:
+        system_info = {}
         whitelabel_settings = get_whitelabel_settings()
 
-        # the whitelabel settings contain paths to static files, we need to convert them to absolute URLs
         for key in ["logo_navbar", "logo_main", "favicon"]:
-            whitelabel_settings[key] = request.build_absolute_uri(
-                static(whitelabel_settings[key])
-            )
+            value = whitelabel_settings.get(key)
+            if value:
+                whitelabel_settings[key] = request.build_absolute_uri(static(value))
 
-        results = {
-            "whitelabel": {
-                **whitelabel_settings,
+        system_info.update(whitelabel_settings)
+
+        results = self.serializer_class(
+            {
+                "system": system_info,
+                "auth_providers": get_all_auth_providers(request),
             }
-        }
-
-        return Response(results, status=status.HTTP_200_OK)
+        )
+        return Response(results.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
Created `auth_providers.py` utils
Added providers to `/server/info` and deprecated `auth/providers` endpoint

Related PR : [PR-1498](https://github.com/opengisch/QFieldCloud/pull/1498)


```
$ curl https://localhost:8002/api/v1/server/info/ | jq
{
    "system": {
        "site_title": "QFieldCloud",
        "logo_navbar": "https://localhost/staticfiles/logo_sidetext_white.svg",
        "logo_main": "https://localhost/staticfiles/logo_undertext.svg",
        "favicon": "https://localhost/staticfiles/favicon.ico"
    },
    "auth_providers": [
        {
            "type": "credentials",
            "id": "credentials",
            "name": "Username / Password"
        },
        {
            "type": "oauth2",
            "id": "entra",
            "name": "Microsoft",
            "grant_flow": 3,
            "scope": "openid profile email",
            "pkce_enabled": true,
            "token_url": "https://login.microsoftonline.com/5f59e5b4-ad92-4c15-ae13-c8317cbefddd/oauth2/v2.0/token",
            "refresh_token_url": "https://login.microsoftonline.com/5f59e5b4-ad92-4c15-ae13-c8317cbefddd/oauth2/v2.0/token",
            "request_url": "https://login.microsoftonline.com/5f59e5b4-ad92-4c15-ae13-c8317cbefddd/oauth2/v2.0/authorize",
            "redirect_host": "localhost",
            "redirect_port": 7070,
            "redirect_url": "",
            "client_id": "5c1b462d-f4e7-4e88-baf5-30afd8cc29fb",
            "extra_tokens": {
                "id_token": "X-QFC-ID-Token"
            },
            "idp_id_header": "X-QFC-IDP-ID",
            "styles": {
                "required": true,
                "light": {
                    "logo": "https://localhost/staticfiles/sso/microsoft.svg",
                    "color_fill": "#FFFFFF",
                    "color_stroke": "#8C8C8C",
                    "color_text": "#5E5E5E"
                },
                "dark": {
                    "logo": "https://localhost/staticfiles/sso/microsoft.svg",
                    "color_fill": "#2F2F2F",
                    "color_stroke": "#2F2F2F",
                    "color_text": "#FFFFFF"
                }
            }
        }
    ]
}
```