### PR TITLE
refactor: enhance storage usage display in `OrganizationAdmin`

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -1761,10 +1761,19 @@ class OrganizationAdmin(QFieldCloudModelAdmin):
 
     @admin.display(description=_("Storage"))
     def storage_usage__field(self, instance) -> str:
+        active_storage_total = filesizeformat10(
+            instance.useraccount.current_subscription.active_storage_total_bytes
+        )
         used_storage = filesizeformat10(instance.useraccount.storage_used_bytes)
-        free_storage = filesizeformat10(instance.useraccount.storage_free_bytes)
         used_storage_perc = instance.useraccount.storage_used_ratio * 100
-        return f"{used_storage} {free_storage} ({used_storage_perc:.2f}%)"
+        free_storage = filesizeformat10(instance.useraccount.storage_free_bytes)
+
+        return _("total: {}; used: {} ({:.2f}%); free: {}").format(
+            active_storage_total,
+            used_storage,
+            used_storage_perc,
+            free_storage,
+        )
 
     def save_formset(self, request, form, formset, change):
         for form_obj in formset:

--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -69,9 +69,9 @@ from qfieldcloud.core.models import (
     UserAccount,
 )
 from qfieldcloud.core.paginators import LargeTablePaginator
-from qfieldcloud.core.templatetags.filters import filesizeformat10
 from qfieldcloud.core.utils import get_file_storage_choices
 from qfieldcloud.core.utils2 import delta_utils, jobs, pg_service_file
+from qfieldcloud.core.utils2.storage import format_storage_usage
 from qfieldcloud.filestorage.backend import QfcS3Boto3Storage
 from qfieldcloud.filestorage.models import File
 from qfieldcloud.subscription.models import get_subscription_model
@@ -739,19 +739,7 @@ class PersonAdmin(QFieldCloudModelAdmin):
 
     @admin.display(description=_("Storage"))
     def storage_usage__field(self, instance) -> str:
-        active_storage_total = filesizeformat10(
-            instance.useraccount.current_subscription.active_storage_total_bytes
-        )
-        used_storage = filesizeformat10(instance.useraccount.storage_used_bytes)
-        used_storage_perc = instance.useraccount.storage_used_ratio * 100
-        free_storage = filesizeformat10(instance.useraccount.storage_free_bytes)
-
-        return _("total: {}; used: {} ({:.2f}%); free: {}").format(
-            active_storage_total,
-            used_storage,
-            used_storage_perc,
-            free_storage,
-        )
+        return format_storage_usage(instance.useraccount)
 
     def save_model(self, request, obj, form, change):
         # Set the password to the value in the field if it's changed.
@@ -1761,19 +1749,7 @@ class OrganizationAdmin(QFieldCloudModelAdmin):
 
     @admin.display(description=_("Storage"))
     def storage_usage__field(self, instance) -> str:
-        active_storage_total = filesizeformat10(
-            instance.useraccount.current_subscription.active_storage_total_bytes
-        )
-        used_storage = filesizeformat10(instance.useraccount.storage_used_bytes)
-        used_storage_perc = instance.useraccount.storage_used_ratio * 100
-        free_storage = filesizeformat10(instance.useraccount.storage_free_bytes)
-
-        return _("total: {}; used: {} ({:.2f}%); free: {}").format(
-            active_storage_total,
-            used_storage,
-            used_storage_perc,
-            free_storage,
-        )
+        return format_storage_usage(instance.useraccount)
 
     def save_formset(self, request, form, formset, change):
         for form_obj in formset:

--- a/docker-app/qfieldcloud/core/utils2/storage.py
+++ b/docker-app/qfieldcloud/core/utils2/storage.py
@@ -20,10 +20,12 @@ from django.db import transaction
 from django.http import FileResponse, HttpRequest
 from django.http.response import HttpResponse, HttpResponseBase
 from django.utils import timezone
+from django.utils.translation import gettext as _
 from mypy_boto3_s3.type_defs import ObjectIdentifierTypeDef
 
 import qfieldcloud.core.models
 import qfieldcloud.core.utils
+from qfieldcloud.core.templatetags.filters import filesizeformat10
 from qfieldcloud.core.utils2.audit import LogEntry, audit
 from qfieldcloud.filestorage.backend import QfcS3Boto3Storage
 from qfieldcloud.filestorage.utils import is_admin_restricted_file
@@ -850,3 +852,22 @@ def calculate_checksums(
         checksums.append(hasher.digest())
 
     return tuple(checksums)
+
+
+def format_storage_usage(useraccount: qfieldcloud.core.models.UserAccount) -> str:
+    """
+    Returns a string with the storage usage in a human readable format
+    """
+    active_storage_total = filesizeformat10(
+        useraccount.current_subscription.active_storage_total_bytes
+    )
+    used_storage = filesizeformat10(useraccount.storage_used_bytes)
+    used_storage_perc: float = useraccount.storage_used_ratio * 100
+    free_storage = filesizeformat10(useraccount.storage_free_bytes)
+
+    return _("total: {}; used: {} ({:.2f}%); free: {}").format(
+        active_storage_total,
+        used_storage,
+        used_storage_perc,
+        free_storage,
+    )


### PR DESCRIPTION
Change the storage usage display to be in a unified format accross `Organization` and `Person`

<img width="788" height="89" alt="image" src="https://github.com/user-attachments/assets/fd817a4d-1f6f-4a6e-8f8d-263567aebf93" />

