### PR TITLE
Hardening the WebDAV storage backend

### DIFF
--- a/docker-app/qfieldcloud/filestorage/backend.py
+++ b/docker-app/qfieldcloud/filestorage/backend.py
@@ -7,7 +7,9 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import ContentFile
 from django.core.files.storage import Storage
 from django.http import HttpResponse
+from requests.adapters import HTTPAdapter
 from storages.backends.s3 import S3Storage
+from urllib3.util.retry import Retry
 
 
 class QfcBackendStorageMixin(ABC):
@@ -63,6 +65,16 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
     Copyright (c) 2020, Mikhail Porokhovnichenko
     """
 
+    # Should this go into .env?
+    DEFAULT_TIMEOUT = (10, 60)
+    UPLOAD_TIMEOUT = (10, 600)
+    RETRY_TOTAL = 5
+    RETRY_BACKOFF_FACTOR = 1
+    RETRY_STATUS_FORCELIST = (429, 502, 503, 504)
+    RETRY_ALLOWED_METHODS = frozenset(
+        ["HEAD", "GET", "PUT", "DELETE", "MKCOL", "PROPFIND"]
+    )
+
     def __init__(self, **options):
         self.requests = self.get_requests_session(**options)
 
@@ -91,11 +103,30 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
 
         return True
 
-    def get_requests_session(self, **kwargs) -> requests.Session:
+    def get_requests_session(self, **_kwargs) -> requests.Session:
         """
-        Creates a HTTP session for requesting webdav later.
+        Creates an HTTP session with retry and connection pooling.
         """
-        return requests.Session()
+        session = requests.Session()
+        retries = Retry(
+            total=self.RETRY_TOTAL,
+            backoff_factor=self.RETRY_BACKOFF_FACTOR,
+            status_forcelist=self.RETRY_STATUS_FORCELIST,
+            allowed_methods=self.RETRY_ALLOWED_METHODS,
+            respect_retry_after_header=True,
+            raise_on_status=False,
+        )
+        adapter = HTTPAdapter(max_retries=retries, pool_connections=10, pool_maxsize=20)
+        session.mount("https://", adapter)
+        session.mount("http://", adapter)
+        return session
+
+    def _timeout_for(self, method: str) -> tuple[int, int]:
+        """Returns the (connect, read) timeout to use for a given HTTP method."""
+        if method.lower() == "put":
+            return self.UPLOAD_TIMEOUT
+
+        return self.DEFAULT_TIMEOUT
 
     def perform_webdav_request(
         self, method: str, name: str, *args, **kwargs
@@ -111,6 +142,7 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
         """
         url = self.get_webdav_url(name)
         method = method.lower()
+        kwargs.setdefault("timeout", self._timeout_for(method))
 
         response = getattr(self.requests, method)(url, *args, **kwargs)
         response.raise_for_status()
@@ -139,7 +171,7 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
         """
         return self.public_url.rstrip("/") + "/" + name.lstrip("/")
 
-    def _open(self, name: str, mode: str = "rb") -> ContentFile:
+    def _open(self, name: str, mode: str = "rb") -> ContentFile:  # pylint: disable=unused-argument
         """Reads the content of a file from the configured webdav storage.
 
         Arguments:
@@ -149,8 +181,11 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
         Returns:
             Content of the requested file.
         """
-        content = self.perform_webdav_request("GET", name).content
-        return ContentFile(content, name)
+        response = self.perform_webdav_request("GET", name, stream=True)
+        return ContentFile(
+            b"".join(response.iter_content(chunk_size=8 * 1024 * 1024)),
+            name,
+        )
 
     def _save(self, name: str, content: ContentFile) -> str:
         """Saves a file on the configured webdav storage.
@@ -174,8 +209,11 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
         return name
 
     def make_collection(self, name: str) -> None:
-        """Creates a so-called collection on the configured webdav storage for a file.
-        Typically creates parent folders if not existing.
+        """Creates parent collections (folders) for a file on the webdav server.
+
+        Sends MKCOL for each parent. Treats 405 (URL already mapped) and 409
+        as success, so the loop is idempotent and tolerant of servers that
+        use 409 loosely for "already exists".
 
         Arguments:
             name: relative path of the file on the webdav server.
@@ -184,10 +222,11 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
 
         for directory in name.split("/")[:-1]:
             col = os.path.join(coll_path, directory, "")
-            resp = self.requests.head(col)
+            resp = self.requests.request(
+                "MKCOL", col, timeout=self._timeout_for("MKCOL")
+            )
 
-            if not resp.ok:
-                resp = self.requests.request("MKCOL", col)
+            if resp.status_code not in (201, 405, 409):
                 resp.raise_for_status()
 
             coll_path = os.path.join(coll_path, directory)
@@ -195,13 +234,18 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
     def delete(self, name: str) -> None:
         """Deletes a file from a configured webdav storage.
 
+        Idempotent for 404/410, raises for other errors.
+
         Arguments:
             name: relative path of the file on the webdav server.
         """
         try:
             self.perform_webdav_request("DELETE", name)
