### PR TITLE
Package cloud project using QGZ to save bandwidth

### DIFF
--- a/docker-app/qfieldcloud/core/tests/test_packages.py
+++ b/docker-app/qfieldcloud/core/tests/test_packages.py
@@ -4,7 +4,6 @@ import logging
 import os
 import tempfile
 import time
-import zipfile
 
 from django.http import FileResponse
 from django.test import tag
@@ -28,6 +27,7 @@ from qfieldcloud.core.models import (
 from qfieldcloud.core.tests.mixins import QfcFilesTestCaseMixin
 from qfieldcloud.core.tests.utils import (
     get_test_postgis_connection,
+    open_qgis_file,
     setup_subscription_plans,
     testdata_path,
     wait_for_project_ok_status,
@@ -258,12 +258,11 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
         )
 
         local_file = os.path.join(tempdir, "project_qfield.qgz")
-        with zipfile.ZipFile(local_file, "r") as qgz:
-            with qgz.open("project_qfield.qgs") as qgs:
-                self.assertEqual(
-                    qgs.readline().strip(),
-                    b"<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>",
-                )
+        with open_qgis_file(local_file) as f:
+            self.assertEqual(
+                f.readline().strip(),
+                b"<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>",
+            )
 
     def test_list_files_for_qfield_broken_file(self):
         self.upload_files(
@@ -347,11 +346,10 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
         )
 
         local_file = os.path.join(tempdir, "project_qfield.qgz")
-        with zipfile.ZipFile(local_file, "r") as qgz:
-            with qgz.open("project_qfield.qgs") as qgs:
-                for line in qgs:
-                    if 'name="theMapCanvas"' in str(line):
-                        return
+        with open_qgis_file(local_file) as f:
+            for line in f:
+                if 'name="theMapCanvas"' in str(line):
+                    return
 
     def test_download_project_with_broken_layer_datasources(self):
         self.upload_files_and_check_package(

--- a/docker-app/qfieldcloud/core/tests/test_packages.py
+++ b/docker-app/qfieldcloud/core/tests/test_packages.py
@@ -4,6 +4,7 @@ import logging
 import os
 import tempfile
 import time
+import zipfile
 
 from django.http import FileResponse
 from django.test import tag
@@ -207,8 +208,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             ],
             expected_files=[
                 "data.gpkg",
-                "project_qfield.qgs",
-                "project_qfield_attachments.zip",
+                "project_qfield.qgz",
             ],
         )
 
@@ -252,18 +252,18 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             ],
             expected_files=[
                 "data.gpkg",
-                "project_qfield.qgs",
-                "project_qfield_attachments.zip",
+                "project_qfield.qgz",
             ],
             tempdir=tempdir,
         )
 
-        local_file = os.path.join(tempdir, "project_qfield.qgs")
-        with open(local_file) as f:
-            self.assertEqual(
-                f.readline().strip(),
-                "<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>",
-            )
+        local_file = os.path.join(tempdir, "project_qfield.qgz")
+        with zipfile.ZipFile(local_file, "r") as qgz:
+            with qgz.open("project_qfield.qgs") as qgs:
+                self.assertEqual(
+                    qgs.readline().strip(),
+                    b"<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>",
+                )
 
     def test_list_files_for_qfield_broken_file(self):
         self.upload_files(
@@ -341,17 +341,17 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             ],
             expected_files=[
                 "data.gpkg",
-                "project_qfield.qgs",
-                "project_qfield_attachments.zip",
+                "project_qfield.qgz",
             ],
             tempdir=tempdir,
         )
 
-        local_file = os.path.join(tempdir, "project_qfield.qgs")
-        with open(local_file) as f:
-            for line in f:
-                if 'name="theMapCanvas"' in line:
-                    return
+        local_file = os.path.join(tempdir, "project_qfield.qgz")
+        with zipfile.ZipFile(local_file, "r") as qgz:
+            with qgz.open("project_qfield.qgs") as qgs:
+                for line in qgs:
+                    if 'name="theMapCanvas"' in str(line):
+                        return
 
     def test_download_project_with_broken_layer_datasources(self):
         self.upload_files_and_check_package(
@@ -366,8 +366,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             ],
             expected_files=[
                 "data.gpkg",
-                "project_broken_datasource_qfield.qgs",
-                "project_broken_datasource_qfield_attachments.zip",
+                "project_broken_datasource_qfield.qgz",
             ],
             invalid_layers=["surfacestructure_35131bca_337c_483b_b09e_1cf77b1dfb16"],
         )
