### PR TITLE
Make both QGIS `3.44.10` to `4.0.2` version available

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,8 +151,25 @@ services:
       network: host
       args:
         DEBUG_BUILD: ${DEBUG}
+        UBUNTU_VERSION: noble
+        QGIS_REPOSITORY: ubuntu-ltr
+        QGIS_VERSION: 1:3.44.10+40noble
     tty: true
-    command: bash -c "echo QGIS built"
+    command: bash -c "echo QGIS3 built"
+    logging: *default-logging
+    stop_grace_period: 15m
+
+  qgis4:
+    build:
+      context: ./docker-qgis
+      network: host
+      args:
+        DEBUG_BUILD: ${DEBUG}
+        UBUNTU_VERSION: resolute
+        QGIS_REPOSITORY: debian
+        QGIS_VERSION: 1:4.0.2+44resolute
+    tty: true
+    command: bash -c "echo QGIS4 built"
     logging: *default-logging
     stop_grace_period: 15m
 

--- a/docker-qgis/Dockerfile
+++ b/docker-qgis/Dockerfile
@@ -99,6 +99,8 @@ ENV XDG_RUNTIME_DIR=/root
 # allow local development for `libqfieldsync`, requires `/libqfieldsync` to be a mounted host directory
 ENV PYTHONPATH=/libqfieldsync
 ENV PYTHONPATH=/qfieldcloud-sdk-python:${PYTHONPATH}
+ENV PYTHONPATH=/usr/share/qgis/python:${PYTHONPATH}
+
 # Fix for "error: the configured Python interpreter version (3.14) is newer than PyO3's maximum supported version (3.13)"
 ENV PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
 

--- a/docker-qgis/Dockerfile
+++ b/docker-qgis/Dockerfile
@@ -99,6 +99,8 @@ ENV XDG_RUNTIME_DIR=/root
 # allow local development for `libqfieldsync`, requires `/libqfieldsync` to be a mounted host directory
 ENV PYTHONPATH=/libqfieldsync
 ENV PYTHONPATH=/qfieldcloud-sdk-python:${PYTHONPATH}
+# Fix for "error: the configured Python interpreter version (3.14) is newer than PyO3's maximum supported version (3.13)"
+ENV PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
 
 # QFC specific variables
 # Controls whether libqfieldsync should log also to the QGIS message log

--- a/docker-qgis/Dockerfile
+++ b/docker-qgis/Dockerfile
@@ -1,5 +1,27 @@
-# NOTE if the ubuntu version is changed, also change it in `Suites:` in apt sources, and in `QGIS_VERSION`
-FROM ubuntu:noble
+# Usually the ARGs are passed via docker-compose.yml, but we set them here as well to have default values and to be able to build the image standalone without passing the args.
+
+# Base Ubuntu image
+ARG UBUNTU_VERSION=noble
+
+# QGIS repository to use, either `ubuntu-ltr` or `debian`
+ARG QGIS_REPOSITORY=ubuntu-ltr
+
+# Set QGIS version as in the ubuntu/debian repos.
+# Choose your version from here: https://debian.qgis.org/ubuntu-ltr/dists/noble/main/binary-amd64/Packages or https://debian.qgis.org/debian/dists/resolute/main/binary-amd64/Packages
+ARG QGIS_VERSION=1:3.44.10+40noble
+
+# Start from a basic Ubuntu image
+FROM ubuntu:${UBUNTU_VERSION}
+
+# Redeclare within the stage, otherwise the variables will not be available in the `RUN` commands.
+ARG UBUNTU_VERSION
+ARG QGIS_REPOSITORY
+ARG QGIS_VERSION
+
+# Print the values of the build arguments to verify they are correctly passed
+RUN echo "UBUNTU_VERSION=${UBUNTU_VERSION}"
+RUN echo "QGIS_REPOSITORY=${QGIS_REPOSITORY}"
+RUN echo "QGIS_VERSION=${QGIS_VERSION}"
 
 # Create the expected /io directory that is usually created via the `worker_wrapper`
 RUN mkdir -p /io
@@ -16,12 +38,14 @@ RUN apt-get update \
 RUN wget -q -O /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
 
 # Add QGIS repository
-RUN echo "Types: deb deb-src\n\
-URIs: https://qgis.org/ubuntu-ltr\n\
-Suites: noble\n\
-Architectures: amd64\n\
-Components: main\n\
-Signed-By: /etc/apt/keyrings/qgis-archive-keyring.gpg\n" > /etc/apt/sources.list.d/qgis.sources
+RUN cat > /etc/apt/sources.list.d/qgis.sources <<EOF
+Types: deb deb-src
+URIs: https://qgis.org/${QGIS_REPOSITORY}
+Suites: ${UBUNTU_VERSION}
+Architectures: amd64
+Components: main
+Signed-By: /etc/apt/keyrings/qgis-archive-keyring.gpg
+EOF
 
 # Disable annoying pip version check, we don't care if pip is slightly older
 ARG PIP_DISABLE_PIP_VERSION_CHECK=1
@@ -38,11 +62,6 @@ RUN apt-get update \
     glibc-tools \
     git \
     && rm -rf /var/lib/apt/lists/*
-
-
-# Set QGIS version as in the debian repos
-# Choose your version from here: https://debian.qgis.org/ubuntu-ltr/dists/noble/main/binary-amd64/Packages
-ARG QGIS_VERSION=1:3.44.10+40noble
 
 # Install QGIS dependencies
 RUN apt-get update \


### PR DESCRIPTION
Unfortunately QGIS 4 is not built for ubuntu 24.04 noble and we have to push the base image too. This needs extensive testing before pushing forward.

Fix #1533 

Waits on https://github.com/opengisch/QFieldCloud/pull/1631