### PR TITLE
fix: clip seed extent to project CRS valid area before reprojection

### DIFF
--- a/docker-qgis/qfc_worker/utils.py
+++ b/docker-qgis/qfc_worker/utils.py
@@ -1034,14 +1034,22 @@ def save_project(
     extent = QgsRectangle()
 
     if ref_extent and ref_extent.isFinite():
-        transform = QgsCoordinateTransform(ref_extent.crs(), project.crs(), project)
+        safe_source_rect = QgsRectangle(ref_extent)
+        source_bounds = project.crs().bounds()
 
-        try:
-            extent = transform.transform(ref_extent)
-        except QgsCsException as err:
-            logging.warning(
-                f"Failed to transform project CRS {ref_extent.crs().authid()} bbox to project CRS {project.crs().authid()}. Error: {err}."
-            )
+        if not source_bounds.isEmpty():
+            safe_source_rect = safe_source_rect.intersect(source_bounds)
+
+        if not safe_source_rect.isEmpty():
+            transform = QgsCoordinateTransform(ref_extent.crs(), project.crs(), project)
+
+            try:
+                extent = transform.transform(safe_source_rect)
+            except QgsCsException as err:
+                logging.warning(
+                    f"Failed to transform {ref_extent.crs().authid()} bbox to {project.crs().authid()}. Error: {err}."
+                )
+                extent = QgsRectangle()
 
     def process_project_write(document: QDomDocument) -> None:
         nl = document.elementsByTagName("qgis")
@@ -1058,7 +1066,7 @@ def save_project(
         ms.setDestinationCrs(project.crs())
         ms.setOutputSize(QSize(500, 500))
 
-        if extent.isFinite():
+        if extent.isFinite() and not extent.isEmpty():
             ms.setExtent(extent)
 
         ms.writeXml(mapcanvas_node, document)

--- a/docker-qgis/qfc_worker/utils.py
+++ b/docker-qgis/qfc_worker/utils.py
@@ -1035,6 +1035,7 @@ def save_project(
 
     if ref_extent and ref_extent.isFinite():
         safe_source_rect = QgsRectangle(ref_extent)
+        # the CRS bounds are always in WGS 84 CRS, see https://qgis.org/pyqgis/latest/core/QgsCoordinateReferenceSystem.html#qgis.core.QgsCoordinateReferenceSystem.bounds
         source_bounds = project.crs().bounds()
 
         if not source_bounds.isEmpty():
@@ -1047,7 +1048,7 @@ def save_project(
                 extent = transform.transform(safe_source_rect)
             except QgsCsException as err:
                 logging.warning(
-                    f"Failed to transform {ref_extent.crs().authid()} bbox to {project.crs().authid()}. Error: {err}."
+                    f"Failed to transform {ref_extent.crs().authid()} bbox CRS to {project.crs().authid()} project CRS. Error: {err}."
                 )
                 extent = QgsRectangle()
 


### PR DESCRIPTION
The issue was that when we set the default extent on a newly created project, the follow-up `process_projectfile` job got stuck on "started" and never finished, the root cause is that the seed extent is stored in `EPSG:4326` as `(-180, -90, 180, 90)`, but the project is created in a different projection (`EPSG:3857`, Web Mercator). When we reprojected that rectangle from `4326` to `3857` before writing it into the project's map canvas, QGIS produced a finite but out-of-world rectangle the Y values came out around ±45 million meters, while Web Mercator is only valid up to ±20 million meters.  see [Projected bounds](https://epsg.io/3857)

Later, when `process_projectfile` tries to render the thumbnail for that extent, the XYZ basemap layer issued HTTP tile requests for tile coordinates that don't exist (outside the valid tile grid). Those requests hang / retry, the render never finishes.

before writing the extent, we clamp it to the project CRS's valid-use bounds (project.crs().bounds()), so the saved extent never extends beyond the area the destination CRS can actually represent.

QGIS python snippet :

```python
from qgis.core import (QgsCoordinateReferenceSystem as CRS,
                       QgsCoordinateTransform as T,
                       QgsCoordinateTransformContext as Ctx,
                       QgsRectangle as R)
tr = T(CRS("EPSG:4326"), CRS("EPSG:3857"), Ctx())

print("reprojected:", tr.transformBoundingBox(R(-180, -90, 180, 90)).toString(1))
print("valid world: -20037508.3,-20037508.3 : 20037508.3,20037508.3")
```

Output : 
```
reprojected: -20037508.3,-44927335.4 : 20037508.3,44927335.4
valid world: -20037508.3,-20037508.3 : 20037508.3,20037508.3
```
we can see **-44927335.4** 