@@ -389,8 +388,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             ],
             expected_files=[
                 "data.gpkg",
-                "project_qfield.qgs",
-                "project_qfield_attachments.zip",
+                "project_qfield.qgz",
             ],
         )
 
@@ -434,8 +432,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             ],
             expected_files=[
                 "data.gpkg",
-                "project_qfield.qgs",
-                "project_qfield_attachments.zip",
+                "project_qfield.qgz",
             ],
         )
 
@@ -555,8 +552,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             ],
             expected_files=[
                 "data.gpkg",
-                "project_qfield.qgs",
-                "project_qfield_attachments.zip",
+                "project_qfield.qgz",
             ],
         )
 
@@ -584,8 +580,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
                 project=self.project1,
                 expected_files=[
                     "data.gpkg",
-                    "project_qfield.qgs",
-                    "project_qfield_attachments.zip",
+                    "project_qfield.qgz",
                 ],
             )
 
@@ -625,8 +620,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
                 project=p1,
                 expected_files=[
                     "data.gpkg",
-                    "project_qfield.qgs",
-                    "project_qfield_attachments.zip",
+                    "project_qfield.qgz",
                 ],
             )
 
@@ -659,8 +653,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             ],
             expected_files=[
                 "data.gpkg",
-                "project_qfield.qgs",
-                "project_qfield_attachments.zip",
+                "project_qfield.qgz",
             ],
         )
 
@@ -686,8 +679,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             self.project1,
             [
                 "data.gpkg",
-                "project_qfield.qgs",
-                "project_qfield_attachments.zip",
+                "project_qfield.qgz",
             ],
         )
 
@@ -725,8 +717,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             ],
             expected_files=[
                 "data.gpkg",
-                "simple_bumblebees_qfield.qgs",
-                "simple_bumblebees_qfield_attachments.zip",
+                "simple_bumblebees_qfield.qgz",
                 "DCIM/1.jpg",
                 "DCIM/2.jpg",
             ],
@@ -785,7 +776,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
                 package_job=package_job_1,
             )
 
-            self.assertEquals(package_files_p1_qs.count(), 3)
+            self.assertEquals(package_files_p1_qs.count(), 2)
 
         # repackage the project for the same user.
         package_job_2 = repackage(self.project1, self.user1)
@@ -818,7 +809,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
                 package_job=package_job_2,
             )
 
-            self.assertEquals(package_files_p2_qs.count(), 3)
+            self.assertEquals(package_files_p2_qs.count(), 2)
 
             # make sure the other user's package files are there.
             other_user_package_files_qs = File.objects.filter(
@@ -827,7 +818,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
                 package_job=other_user_package_job,
             )
 
-            self.assertEquals(other_user_package_files_qs.count(), 3)
+            self.assertEquals(other_user_package_files_qs.count(), 2)
 
     def test_needs_repackaging(self):
         # 0. Create two users, where one owns the project and the other is a project collaborator.
@@ -870,8 +861,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             p1,
             [
                 "data.gpkg",
-                "project_qfield.qgs",
-                "project_qfield_attachments.zip",
+                "project_qfield.qgz",
             ],
         )
         wait_for_project_ok_status(p1)
@@ -889,8 +879,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             p1,
             [
                 "data.gpkg",
-                "project_qfield.qgs",
-                "project_qfield_attachments.zip",
+                "project_qfield.qgz",
             ],
         )
         wait_for_project_ok_status(p1)
@@ -963,8 +952,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             p1,
             [
                 "data.gpkg",
-                "project_qfield.qgs",
-                "project_qfield_attachments.zip",
+                "project_qfield.qgz",
             ],
         )
         wait_for_project_ok_status(p1)
@@ -981,8 +969,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             p1,
             [
                 "data.gpkg",
-                "project_qfield.qgs",
-                "project_qfield_attachments.zip",
+                "project_qfield.qgz",
             ],
         )
         wait_for_project_ok_status(p1)

--- a/docker-app/qfieldcloud/core/tests/utils.py
+++ b/docker-app/qfieldcloud/core/tests/utils.py
@@ -1,9 +1,11 @@
 import io
 import os
 import tempfile
