### PR TITLE
feat: allow organization members to view current subscription

### DIFF
--- a/docker-app/qfieldcloud/core/permissions_utils.py
+++ b/docker-app/qfieldcloud/core/permissions_utils.py
@@ -756,6 +756,23 @@ def can_read_billing(user: QfcUser, account: QfcUser) -> bool:
         return False
 
 
+def can_read_current_subscription(user: QfcUser, account: QfcUser) -> bool:
+    if user_eq(user, account):
+        return True
+
+    if account.is_organization:
+        return user_has_organization_role_origins(
+            user,
+            account,
+            [
+                OrganizationQueryset.RoleOrigins.ORGANIZATIONOWNER,
+                OrganizationQueryset.RoleOrigins.ORGANIZATIONMEMBER,
+            ],
+        )
+    else:
+        return False
+
+
 def can_change_additional_storage(user: QfcUser, subscription: Subscription) -> bool:
     if not subscription.plan.is_storage_modifiable:
         return False

--- a/docker-app/qfieldcloud/subscription/tests/test_subscription_views.py
+++ b/docker-app/qfieldcloud/subscription/tests/test_subscription_views.py
@@ -4,7 +4,7 @@ from rest_framework import status
 from rest_framework.test import APITransactionTestCase
 
 from qfieldcloud.authentication.models import AuthToken
-from qfieldcloud.core.models import Person
+from qfieldcloud.core.models import Organization, OrganizationMember, Person
 from qfieldcloud.core.tests.utils import setup_subscription_plans
 
 logging.disable(logging.CRITICAL)
@@ -14,9 +14,25 @@ class QfcTestCase(APITransactionTestCase):
     def setUp(self):
         setup_subscription_plans()
 
-        # Create a user
         self.user1 = Person.objects.create_user(username="user1", password="abc123")
+        self.user2 = Person.objects.create_user(username="user2", password="abc123")
+        self.user3 = Person.objects.create_user(username="user3", password="abc123")
         self.token1 = AuthToken.objects.get_or_create(user=self.user1)[0]
+        self.token2 = AuthToken.objects.get_or_create(user=self.user2)[0]
+        self.token3 = AuthToken.objects.get_or_create(user=self.user3)[0]
+
+        self.organization1 = Organization.objects.create(
+            username="organization1",
+            password="abc123",
+            type=2,
+            organization_owner=self.user1,
+        )
+
+        OrganizationMember.objects.create(
+            organization=self.organization1,
+            member=self.user2,
+            role=OrganizationMember.Roles.MEMBER,
+        )
 
     def test_get_account_subscription(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
@@ -31,3 +47,41 @@ class QfcTestCase(APITransactionTestCase):
             response.data["plan_display_name"],
             self.user1.useraccount.current_subscription.plan.display_name,
         )
+
+    def test_get_organization_subscription(self):
+        # check if owner can access the subscription
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
+        response = self.client.get(
+            f"/api/v1/subscriptions/{self.organization1.username}/current/",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data["uuid"],
+            str(self.organization1.useraccount.current_subscription.uuid),
+        )
+        self.assertEqual(
+            response.data["plan_display_name"],
+            self.organization1.useraccount.current_subscription.plan.display_name,
+        )
+
+        # check if member can access the subscription
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token2.key)
+        response = self.client.get(
+            f"/api/v1/subscriptions/{self.organization1.username}/current/",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data["uuid"],
+            str(self.organization1.useraccount.current_subscription.uuid),
+        )
+        self.assertEqual(
+            response.data["plan_display_name"],
+            self.organization1.useraccount.current_subscription.plan.display_name,
+        )
+
+        # check if other user cannot access the subscription
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token3.key)
+        response = self.client.get(
+            f"/api/v1/subscriptions/{self.organization1.username}/current/",
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/docker-app/qfieldcloud/subscription/views.py
+++ b/docker-app/qfieldcloud/subscription/views.py
@@ -19,7 +19,7 @@ class RetrieveCurrentSubscriptionViewPermissions(BasePermission):
         except ObjectDoesNotExist:
             return False
 
-        return permissions_utils.can_read_billing(request.user, user)
+        return permissions_utils.can_read_current_subscription(request.user, user)
 
 
 @extend_schema_view(


### PR DESCRIPTION
Previously we only allowed `organization owners` to retrieve current subscription now we allow organization memeber to retrieve current subscription.

- Added a new permission `can_read_current_subscription`
- Adjusted `RetrieveCurrentSubscriptionViewPermissions` to include the new permission function
- Added tests

Follow up for #1521 