### PR TITLE
chore: replace `mc` with `rc` in the createbuckets local service

### DIFF
--- a/docker-createbuckets/Dockerfile
+++ b/docker-createbuckets/Dockerfile
@@ -6,8 +6,9 @@ RUN apt-get update \
     python3 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2025-03-12T17-29-24Z -o /usr/bin/mc
-RUN chmod +x /usr/bin/mc
+RUN curl -L https://github.com/rustfs/cli/releases/download/v0.1.12/rustfs-cli-linux-amd64-gnu-v0.1.12.tar.gz \
+    | tar -xz -C /usr/bin rc
+RUN chmod +x /usr/bin/rc
 
 COPY ./createbuckets.py /createbuckets.py
 RUN chmod +x /createbuckets.py

--- a/docker-createbuckets/createbuckets.py
+++ b/docker-createbuckets/createbuckets.py
@@ -37,25 +37,26 @@ for storage_name, storage_config in STORAGES.items():
     bucket_name = storage_config["OPTIONS"]["bucket_name"]
 
     subprocess.run(
-        f"/usr/bin/mc alias set {storage_name} {endpoint_url} {access_key} {secret_key}",
+        f"/usr/bin/rc alias set {storage_name} {endpoint_url} {access_key} {secret_key}",
         shell=True,
         check=True,
     )
 
     subprocess.run(
-        f"/usr/bin/mc mb --ignore-existing {storage_name}/{bucket_name}",
+        f"/usr/bin/rc mb --ignore-existing {storage_name}/{bucket_name}",
         shell=True,
+        check=True,
     )
 
     subprocess.run(
-        f"/usr/bin/mc anonymous set download {storage_name}/{bucket_name}/users",
+        f"/usr/bin/rc anonymous set public {storage_name}/{bucket_name}/users",
         shell=True,
         check=True,
     )
 
     # We should always enable versioning even for non-legacy storage, as we want to have soft delete on application level
     subprocess.run(
-        f"/usr/bin/mc version enable {storage_name}/{bucket_name}",
+        f"/usr/bin/rc version enable {storage_name}/{bucket_name}",
         shell=True,
         check=True,
     )


### PR DESCRIPTION
Since local QFieldCloud is making use of rustfs and not minio anymore, it might be more logic to create local buckets with rustfs cli with the `rc` command tool.