+import zipfile
 from datetime import timedelta
+from pathlib import Path
 from time import sleep
-from typing import IO, Iterable
+from typing import IO, Iterable, TextIO
 
 import psycopg2
 from django.conf import settings
@@ -207,3 +209,15 @@ def get_test_postgis_connection() -> psycopg2.extensions.connection:
     cursor.close()
 
     return conn
+
+
+def open_qgis_file(path: str | Path) -> TextIO:
+    path = Path(path)
+
+    if path.suffix.lower() == ".qgz":
+        with zipfile.ZipFile(path, "r") as qgz:
+            return qgz.open(f"{path.name[:-4]}.qgs")
+    elif path.suffix.lower() == ".qgs":
+        return open(path)
+
+    raise Exception("The QGIS project file could not be opened")

--- a/docker-app/qfieldcloud/core/tests/utils.py
+++ b/docker-app/qfieldcloud/core/tests/utils.py
@@ -211,13 +211,13 @@ def get_test_postgis_connection() -> psycopg2.extensions.connection:
     return conn
 
 
-def open_qgis_file(path: str | Path) -> TextIO:
-    path = Path(path)
+def open_qgis_file(filename: str | Path) -> TextIO:
+    filename = Path(filename)
 
-    if path.suffix.lower() == ".qgz":
-        with zipfile.ZipFile(path, "r") as qgz:
-            return qgz.open(f"{path.name[:-4]}.qgs")
-    elif path.suffix.lower() == ".qgs":
-        return open(path)
+    if filename.suffix.lower() == ".qgz":
+        with zipfile.ZipFile(filename, "r") as qgz:
+            return qgz.open(f"{filename.stem}.qgs")
+    elif filename.suffix.lower() == ".qgs":
+        return open(filename)
 
     raise Exception("The QGIS project file could not be opened")

--- a/docker-qgis/qfc_worker/commands/package.py
+++ b/docker-qgis/qfc_worker/commands/package.py
@@ -111,7 +111,7 @@ def call_libqfieldsync_packager(
     logger.info("Packaging…")
 
     the_packaged_qgis_filename = package_dir.joinpath(
-        f"{the_qgis_file_name.stem}_qfield.qgs"
+        f"{the_qgis_file_name.stem}_qfield.qgz"
     )
     offline_converter = OfflineConverter(
         project,

--- a/docker-qgis/requirements_internal.txt
+++ b/docker-qgis/requirements_internal.txt
@@ -1,3 +1,3 @@
 # NOTE dependency versions should be defined in the `*.tar.gz` format, not `git+https://` to make `wheel` happy
-libqfieldsync @ git+https://github.com/opengisch/libqfieldsync@6eeff164d28b899b997b0dcee14977781b6a0e7e
+libqfieldsync @ git+https://github.com/opengisch/libqfieldsync@973479e6e1ecffc566063f3b65fadec7ab150119
 xlsform2qgis @ git+https://github.com/opengisch/xlsform2qgis@ab8f8014ea4465a454f709f733fcd173dd5bdd24

--- a/docker-qgis/tests/test_qgis.py
+++ b/docker-qgis/tests/test_qgis.py
@@ -30,7 +30,7 @@ class QfcTestCase(unittest.TestCase):
 
         files = os.listdir(output_directory)
 
-        self.assertIn("project_qfield.qgs", files)
+        self.assertIn("project_qfield.qgz", files)
         self.assertIn("france_parts_shape.shp", files)
         self.assertIn("france_parts_shape.dbf", files)
         self.assertIn("curved_polys.gpkg", files)


### PR DESCRIPTION
I was debugging why a ~600kb project turned into a 1.4mb download when packaged by QFieldCloud. Turns out my source project was using the .qgz format while QFieldCloud packages using the .qgs format.

I'm proposing we move to .qgz, for two reasons.

- First, the file size of a .qgs is _exponentially_ larger. In this project I was looking at, the source project file fieldtm.qgz weights 44,215 bytes. The exported fieldtm_qfield.qgs (and its _attachments.zip sidecate) size is 884,950 bytes. That's a 20-fold increase. In my part of the world, it amounts extra seconds of waiting.

- Second, the .qgs always comes with the _attachments.zip sidecar, which forces _two file downloads_ instead of a single .qgz.

Members of the jury, I rest my case.