-        except requests.HTTPError:
-            pass
+        except requests.HTTPError as exc:
+            if exc.response is not None and exc.response.status_code in (404, 410):
+                return
+
+            raise
 
     def exists(self, name: str) -> bool:
         """Checks if a file exists on a configured webdav storage.
@@ -209,15 +253,28 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
         Arguments:
             name: relative path of the file on the webdav server.
 
+        Raises:
+            IOError: when the server is unreachable or returns a status that
+                is neither a clear hit (2xx) nor a clear miss (404/410).
+
         Returns:
-            True if exists, False if not.
+            True if the file exists, False if not.
         """
+        url = self.get_webdav_url(name)
         try:
-            self.perform_webdav_request("HEAD", name)
-        except requests.exceptions.HTTPError:
+            resp = self.requests.head(url, timeout=self._timeout_for("HEAD"))
+        except requests.exceptions.RequestException as exc:
+            raise IOError(f"WebDAV exists() network error for {name!r}: {exc}") from exc
+
+        if 200 <= resp.status_code < 300:
+            return True
+
+        if resp.status_code in (404, 410):
             return False
 
-        return True
+        raise IOError(
+            f"WebDAV exists() got unexpected status {resp.status_code} for {name!r}"
+        )
 
     def size(self, name: str) -> int:
         """Returns the size of a file on a configured webdav storage.
@@ -235,10 +292,10 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
             return int(
                 self.perform_webdav_request("HEAD", name).headers["content-length"]
             )
-        except (ValueError, requests.exceptions.HTTPError):
-            raise IOError("Unable get size for %s" % name)
+        except (ValueError, requests.exceptions.HTTPError) as exc:
+            raise IOError(f"Unable to get size for {name}") from exc
 
-    def url(self, name: str, **kwargs) -> str:  # type: ignore
+    def url(self, name: str, **_kwargs) -> str:  # type: ignore
         """Returns the URL of a file from the configured webdav storage.
 
         Arguments:

--- a/docker-app/qfieldcloud/filestorage/backend.py
+++ b/docker-app/qfieldcloud/filestorage/backend.py
@@ -4,10 +4,28 @@ from abc import ABC
 
 import requests
 from django.core.exceptions import ImproperlyConfigured
-from django.core.files.base import ContentFile
+from django.core.files.base import ContentFile, File
 from django.core.files.storage import Storage
 from django.http import HttpResponse
+from requests.adapters import HTTPAdapter
+from rest_framework import status
 from storages.backends.s3 import S3Storage
+from urllib3.util.retry import Retry
+
+# WebDAV request timeouts (connect, read) in seconds
+DEFAULT_TIMEOUT = (10, 60)
+UPLOAD_TIMEOUT = (10, 600)
+
+# Retry configuration
+RETRY_TOTAL = 5
+RETRY_BACKOFF_FACTOR = 1
+RETRY_STATUS_FORCELIST = (
+    status.HTTP_429_TOO_MANY_REQUESTS,
+    status.HTTP_502_BAD_GATEWAY,
+    status.HTTP_503_SERVICE_UNAVAILABLE,
+    status.HTTP_504_GATEWAY_TIMEOUT,
+)
+RETRY_ALLOWED_METHODS = frozenset(["HEAD", "GET", "PUT", "DELETE", "MKCOL", "PROPFIND"])
 
 
 class QfcBackendStorageMixin(ABC):
@@ -91,11 +109,30 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
 
         return True
 
-    def get_requests_session(self, **kwargs) -> requests.Session:
+    def get_requests_session(self, **_kwargs) -> requests.Session:
         """
-        Creates a HTTP session for requesting webdav later.
+        Creates an HTTP session with retry and connection pooling.
         """
