### PR TITLE
Make the qgis worker Python code Qt6-ready

### DIFF
--- a/docker-qgis/qfc_worker/commands/apply_deltas.py
+++ b/docker-qgis/qfc_worker/commands/apply_deltas.py
@@ -698,7 +698,7 @@ def cleanup_backups(layer_paths: set[str]) -> bool:
 def get_pk_attr_name(layer: QgsVectorLayer) -> str:
     pk_attr_name: str = ""
 
-    if layer.type() != QgsMapLayer.VectorLayer:
+    if layer.type() != QgsMapLayer.LayerType.VectorLayer:
         raise DeltaException(f"Expected layer {layer.name()} to be a vector layer!")
 
     pk_indexes = layer.primaryKeyAttributes()
@@ -1018,10 +1018,12 @@ def compare_feature(
             if incoming_value is not None:
                 if isinstance(current_value, QDateTime):
                     incoming_value = QDateTime.fromString(
-                        incoming_value, Qt.ISODateWithMs
+                        incoming_value, Qt.DateFormat.ISODateWithMs
                     )
                 elif isinstance(current_value, QDate):
-                    incoming_value = QDate.fromString(incoming_value, Qt.ISODate)
+                    incoming_value = QDate.fromString(
+                        incoming_value, Qt.DateFormat.ISODate
+                    )
                 elif isinstance(current_value, QTime):
                     incoming_value = QTime.fromString(incoming_value)
 

--- a/docker-qgis/qfc_worker/commands/create_project.py
+++ b/docker-qgis/qfc_worker/commands/create_project.py
@@ -300,11 +300,11 @@ def create_basemap_layer(basemap_config: BasemapConfig) -> QgsRasterLayer | None
         pass
     elif style == BasemapStyle.GRAYSCALE_LIGHT:
         hue_saturation_filter.setGrayscaleMode(
-            QgsHueSaturationFilter.GrayscaleLightness
+            QgsHueSaturationFilter.GrayscaleMode.GrayscaleLightness
         )
     elif style == BasemapStyle.GRAYSCALE_DARK:
         hue_saturation_filter.setGrayscaleMode(
-            QgsHueSaturationFilter.GrayscaleLightness
+            QgsHueSaturationFilter.GrayscaleMode.GrayscaleLightness
         )
         hue_saturation_filter.setInvertColors(True)
     else:

--- a/docker-qgis/qfc_worker/commands/process_projectfile.py
+++ b/docker-qgis/qfc_worker/commands/process_projectfile.py
@@ -141,7 +141,7 @@ def _generate_thumbnail(
 
         return None
 
-    img = QImage(map_settings.outputSize(), QImage.Format_ARGB32)
+    img = QImage(map_settings.outputSize(), QImage.Format.Format_ARGB32)
     painter = QPainter(img)
     job = QgsMapRendererCustomPainterJob(map_settings, painter)
 

--- a/docker-qgis/qfc_worker/utils.py
+++ b/docker-qgis/qfc_worker/utils.py
@@ -38,7 +38,7 @@ from qgis.core import (
     QgsZipUtils,
 )
 from qgis.PyQt import QtCore, QtGui
-from qgis.PyQt.QtCore import QSize
+from qgis.PyQt.QtCore import QSize, QtMsgType
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtXml import QDomDocument
 from tabulate import tabulate
@@ -59,15 +59,15 @@ qgs_msglog_logger.setLevel(logging.DEBUG)
 
 def _qt_message_handler(mode, context, message):
     log_level = logging.DEBUG
-    if mode == QtCore.QtDebugMsg:
+    if mode == QtMsgType.QtDebugMsg:
         log_level = logging.DEBUG
-    elif mode == QtCore.QtInfoMsg:
+    elif mode == QtMsgType.QtInfoMsg:
         log_level = logging.INFO
-    elif mode == QtCore.QtWarningMsg:
+    elif mode == QtMsgType.QtWarningMsg:
         log_level = logging.WARNING
-    elif mode == QtCore.QtCriticalMsg:
+    elif mode == QtMsgType.QtCriticalMsg:
         log_level = logging.CRITICAL
-    elif mode == QtCore.QtFatalMsg:
+    elif mode == QtMsgType.QtFatalMsg:
         log_level = logging.FATAL
 
     qgs_stderr_logger.log(
@@ -90,19 +90,19 @@ def _write_log_message(message, tag, level):
 
     # in 3.16 it was Qgis.None, but since None is a reserved keyword, it was inaccessible
     try:
-        Qgis.NoLevel
+        Qgis.MessageLevel.NoLevel
     except Exception:
-        Qgis.NoLevel = 4
+        Qgis.MessageLevel.NoLevel = 4
 
-    if level == Qgis.NoLevel:
+    if level == Qgis.MessageLevel.NoLevel:
         log_level = logging.DEBUG
-    elif level == Qgis.Info:
+    elif level == Qgis.MessageLevel.Info:
         log_level = logging.INFO
-    elif level == Qgis.Success:
+    elif level == Qgis.MessageLevel.Success:
         log_level = logging.INFO
-    elif level == Qgis.Warning:
+    elif level == Qgis.MessageLevel.Warning:
         log_level = logging.WARNING
-    elif level == Qgis.Critical:
+    elif level == Qgis.MessageLevel.Critical:
         log_level = logging.CRITICAL
 
     qgs_msglog_logger.log(
@@ -654,7 +654,7 @@ def get_layers_data(project: QgsProject) -> dict[str, dict]:
             layer_error_summary = error.summary()
 
         wkb_type = None
-        if layer.type() == QgsMapLayer.VectorLayer:
+        if layer.type() == QgsMapLayer.LayerType.VectorLayer:
             wkb_type = layer.wkbType()
 
         crs = None
@@ -678,7 +678,7 @@ def get_layers_data(project: QgsProject) -> dict[str, dict]:
             data_provider_source = layer.dataProvider().uri().uri()
             data_provider_name = layer.dataProvider().name()
 
-        if layer.type() == QgsMapLayer.VectorLayer:
+        if layer.type() == QgsMapLayer.LayerType.VectorLayer:
             fields = []
 
             for field in layer.fields():


### PR DESCRIPTION
The Qt5->Qt6 transition requires some changes, that are backwards compatible to qt5. 

Those changes are required to move the QGIS worker container to use QGIS4 and Qt6.