### PR TITLE
Bump qgis from 3.44.7 to 3.44.9

### DIFF
--- a/docker-qgis/Dockerfile
+++ b/docker-qgis/Dockerfile
@@ -17,7 +17,7 @@ RUN wget -O /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org
 
 # Add QGIS repository
 RUN echo "Types: deb deb-src\n\
-URIs: https://qgis.org/debian\n\
+URIs: https://qgis.org/ubuntu-ltr\n\
 Suites: noble\n\
 Architectures: amd64\n\
 Components: main\n\
@@ -41,8 +41,8 @@ RUN apt-get update \
 
 
 # Set QGIS version as in the debian repos
-# Choose your version from here: https://debian.qgis.org/debian/dists/noble/main/binary-amd64/Packages
-ARG QGIS_VERSION=1:3.44.7+40noble
+# Choose your version from here: https://debian.qgis.org/ubuntu-ltr/dists/noble/main/binary-amd64/Packages
+ARG QGIS_VERSION=1:3.44.9+40noble
 
 # Install QGIS dependencies
 RUN apt-get update \


### PR DESCRIPTION
We also have changed the source repository, as it turned out that `ubuntu` and `debian` repos no longer receive updates on `3.44.x`.

In future changes, once we change the base image, we will switch to QGIS 4.