### PR TITLE
feat: add current subscription retrieval endpoint

### DIFF
--- a/docker-app/qfieldcloud/core/urls.py
+++ b/docker-app/qfieldcloud/core/urls.py
@@ -14,6 +14,7 @@ from qfieldcloud.core.views import (
 )
 from qfieldcloud.core.views.accounts_views import resend_confirmation_email
 from qfieldcloud.filestorage.urls import urlpatterns as filestorage_urlpatterns
+from qfieldcloud.subscription.urls import urlpatterns as subscription_urlpatterns
 
 router = DefaultRouter()
 router.register(r"projects", projects_views.ProjectViewSet, basename="project")
@@ -43,6 +44,7 @@ organizations/<str:organization_name>/teams/<str:team_name>/members/
 
 urlpatterns = [
     *filestorage_urlpatterns,
+    *subscription_urlpatterns,
     path("projects/public/", projects_views.PublicProjectsListView.as_view()),
     path("", include(router.urls)),
     path("users/", users_views.ListUsersView.as_view()),

--- a/docker-app/qfieldcloud/core/views/accounts_views.py
+++ b/docker-app/qfieldcloud/core/views/accounts_views.py
@@ -1,9 +1,12 @@
 from allauth.account.models import EmailAddress
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth import get_user_model
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
+
+User = get_user_model()
 
 
 def redirect_to_referer_or_view(

--- a/docker-app/qfieldcloud/subscription/serializers.py
+++ b/docker-app/qfieldcloud/subscription/serializers.py
@@ -1,0 +1,34 @@
+from rest_framework import serializers
+
+from qfieldcloud.subscription.models import CurrentSubscription
+
+
+class CurrentSubscriptionSerializer(serializers.ModelSerializer):
+    plan_display_name = serializers.CharField(source="plan.display_name")
+    storage_used_bytes = serializers.FloatField(source="account.storage_used_bytes")
+
+    def get_storage_used_bytes(self, obj):
+        return obj.account.storage_used_bytes
+
+    class Meta:
+        model = CurrentSubscription
+        fields = (
+            "uuid",
+            "plan_display_name",
+            "status",
+            "active_since",
+            "active_until",
+            # how many bytes of storage we have used
+            "storage_used_bytes",
+            # how many bytes of storage we have in the current subscription
+            "active_storage_total_bytes",
+        )
+        read_only_fields = (
+            "uuid",
+            "plan_display_name",
+            "status",
+            "active_since",
+            "active_until",
+            "storage_used_bytes",
+            "active_storage_total_bytes",
+        )

--- a/docker-app/qfieldcloud/subscription/tests/test_subscription_views.py
+++ b/docker-app/qfieldcloud/subscription/tests/test_subscription_views.py
@@ -1,0 +1,33 @@
+import logging
+
+from rest_framework import status
+from rest_framework.test import APITransactionTestCase
+
+from qfieldcloud.authentication.models import AuthToken
+from qfieldcloud.core.models import Person
+from qfieldcloud.core.tests.utils import setup_subscription_plans
+
+logging.disable(logging.CRITICAL)
+
+
+class QfcTestCase(APITransactionTestCase):
+    def setUp(self):
+        setup_subscription_plans()
+
+        # Create a user
+        self.user1 = Person.objects.create_user(username="user1", password="abc123")
+        self.token1 = AuthToken.objects.get_or_create(user=self.user1)[0]
+
+    def test_get_account_subscription(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
+        response = self.client.get(
+            f"/api/v1/subscriptions/{self.user1.username}/current/",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data["uuid"], str(self.user1.useraccount.current_subscription.uuid)
+        )
+        self.assertEqual(
+            response.data["plan_display_name"],
+            self.user1.useraccount.current_subscription.plan.display_name,
+        )

--- a/docker-app/qfieldcloud/subscription/urls.py
+++ b/docker-app/qfieldcloud/subscription/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from qfieldcloud.subscription.views import RetrieveCurrentSubscriptionView
+
+urlpatterns = [
+    path(
+        "subscriptions/<str:username>/current/",
+        RetrieveCurrentSubscriptionView.as_view(),
+        name="retrieve_current_subscription",
+    ),
+]

--- a/docker-app/qfieldcloud/subscription/views.py
+++ b/docker-app/qfieldcloud/subscription/views.py
@@ -1,0 +1,42 @@
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ObjectDoesNotExist
+from drf_spectacular.utils import extend_schema, extend_schema_view
+from rest_framework.generics import RetrieveAPIView
+from rest_framework.permissions import BasePermission, IsAuthenticated
+
+from qfieldcloud.core import permissions_utils
+from qfieldcloud.subscription.serializers import CurrentSubscriptionSerializer
+
+User = get_user_model()
+
+
+class RetrieveCurrentSubscriptionViewPermissions(BasePermission):
+    def has_permission(self, request, view):
+        username = permissions_utils.get_param_from_request(request, "username")
+
+        try:
+            user = User.objects.get(username=username)
+        except ObjectDoesNotExist:
+            return False
+
+        return permissions_utils.can_read_billing(request.user, user)
+
+
+@extend_schema_view(
+    get=extend_schema(
+        description="Retrieve the current subscription for a user or organization",
+    ),
+)
+class RetrieveCurrentSubscriptionView(RetrieveAPIView):
+    """Retrieve the current subscription for a user or organization."""
+
+    permission_classes = [
+        IsAuthenticated,
+        RetrieveCurrentSubscriptionViewPermissions,
+    ]
+    serializer_class = CurrentSubscriptionSerializer
+
+    def get_object(self):
+        username = self.kwargs["username"]
+        user = User.objects.get(username=username)
+        return user.useraccount.current_subscription


### PR DESCRIPTION
Add a new endpoint to retrieve user / organization subscription details

- Add `RetrieveCurrentSubscriptionView` to allow users to fetch subscription details.
- Add `CurrentSubscriptionSerializer` for serializing subscription data.

endpoint : `/api/v1/subscriptions/{username or organization name}/current`

```
$ curl https://localhost/api/v1/subscriptions/super_user/current | jq
{
    "uuid": "e9832476-a7a3-4789-96f5-753be6a21478",
    "plan_display_name": "Community",
    "status": "active_paid",
    "active_since": "2026-03-18T22:00:30+01:00",
    "active_until": null,
    "storage_used_bytes": 63677.0,
    "active_storage_total_bytes": 100000000
}
```