### PR TITLE
feat: propagate a potential certificate authority to workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ conf/certbot/*
 conf/nginx/certs/*.pem
 conf/nginx/config.d/*.conf
 conf/nginx/dhparams/*.pem
+conf/ca/custom_ca.crt
 Pipfile*
 **/site-packages
 docker-qgis/libqfieldsync

--- a/conf/ca/README.md
+++ b/conf/ca/README.md
@@ -1,0 +1,3 @@
+# Custom CA directory
+
+Place a file named `custom_ca.crt` in this directory, and QFieldCloud will recognize it as a custom Certificate Authority (CA) bundle.

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -999,3 +999,12 @@ CORS_URLS_REGEX = r"^/(api/.*|swagger/)$"
 # Whether to include credentials (cookies, authorization headers) in
 # cross-origin requests. Required when clients send auth tokens.
 CORS_ALLOW_CREDENTIALS = parse_string_to_bool(os.environ["CORS_ALLOW_CREDENTIALS"])
+
+# Optional volume name where custom CA files are mounted
+QFIELDCLOUD_CUSTOM_CA_VOLUME_NAME = (
+    f"{os.environ['COMPOSE_PROJECT_NAME']}_custom_ca_certificates"
+)
+
+# Filename where optional custom CA certificate are stored.
+QFIELDCLOUD_CUSTOM_CA_DIR = "/etc/ssl/certs"
+QFIELDCLOUD_CUSTOM_CA_FILENAME = f"{QFIELDCLOUD_CUSTOM_CA_DIR}/custom_ca.crt"

--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -132,6 +132,12 @@ class JobRun:
             f"{settings.QFIELDCLOUD_TRANSFORMATION_GRIDS_VOLUME_NAME}:{TRANSFORMATION_GRIDS_PATH}:ro",
         ]
 
+        # If the env configuration provides a custom CA, mount it in the worker.
+        if Path(settings.QFIELDCLOUD_CUSTOM_CA_FILENAME).exists():
+            volumes.append(
+                f"{settings.QFIELDCLOUD_CUSTOM_CA_VOLUME_NAME}:{settings.QFIELDCLOUD_CUSTOM_CA_DIR}:ro"
+            )
+
         return volumes
 
     def get_ports(self) -> dict[str, int]:
@@ -141,6 +147,11 @@ class JobRun:
 
     def get_environment(self) -> dict[str, str]:
         extra_envvars = {}
+
+        if Path(settings.QFIELDCLOUD_CUSTOM_CA_FILENAME).exists():
+            extra_envvars["REQUESTS_CA_BUNDLE"] = (
+                settings.QFIELDCLOUD_CUSTOM_CA_FILENAME
+            )
 
         pgservice_file_contents = ""
         for secret in Secret.objects.for_user_and_project(  # type:ignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     volumes:
       - static_volume:/usr/src/app/staticfiles
       - media_volume:/usr/src/app/mediafiles/
+      - custom_ca_certificates:/etc/ssl/certs/:ro
     environment:
       DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS}
       DJANGO_USE_X_FORWARDED_HOST: ${DJANGO_USE_X_FORWARDED_HOST}
@@ -52,6 +53,7 @@ services:
       STORAGES_PROJECT_DEFAULT_STORAGE: ${STORAGES_PROJECT_DEFAULT_STORAGE:-}
       STORAGES_PROJECT_DEFAULT_ATTACHMENTS_STORAGE: ${STORAGES_PROJECT_DEFAULT_ATTACHMENTS_STORAGE:-}
       STORAGE_PROJECT_DEFAULT_ATTACHMENTS_VERSIONED: ${STORAGE_PROJECT_DEFAULT_ATTACHMENTS_VERSIONED:-}
+      COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME}
       QFIELDCLOUD_DEFAULT_NETWORK: ${QFIELDCLOUD_DEFAULT_NETWORK:-${COMPOSE_PROJECT_NAME}_default}
       QFIELDCLOUD_PASSWORD_LOGIN_IS_ENABLED: ${QFIELDCLOUD_PASSWORD_LOGIN_IS_ENABLED}
       ACCOUNT_EMAIL_VERIFICATION: ${ACCOUNT_EMAIL_VERIFICATION}
@@ -171,6 +173,7 @@ services:
       - transformation_grids:/transformation_grids
       - /var/run/docker.sock:/var/run/docker.sock
       - ${TMP_DIRECTORY}:/tmp
+      - custom_ca_certificates:/etc/ssl/certs/:ro
     logging: *default-logging
     scale: ${QFIELDCLOUD_WORKER_REPLICAS}
     stop_grace_period: 15m
@@ -205,3 +208,13 @@ volumes:
   media_volume:
   transformation_grids:
   certbot_www:
+  custom_ca_certificates:
+    # We use a bind mount to mount the custom CA bundle from the host machine into the Docker volume,
+    # this way we can easily manage the CA bundle on the host and have them available in the containers.
+    # The docker in docker setup of the workers spawned by the wrapper requires the CA bundle to be available as a volume,
+    # either with absolute host path, either a named one which we prefer here to share it across services.
+    driver: local
+    driver_opts:
+      type: none
+      device: ${PWD:-.}/conf/ca
+      o: bind, ro

--- a/docker-qgis/requirements.in
+++ b/docker-qgis/requirements.in
@@ -2,4 +2,4 @@ jsonschema==4.25.1
 typing-extensions==4.14.1
 tabulate==v0.9.0
 requests==2.33.1
-qfieldcloud-sdk==0.13.0
+qfieldcloud-sdk==0.14.0

--- a/docker-qgis/requirements.txt
+++ b/docker-qgis/requirements.txt
@@ -28,7 +28,7 @@ jsonschema-specifications==2023.12.1
     # via jsonschema
 pathvalidate==3.3.1
     # via qfieldcloud-sdk
-qfieldcloud-sdk==0.13.0
+qfieldcloud-sdk==0.14.0
     # via -r requirements.in
 referencing==0.35.1
     # via


### PR DESCRIPTION
This PR intends to propagate a potential CA to the workers, in order to allow the workers - making use of the QFieldCloud SDK and spawned by the `worker_wrapper` -  to have the `REQUESTS_CA_BUNDLE` in their environment.

There is a new docker named volume, `custom_ca_certificates`, that is mounted in any case in the `app` and `worker_wrapper` services.  
For configuring a custom CA used by the app and workers during outgoing connections using the `requests` lib, a `custom_ca.crt` has to be placed in that directory.

Sister PR of https://github.com/opengisch/qfieldcloud-sdk-python/pull/102 for enabling the SDK to make use of this `REQUESTS_CA_BUNDLE` env var.