### PR TITLE
fix:`PROCESS_PROJECTFILE` being triggered on shared_datasets projects

### DIFF
--- a/docker-app/qfieldcloud/filestorage/view_helpers.py
+++ b/docker-app/qfieldcloud/filestorage/view_helpers.py
@@ -136,7 +136,7 @@ def upload_project_file_version(
             update_fields = ["data_last_updated_at"]
 
             if get_attachment_dir_prefix(project, filename) == "" and (
-                is_qgis_file or project.the_qgis_file_name is not None
+                is_qgis_file or project.has_the_qgis_file
             ):
                 if is_qgis_file:
                     project.the_qgis_file_name = filename


### PR DESCRIPTION
When `the_qgis_file_name` is set to be an empty string (blank), and a gpgk file is uploaded, then a `PROCESS_PROJECTFILE` job is triggered which will cause it to fail. since it was resolving to True

- Use `has_the_qgis_file` property to correctly check if th project has qgis file