-        return requests.Session()
+        session = requests.Session()
+        retries = Retry(
+            total=RETRY_TOTAL,
+            backoff_factor=RETRY_BACKOFF_FACTOR,
+            status_forcelist=RETRY_STATUS_FORCELIST,
+            allowed_methods=RETRY_ALLOWED_METHODS,
+            respect_retry_after_header=True,
+            raise_on_status=False,
+        )
+        adapter = HTTPAdapter(max_retries=retries, pool_connections=10, pool_maxsize=20)
+        session.mount("https://", adapter)
+        session.mount("http://", adapter)
+        return session
+
+    def _timeout_for(self, method: str) -> tuple[int, int]:
+        """Returns the (connect, read) timeout to use for a given HTTP method."""
+        if method.lower() == "put":
+            return UPLOAD_TIMEOUT
+
+        return DEFAULT_TIMEOUT
 
     def perform_webdav_request(
         self, method: str, name: str, *args, **kwargs
@@ -111,6 +148,7 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
         """
         url = self.get_webdav_url(name)
         method = method.lower()
+        kwargs.setdefault("timeout", self._timeout_for(method))
 
         response = getattr(self.requests, method)(url, *args, **kwargs)
         response.raise_for_status()
@@ -139,18 +177,24 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
         """
         return self.public_url.rstrip("/") + "/" + name.lstrip("/")
 
-    def _open(self, name: str, mode: str = "rb") -> ContentFile:
-        """Reads the content of a file from the configured webdav storage.
+    def _open(self, name: str, mode: str = "rb") -> File:  # pylint: disable=unused-argument
+        """Reads file from webdav storage, streaming to minimize memory usage.
+
+        Uses stream=True to avoid loading large files entirely into RAM,
+        critical for handling large GeoPackage files. The raw response stream
+        is decoded on the fly to handle gzip/deflate compression.
 
         Arguments:
             name: relative path of the file on the webdav server.
             mode: opening mode (default: "rb").
 
         Returns:
-            Content of the requested file.
+            File object streaming from webdav without loading into memory.
         """
-        content = self.perform_webdav_request("GET", name).content
-        return ContentFile(content, name)
+        response = self.perform_webdav_request("GET", name, stream=True)
+        # Ensure raw stream decompresses gzip/deflate on the fly
+        response.raw.decode_content = True
+        return File(response.raw, name=name)  # type: ignore[arg-type]
 
     def _save(self, name: str, content: ContentFile) -> str:
         """Saves a file on the configured webdav storage.
@@ -174,8 +218,11 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
         return name
 
     def make_collection(self, name: str) -> None:
-        """Creates a so-called collection on the configured webdav storage for a file.
-        Typically creates parent folders if not existing.
+        """Creates parent collections (folders) for a file on the webdav server.
+
+        Sends MKCOL for each parent. Treats 405 (URL already mapped) and 409
+        as success, so the loop is idempotent and tolerant of servers that
+        use 409 loosely for "already exists".
 
         Arguments:
             name: relative path of the file on the webdav server.
@@ -184,10 +231,11 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
 
         for directory in name.split("/")[:-1]:
             col = os.path.join(coll_path, directory, "")
-            resp = self.requests.head(col)
+            resp = self.requests.request(
+                "MKCOL", col, timeout=self._timeout_for("MKCOL")
+            )
 
-            if not resp.ok:
-                resp = self.requests.request("MKCOL", col)
+            if resp.status_code not in (201, 405, 409):
                 resp.raise_for_status()
 
             coll_path = os.path.join(coll_path, directory)
@@ -195,13 +243,18 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
     def delete(self, name: str) -> None:
         """Deletes a file from a configured webdav storage.
 
+        Idempotent for 404/410, raises for other errors.
+
         Arguments:
             name: relative path of the file on the webdav server.
         """
         try:
             self.perform_webdav_request("DELETE", name)
-        except requests.HTTPError:
-            pass
+        except requests.HTTPError as exc:
+            if exc.response is not None and exc.response.status_code in (404, 410):
+                return
+
+            raise
 
     def exists(self, name: str) -> bool:
         """Checks if a file exists on a configured webdav storage.
@@ -209,15 +262,28 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
         Arguments:
             name: relative path of the file on the webdav server.
 
+        Raises:
+            IOError: when the server is unreachable or returns a status that
+                is neither a clear hit (2xx) nor a clear miss (404/410).
+
         Returns:
-            True if exists, False if not.
+            True if the file exists, False if not.
         """
+        url = self.get_webdav_url(name)
         try:
-            self.perform_webdav_request("HEAD", name)
-        except requests.exceptions.HTTPError:
+            resp = self.requests.head(url, timeout=self._timeout_for("HEAD"))
+        except requests.exceptions.RequestException as exc:
+            raise IOError(f"WebDAV exists() network error for {name!r}: {exc}") from exc
+
+        if 200 <= resp.status_code < 300:
+            return True
+
+        if resp.status_code in (404, 410):
             return False
 
-        return True
+        raise IOError(
+            f"WebDAV exists() got unexpected status {resp.status_code} for {name!r}"
+        )
 
     def size(self, name: str) -> int:
         """Returns the size of a file on a configured webdav storage.
@@ -235,10 +301,10 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
             return int(
                 self.perform_webdav_request("HEAD", name).headers["content-length"]
             )
-        except (ValueError, requests.exceptions.HTTPError):
-            raise IOError("Unable get size for %s" % name)
+        except (ValueError, requests.exceptions.HTTPError) as exc:
+            raise IOError(f"Unable to get size for {name}") from exc
 
-    def url(self, name: str, **kwargs) -> str:  # type: ignore
+    def url(self, name: str, **_kwargs) -> str:  # type: ignore
         """Returns the URL of a file from the configured webdav storage.
 
         Arguments:

--- a/docker-app/qfieldcloud/filestorage/tests/test_webdav.py
+++ b/docker-app/qfieldcloud/filestorage/tests/test_webdav.py
@@ -1,7 +1,10 @@
 import logging
 from io import StringIO
+from unittest import mock
 
+import requests
 from django.http import FileResponse
+from django.test import SimpleTestCase
 from rest_framework import status
 from rest_framework.test import APITransactionTestCase
 
@@ -14,6 +17,7 @@ from qfieldcloud.core.tests.mixins import QfcFilesTestCaseMixin
 from qfieldcloud.core.tests.utils import (
     setup_subscription_plans,
 )
+from qfieldcloud.filestorage.backend import QfcWebDavStorage
 
 logging.disable(logging.CRITICAL)
 
@@ -65,3 +69,249 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
         response = self._delete_file(self.u1, self.p1, "file.name")
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_old_version_is_downloadable_after_new_upload(self):
+        # Uploads two versions and verifies the latest is served by default
+        # while the older one is still retrievable via ?version=<uuid>.
+        self._upload_file(self.u1, self.p1, "file.name", StringIO("v1"))
+        first_version_id = str(self.p1.get_file("file.name").latest_version.id)
+
+        self._upload_file(self.u1, self.p1, "file.name", StringIO("v2"))
+
+        # Default download → latest version
+        response = self._download_file(self.u1, self.p1, "file.name")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(b"".join(response.streaming_content), b"v2")
+
+        # Explicit version download → first version still retrievable
+        response = self._download_file(
+            self.u1,
+            self.p1,
+            "file.name",
+            params={"version": first_version_id},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(b"".join(response.streaming_content), b"v1")
+
+    def test_delete_specific_version_keeps_other_versions(self):
+        # Uploads three versions, deletes the middle one by id,
+        # verifies the remaining two are intact and the latest is unchanged.
+        self._upload_file(self.u1, self.p1, "file.name", StringIO("v1"))
+        self._upload_file(self.u1, self.p1, "file.name", StringIO("v2"))
+        middle_version_id = str(self.p1.get_file("file.name").latest_version.id)
+        self._upload_file(self.u1, self.p1, "file.name", StringIO("v3"))
+
+        file = self.p1.get_file("file.name")
+        self.assertEqual(file.versions.count(), 3)
+        latest_before_delete = file.latest_version.id
+
+        response = self._delete_file(
+            self.u1,
+            self.p1,
+            "file.name",
+            params={"version": middle_version_id},
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        file = self.p1.get_file("file.name")
+        self.assertEqual(file.versions.count(), 2)
+        self.assertEqual(file.latest_version.id, latest_before_delete)
+
+        # Latest download still returns v3
+        response = self._download_file(self.u1, self.p1, "file.name")
+        self.assertEqual(b"".join(response.streaming_content), b"v3")
+
+    def test_delete_then_reupload_same_path_succeeds(self):
+        # Regression guard for the "create → delete → create" lifecycle.
+        # Verifies WebDAV does not leave the path in a state that blocks
+        # re-creation (e.g. a Nextcloud trash entry holding the name).
+        self._upload_file(self.u1, self.p1, "file.name", StringIO("v1"))
+
+        response = self._delete_file(self.u1, self.p1, "file.name")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(self.p1.project_files.count(), 0)
+
+        response = self._upload_file(self.u1, self.p1, "file.name", StringIO("v2"))
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(self.p1.project_files.count(), 1)
+        self.assertEqual(self.p1.get_file("file.name").versions.count(), 1)
+
+        response = self._download_file(self.u1, self.p1, "file.name")
+        self.assertEqual(b"".join(response.streaming_content), b"v2")
+
+
+def _make_storage() -> QfcWebDavStorage:
+    return QfcWebDavStorage(
+        webdav_url="http://webdav.example/",
+        public_url="http://webdav.example/",
+        basic_auth="user:pwd",
+    )
+
+
+class WebDavSessionConfigTests(SimpleTestCase):
+    def test_session_has_retry_adapter_with_webdav_methods(self):
+        storage = _make_storage()
+        adapter = storage.requests.get_adapter("https://webdav.example/")
+        retry = adapter.max_retries
+
+        self.assertEqual(retry.total, storage.RETRY_TOTAL)
+        for method in ("PUT", "DELETE", "MKCOL", "PROPFIND"):
+            self.assertIn(method, retry.allowed_methods)
+
+        for status_code in (429, 502, 503, 504):
+            self.assertIn(status_code, retry.status_forcelist)
+
+    def test_perform_webdav_request_sets_default_timeout(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "head") as head:
+            head.return_value = mock.Mock(status_code=200, headers={})
+            head.return_value.raise_for_status = mock.Mock()
+            storage.perform_webdav_request("HEAD", "/foo")
+            self.assertEqual(head.call_args.kwargs["timeout"], storage.DEFAULT_TIMEOUT)
+
+    def test_perform_webdav_request_uses_longer_timeout_for_put(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "put") as put:
+            put.return_value = mock.Mock(status_code=201, headers={})
+            put.return_value.raise_for_status = mock.Mock()
+            storage.perform_webdav_request("PUT", "/foo", data=b"x")
+            self.assertEqual(put.call_args.kwargs["timeout"], storage.UPLOAD_TIMEOUT)
+
+    def test_perform_webdav_request_respects_caller_timeout_override(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "put") as put:
+            put.return_value = mock.Mock(status_code=201, headers={})
+            put.return_value.raise_for_status = mock.Mock()
+            storage.perform_webdav_request("PUT", "/foo", data=b"x", timeout=42)
+            self.assertEqual(put.call_args.kwargs["timeout"], 42)
+
+
+class WebDavExistsTests(SimpleTestCase):
+    def test_exists_returns_true_on_200(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "head") as head:
+            head.return_value = mock.Mock(status_code=200)
+            self.assertTrue(storage.exists("/foo"))
+
+    def test_exists_returns_false_on_404(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "head") as head:
+            head.return_value = mock.Mock(status_code=404)
+            self.assertFalse(storage.exists("/foo"))
+
+    def test_exists_returns_false_on_410(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "head") as head:
+            head.return_value = mock.Mock(status_code=410)
+            self.assertFalse(storage.exists("/foo"))
+
+    def test_exists_raises_ioerror_on_500(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "head") as head:
+            head.return_value = mock.Mock(status_code=500)
+            with self.assertRaises(IOError):
+                storage.exists("/foo")
+
+    def test_exists_raises_ioerror_on_401(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "head") as head:
+            head.return_value = mock.Mock(status_code=401)
+            with self.assertRaises(IOError):
+                storage.exists("/foo")
+
+    def test_exists_raises_ioerror_on_network_error(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "head") as head:
+            head.side_effect = requests.exceptions.ConnectionError("boom")
+            with self.assertRaises(IOError):
+                storage.exists("/foo")
+
+    def test_exists_uses_default_timeout(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "head") as head:
+            head.return_value = mock.Mock(status_code=200)
+            storage.exists("/foo")
+            self.assertEqual(head.call_args.kwargs["timeout"], storage.DEFAULT_TIMEOUT)
+
+
+class WebDavDeleteTests(SimpleTestCase):
+    def test_delete_swallows_404(self):
+        storage = _make_storage()
+        err = requests.HTTPError(response=mock.Mock(status_code=404))
+        with mock.patch.object(storage, "perform_webdav_request", side_effect=err):
+            storage.delete("/foo")
+
+    def test_delete_swallows_410(self):
+        storage = _make_storage()
+        err = requests.HTTPError(response=mock.Mock(status_code=410))
+        with mock.patch.object(storage, "perform_webdav_request", side_effect=err):
+            storage.delete("/foo")
+
+    def test_delete_propagates_500(self):
+        storage = _make_storage()
+        err = requests.HTTPError(response=mock.Mock(status_code=500))
+        with mock.patch.object(storage, "perform_webdav_request", side_effect=err):
+            with self.assertRaises(requests.HTTPError):
+                storage.delete("/foo")
+
+    def test_delete_propagates_403(self):
+        storage = _make_storage()
+        err = requests.HTTPError(response=mock.Mock(status_code=403))
+        with mock.patch.object(storage, "perform_webdav_request", side_effect=err):
+            with self.assertRaises(requests.HTTPError):
+                storage.delete("/foo")
+
+
+class WebDavMakeCollectionTests(SimpleTestCase):
+    def test_make_collection_treats_201_as_success(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "request") as req:
+            req.return_value = mock.Mock(status_code=201)
+            req.return_value.raise_for_status = mock.Mock()
+            storage.make_collection("a/b/file.txt")
+            self.assertEqual(req.call_count, 2)
+            for call in req.call_args_list:
+                self.assertEqual(call.args[0], "MKCOL")
+
+    def test_make_collection_treats_405_as_already_exists(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "request") as req:
+            req.return_value = mock.Mock(status_code=405)
+            storage.make_collection("a/b/file.txt")
+            req.return_value.raise_for_status.assert_not_called()
+
+    def test_make_collection_accepts_409_defensively(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "request") as req:
+            req.return_value = mock.Mock(status_code=409)
+            storage.make_collection("a/b/file.txt")
+            req.return_value.raise_for_status.assert_not_called()
+
+    def test_make_collection_propagates_500(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "request") as req:
+            resp = mock.Mock(status_code=500)
+            resp.raise_for_status = mock.Mock(
+                side_effect=requests.HTTPError(response=resp)
+            )
+            req.return_value = resp
+            with self.assertRaises(requests.HTTPError):
+                storage.make_collection("a/b/file.txt")
+
+    def test_make_collection_propagates_401(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "request") as req:
+            resp = mock.Mock(status_code=401)
+            resp.raise_for_status = mock.Mock(
+                side_effect=requests.HTTPError(response=resp)
+            )
+            req.return_value = resp
+            with self.assertRaises(requests.HTTPError):
+                storage.make_collection("a/b/file.txt")
+
+    def test_make_collection_uses_default_timeout(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "request") as req:
+            req.return_value = mock.Mock(status_code=201)
+            storage.make_collection("a/file.txt")
+            self.assertEqual(req.call_args.kwargs["timeout"], storage.DEFAULT_TIMEOUT)

--- a/docker-app/qfieldcloud/filestorage/tests/test_webdav.py
+++ b/docker-app/qfieldcloud/filestorage/tests/test_webdav.py
@@ -1,7 +1,10 @@
 import logging
 from io import StringIO
+from unittest import mock
 
+import requests
 from django.http import FileResponse
+from django.test import SimpleTestCase
 from rest_framework import status
 from rest_framework.test import APITransactionTestCase
 
@@ -14,6 +17,7 @@ from qfieldcloud.core.tests.mixins import QfcFilesTestCaseMixin
 from qfieldcloud.core.tests.utils import (
     setup_subscription_plans,
 )
+from qfieldcloud.filestorage.backend import QfcWebDavStorage
 
 logging.disable(logging.CRITICAL)
 
@@ -65,3 +69,284 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
         response = self._delete_file(self.u1, self.p1, "file.name")
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_old_version_is_downloadable_after_new_upload(self):
+        # Uploads two versions and verifies the latest is served by default
+        # while the older one is still retrievable via ?version=<uuid>.
+        self._upload_file(self.u1, self.p1, "file.name", StringIO("v1"))
+        first_version_id = str(self.p1.get_file("file.name").latest_version.id)
+
+        self._upload_file(self.u1, self.p1, "file.name", StringIO("v2"))
+
+        # Default download → latest version
+        response = self._download_file(self.u1, self.p1, "file.name")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(b"".join(response.streaming_content), b"v2")
+
+        # Explicit version download → first version still retrievable
+        response = self._download_file(
+            self.u1,
+            self.p1,
+            "file.name",
+            params={"version": first_version_id},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(b"".join(response.streaming_content), b"v1")
+
+    def test_delete_specific_version_keeps_other_versions(self):
+        # Uploads three versions, deletes the middle one by id,
+        # verifies the remaining two are intact and the latest is unchanged.
+        self._upload_file(self.u1, self.p1, "file.name", StringIO("v1"))
+        self._upload_file(self.u1, self.p1, "file.name", StringIO("v2"))
+        middle_version_id = str(self.p1.get_file("file.name").latest_version.id)
+        self._upload_file(self.u1, self.p1, "file.name", StringIO("v3"))
+
+        file = self.p1.get_file("file.name")
+        self.assertEqual(file.versions.count(), 3)
+        latest_before_delete = file.latest_version.id
+
+        response = self._delete_file(
+            self.u1,
+            self.p1,
+            "file.name",
+            params={"version": middle_version_id},
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        file = self.p1.get_file("file.name")
+        self.assertEqual(file.versions.count(), 2)
+        self.assertEqual(file.latest_version.id, latest_before_delete)
+
+        # Latest download still returns v3
+        response = self._download_file(self.u1, self.p1, "file.name")
+        self.assertEqual(b"".join(response.streaming_content), b"v3")
+
+    def test_delete_then_reupload_same_path_succeeds(self):
+        # Regression guard for the "create → delete → create" lifecycle.
+        # Verifies WebDAV does not leave the path in a state that blocks
+        # re-creation (e.g. a Nextcloud trash entry holding the name).
+        self._upload_file(self.u1, self.p1, "file.name", StringIO("v1"))
+
+        response = self._delete_file(self.u1, self.p1, "file.name")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(self.p1.project_files.count(), 0)
+
+        response = self._upload_file(self.u1, self.p1, "file.name", StringIO("v2"))
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(self.p1.project_files.count(), 1)
+        self.assertEqual(self.p1.get_file("file.name").versions.count(), 1)
+
+        response = self._download_file(self.u1, self.p1, "file.name")
+        self.assertEqual(b"".join(response.streaming_content), b"v2")
+
+
+def _make_storage() -> QfcWebDavStorage:
+    return QfcWebDavStorage(
+        webdav_url="http://webdav.example/",
+        public_url="http://webdav.example/",
+        basic_auth="user:pwd",
+    )
+
+
+class WebDavSessionConfigTests(SimpleTestCase):
+    def test_session_has_retry_adapter_with_webdav_methods(self):
+        storage = _make_storage()
+        adapter = storage.requests.get_adapter("https://webdav.example/")
+        retry = adapter.max_retries
+
+        self.assertEqual(retry.total, storage.RETRY_TOTAL)
+        for method in ("PUT", "DELETE", "MKCOL", "PROPFIND"):
+            self.assertIn(method, retry.allowed_methods)
+
+        for status_code in (
+            status.HTTP_429_TOO_MANY_REQUESTS,
+            status.HTTP_502_BAD_GATEWAY,
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            status.HTTP_504_GATEWAY_TIMEOUT,
+        ):
+            self.assertIn(status_code, retry.status_forcelist)
+
+    def test_perform_webdav_request_sets_default_timeout(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "head") as head:
+            head.return_value = mock.Mock(status_code=200, headers={})
+            head.return_value.raise_for_status = mock.Mock()
+            storage.perform_webdav_request("HEAD", "/foo")
+            self.assertEqual(head.call_args.kwargs["timeout"], storage.DEFAULT_TIMEOUT)
+
+    def test_perform_webdav_request_uses_longer_timeout_for_put(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "put") as put:
+            put.return_value = mock.Mock(status_code=201, headers={})
+            put.return_value.raise_for_status = mock.Mock()
+            storage.perform_webdav_request("PUT", "/foo", data=b"x")
+            self.assertEqual(put.call_args.kwargs["timeout"], storage.UPLOAD_TIMEOUT)
+
+    def test_perform_webdav_request_respects_caller_timeout_override(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "put") as put:
+            put.return_value = mock.Mock(status_code=201, headers={})
+            put.return_value.raise_for_status = mock.Mock()
+            storage.perform_webdav_request("PUT", "/foo", data=b"x", timeout=42)
+            self.assertEqual(put.call_args.kwargs["timeout"], 42)
+
+
+class WebDavOpenTests(SimpleTestCase):
+    def test_open_uses_streaming_with_decode_content(self):
+        """Verify _open() uses streaming to minimize memory for large files.
+
+        Tests that:
+        1. stream=True is passed to perform_webdav_request
+        2. response.raw.decode_content is set to True (handles gzip/deflate)
+        3. Returns File object (not ContentFile) for true streaming
+        """
+        from django.core.files import File
+
+        storage = _make_storage()
+        with mock.patch.object(storage, "perform_webdav_request") as perform:
+            # Mock response with raw stream attribute
+            mock_response = mock.Mock()
+            mock_response.raw = mock.Mock()
+            perform.return_value = mock_response
+
+            result = storage._open("test.txt")
+
+            # Verify stream=True was passed
+            self.assertTrue(perform.call_args.kwargs.get("stream"))
+            # Verify decode_content flag was set for decompression
+            self.assertTrue(mock_response.raw.decode_content)
+            # Verify File (not ContentFile) is returned for true streaming
+            self.assertIsInstance(result, File)
+            # Verify the raw stream is wrapped
+            self.assertEqual(result.file, mock_response.raw)
+
+
+class WebDavExistsTests(SimpleTestCase):
+    def test_exists_returns_true_on_200(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "head") as head:
+            head.return_value = mock.Mock(status_code=200)
+            self.assertTrue(storage.exists("/foo"))
+
+    def test_exists_returns_false_on_404(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "head") as head:
+            head.return_value = mock.Mock(status_code=404)
+            self.assertFalse(storage.exists("/foo"))
+
+    def test_exists_returns_false_on_410(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "head") as head:
+            head.return_value = mock.Mock(status_code=410)
+            self.assertFalse(storage.exists("/foo"))
+
+    def test_exists_raises_ioerror_on_500(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "head") as head:
+            head.return_value = mock.Mock(status_code=500)
+            with self.assertRaises(IOError):
+                storage.exists("/foo")
+
+    def test_exists_raises_ioerror_on_401(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "head") as head:
+            head.return_value = mock.Mock(status_code=401)
+            with self.assertRaises(IOError):
+                storage.exists("/foo")
+
+    def test_exists_raises_ioerror_on_network_error(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "head") as head:
+            head.side_effect = requests.exceptions.ConnectionError("boom")
+            with self.assertRaises(IOError):
+                storage.exists("/foo")
+
+    def test_exists_uses_default_timeout(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "head") as head:
+            head.return_value = mock.Mock(status_code=200)
+            storage.exists("/foo")
+            self.assertEqual(head.call_args.kwargs["timeout"], storage.DEFAULT_TIMEOUT)
+
+
+class WebDavDeleteTests(SimpleTestCase):
+    def test_delete_swallows_404(self):
+        storage = _make_storage()
+        err = requests.HTTPError(response=mock.Mock(status_code=404))
+        with mock.patch.object(storage, "perform_webdav_request", side_effect=err):
+            storage.delete("/foo")
+
+    def test_delete_swallows_410(self):
+        storage = _make_storage()
+        err = requests.HTTPError(response=mock.Mock(status_code=410))
+        with mock.patch.object(storage, "perform_webdav_request", side_effect=err):
+            storage.delete("/foo")
+
+    def test_delete_propagates_500(self):
+        storage = _make_storage()
+        err = requests.HTTPError(response=mock.Mock(status_code=500))
+        with mock.patch.object(storage, "perform_webdav_request", side_effect=err):
+            with self.assertRaises(requests.HTTPError):
+                storage.delete("/foo")
+
+    def test_delete_propagates_403(self):
+        storage = _make_storage()
+        err = requests.HTTPError(response=mock.Mock(status_code=403))
+        with mock.patch.object(storage, "perform_webdav_request", side_effect=err):
+            with self.assertRaises(requests.HTTPError):
+                storage.delete("/foo")
+
+
+class WebDavMakeCollectionTests(SimpleTestCase):
+    def test_make_collection_treats_201_as_success(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "request") as req:
+            req.return_value = mock.Mock(status_code=201)
+            req.return_value.raise_for_status = mock.Mock()
+            storage.make_collection("a/b/file.txt")
+            self.assertEqual(req.call_count, 2)
+            for call in req.call_args_list:
+                self.assertEqual(call.args[0], "MKCOL")
+
+    def test_make_collection_treats_405_as_already_exists(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "request") as req:
+            req.return_value = mock.Mock(status_code=405)
+            storage.make_collection("a/b/file.txt")
+            req.return_value.raise_for_status.assert_not_called()
+
+    def test_make_collection_accepts_409_defensively(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "request") as req:
+            req.return_value = mock.Mock(status_code=409)
+            storage.make_collection("a/b/file.txt")
+            req.return_value.raise_for_status.assert_not_called()
+
+    def test_make_collection_propagates_500(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "request") as req:
+            resp = mock.Mock(status_code=500)
+            resp.raise_for_status = mock.Mock(
+                side_effect=requests.HTTPError(response=resp)
+            )
+            req.return_value = resp
+            with self.assertRaises(requests.HTTPError):
+                storage.make_collection("a/b/file.txt")
+
+    def test_make_collection_propagates_401(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "request") as req:
+            resp = mock.Mock(status_code=401)
+            resp.raise_for_status = mock.Mock(
+                side_effect=requests.HTTPError(response=resp)
+            )
+            req.return_value = resp
+            with self.assertRaises(requests.HTTPError):
+                storage.make_collection("a/b/file.txt")
+
+    def test_make_collection_uses_default_timeout(self):
+        storage = _make_storage()
+        with mock.patch.object(storage.requests, "request") as req:
+            req.return_value = mock.Mock(status_code=201)
+            storage.make_collection("a/file.txt")
+            self.assertEqual(req.call_args.kwargs["timeout"], storage.DEFAULT_TIMEOUT)


### PR DESCRIPTION
Implements the proposal from https://ideas.qfield.org/qfieldcloud-feature-requests/p/improve-resilience-of-qfcwebdavstorage-against-real-world-webdav-servers-without

### Context

`QfcWebDavStorage` works against the `bytemark/webdav:2.4` container in the dev stack, but breaks against modern WebDAV servers. Most visibly against Nextcloud/SabreDAV, where a file upload crashes with a 500 during `make_collection`: a HEAD-based existence check misreads SabreDAV's `405 Method Not Allowed` as "collection absent" and then crashes on the redundant MKCOL.

While fixing that, a few other robustness gaps became visible: no retries on transient `5xx`, no request timeouts, and `exists()` / `delete()` swallowing all HTTP errors — survivable on S3 thanks to bucket versioning, but risky on WebDAV where there is no such safety net.

This PR addresses all five issues, scoped to `QfcWebDavStorage`. No signature changes, no new dependencies, no changes to S3, migrations, CI matrix, or documentation. **The project's stance that S3 is the only production-supported backend remains unchanged; this only makes the WebDAV option more robust for self-hosters.**

### What changes

- **`make_collection`** sends `MKCOL` unconditionally and accepts `201/405/409` as success. Fixes the Nextcloud 500 crash, saves one round-trip per directory level, race-condition-free.
- **`get_requests_session`** configures a `urllib3.Retry` adapter for `429/502/503/504` with `MKCOL` and `PROPFIND` in `allowed_methods` (urllib3 defaults do not include them).
- **`perform_webdav_request`** applies method-aware timeouts via `_timeout_for()` — longer read timeout for `PUT` to accommodate server-side processing (virus scan, version snapshot).
- **`exists`** distinguishes "absent" (404/410) from "unreachable" (401/403/5xx, network errors), which now raise `IOError` instead of silently returning `False` and risking data overwrite in `Storage.save()`.
- **`delete`** is idempotent for 404/410 and raises all other HTTP errors.

### Tests

Three new integration tests added to the existing `QfcTestCase`, covering the versioning lifecycle (old-version download after new upload, targeted version delete, delete-then-reupload). They reuse the WebDAV service the existing integration tests already depend.

Four new mock-based `SimpleTestCase` classes add 21 unit tests for the resilience changes. They require no WebDAV service and no DB.

### Verification

Tests run locally against both backends by swapping the `"webdav"` entry in `STORAGES`: `bytemark/webdav:2.4` (current dev stack) and hosted Nextcloud (SabreDAV). Both pass.