### PR TITLE
Fix migration to target only project files, instead of breaking existing packages

### DIFF
--- a/docker-app/qfieldcloud/filestorage/migrations/0006_alter_file_unique_together_and_more.py
+++ b/docker-app/qfieldcloud/filestorage/migrations/0006_alter_file_unique_together_and_more.py
@@ -65,7 +65,10 @@ def fix_duplicating_filenames_as_versions(apps, schema_editor):
     file_summaries_count = (
         File.objects.values("project_id", "name", "file_type")
         .annotate(count=models.Count("*"))
-        .filter(count__gt=1)
+        .filter(
+            file_type=FILE_TYPE_PROJECT_FILE,
+            count__gt=1,
+        )
         .count()
     )
 


### PR DESCRIPTION
If we run the migration without the introduced filter by package type, we will potentially break the packages of projects in such way, that we have to repackagee every single project for every single user that already had a package.

The reason is because we can easily have a file within a given project, name and file_type (used in the group by), but part of different package jobs. In this case we should not try to re-parent all the versions.

E.g. we have project p1 with the following project files:

- p1.qgz
- p1.gpkg

Then user u1 and u2 create their respective jobs.

In our database we will store:

| id | project | name       | file_type    | package_job_id |
|----|---------|------------|--------------|----------------|
| 1  | p1      | p1.qgz     | project_file | <null>         |
| 2  | p1      | p1.gpkg    | project_file | <null>         |
| 3  | p1      | p1.qgz     | package_file | u1_package_id  |
| 4  | p1      | data.gpkg  | package_file | u1_package_id  |
| 5  | p1      | p1.qgz     | package_file | u2_package_id  |
| 6  | p1      | data.gpkg  | package_file | u2_package_id  |

The group by project, name and type will should that file id 3 and 5, as well as 4 and 6 need to be merge, which is false, since they are part of different packages.

Then all versions of file 5 and 6 will be transferred to 3 and 4, which is wrong on two levels - it should not happen and package files should not have more than one version. What is even worse, the files 5 and 6 will be deleted, so when u2 tries to synchronize, their QField will receive an empty list of files and the project will not work at all.

Repackaging will be blocked if it is a gpkg only project and there if there is no data change, packaging is not triggered.

---

In theory the problem with duplicate files might happen also for package files, but since we are ensured by other levels of the application logic that we will never have two exactly the same names (or object storage prefixes, or versions) for package files, therefore we just filter them out from the query.

--- 

This was caught due to the "confirmation" query:
```select project_id, name, file_type, package_job_id, count(*) from filestorage_file where true group by 1, 2, 3, 4 having count(*) > 1 order by 1, 5;```