### PR TITLE
fix: change mounted repository for custom ca bundles

### DIFF
--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -1006,5 +1006,5 @@ QFIELDCLOUD_CUSTOM_CA_VOLUME_NAME = (
 )
 
 # Filename where optional custom CA certificate are stored.
-QFIELDCLOUD_CUSTOM_CA_DIR = "/etc/ssl/certs"
+QFIELDCLOUD_CUSTOM_CA_DIR = "/etc/ssl/custom_certs"
 QFIELDCLOUD_CUSTOM_CA_FILENAME = f"{QFIELDCLOUD_CUSTOM_CA_DIR}/custom_ca.crt"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     volumes:
       - static_volume:/usr/src/app/staticfiles
       - media_volume:/usr/src/app/mediafiles/
-      - custom_ca_certificates:/etc/ssl/certs/:ro
+      - custom_ca_certificates:/etc/ssl/custom_certs/:ro
     environment: &django-env
       DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS}
       DJANGO_USE_X_FORWARDED_HOST: ${DJANGO_USE_X_FORWARDED_HOST}
@@ -171,7 +171,7 @@ services:
       - media_volume:/usr/src/app/mediafiles/
       - transformation_grids:/transformation_grids
       - /var/run/docker.sock:/var/run/docker.sock
-      - custom_ca_certificates:/etc/ssl/certs/:ro
+      - custom_ca_certificates:/etc/ssl/custom_certs/:ro
       - ${TMP_DIRECTORY}:/tmp
     environment:
       <<: *django-env


### PR DESCRIPTION
Since `/etc/ssl/certs` is used for storing CAs trusted by the system, we should use an empty repository for custom CA bundles.