### PR TITLE
Enable ruff rule B006 and fix all violations

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -2182,7 +2182,10 @@ class Delta(models.Model):
         return str(self.id) + ", project: " + str(self.project.id)
 
     @staticmethod
-    def get_status_summary(filters={}):
+    def get_status_summary(filters=None):
+        if filters is None:
+            filters = {}
+
         rows = (
             Delta.objects.filter(**filters)
             .values("last_status")

--- a/docker-app/qfieldcloud/core/permission_check.py
+++ b/docker-app/qfieldcloud/core/permission_check.py
@@ -6,7 +6,12 @@ from django.http.response import HttpResponse, HttpResponseForbidden
 from qfieldcloud.core import permissions_utils
 
 
-def permission_check(perm: str, check_args: list[str | Callable] = []) -> Callable:
+def permission_check(
+    perm: str, check_args: list[str | Callable] | None = None
+) -> Callable:
+    if check_args is None:
+        check_args = []
+
     perm_check = getattr(permissions_utils, perm)
 
     def decorator_wrapper(func: Callable):

--- a/docker-app/qfieldcloud/core/tests/test_delta.py
+++ b/docker-app/qfieldcloud/core/tests/test_delta.py
@@ -1221,11 +1221,17 @@ class QfcTestCase(APITransactionTestCase):
         delta_filename,
         final_values,
         token,
-        wait_status=["STATUS_PENDING", "STATUS_BUSY"],
-        failing_status=["STATUS_ERROR"],
+        wait_status=None,
+        failing_status=None,
         immediate_values=None,
         deltafile_id=None,
     ):
+        if failing_status is None:
+            failing_status = ["STATUS_ERROR"]
+
+        if wait_status is None:
+            wait_status = ["STATUS_PENDING", "STATUS_BUSY"]
+
         self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
 
         if delta_filename is not None:
@@ -1254,10 +1260,16 @@ class QfcTestCase(APITransactionTestCase):
         deltafile_id,
         final_values,
         token,
-        wait_status=["STATUS_PENDING", "STATUS_BUSY"],
-        failing_status=["STATUS_ERROR"],
+        wait_status=None,
+        failing_status=None,
         immediate_values=None,
     ):
+        if failing_status is None:
+            failing_status = ["STATUS_ERROR"]
+
+        if wait_status is None:
+            wait_status = ["STATUS_PENDING", "STATUS_BUSY"]
+
         self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
 
         uri = f"/api/v1/deltas/{project.id}/"

--- a/docker-app/qfieldcloud/core/utils2/jobs.py
+++ b/docker-app/qfieldcloud/core/utils2/jobs.py
@@ -16,9 +16,12 @@ def apply_deltas(
     user: "models.User",
     project_file: str,
     overwrite_conflicts: bool,
-    delta_ids: list[str] = [],
+    delta_ids: list[str] | None = None,
 ) -> list["models.ApplyJob"]:
     """Apply a deltas"""
+
+    if delta_ids is None:
+        delta_ids = []
 
     logger.info(
         f"Requested apply_deltas on {project} with {project_file}; overwrite_conflicts: {overwrite_conflicts}; delta_ids: {delta_ids}"

--- a/docker-qgis/qfc_worker/commands/apply_deltas.py
+++ b/docker-qgis/qfc_worker/commands/apply_deltas.py
@@ -610,7 +610,7 @@ def apply_deltas_without_transaction(
 
 def rollback_deltas(
     layers_by_id: dict[LayerId, QgsVectorLayer],
-    committed_layer_ids: set[LayerId] = set(),
+    committed_layer_ids: set[LayerId] | None = None,
 ) -> bool:
     """Rollback applied deltas by restoring the layer data source backup files.
 
@@ -623,6 +623,9 @@ def rollback_deltas(
         the project might be broken, but the old data is preserved in the
         backup files.
     """
+    if committed_layer_ids is None:
+        committed_layer_ids = set()
+
     is_success = True
     # we need to keep the backups of `committed_layer_ids` in case something goes wrong
     backups_to_remove_layer_ids = set(layers_by_id.keys()) - committed_layer_ids

--- a/ruff.toml
+++ b/ruff.toml
@@ -20,7 +20,10 @@ exclude = [
 target-version = "py310"
 
 [lint]
-extend-select = ["I"]
+extend-select = [
+    "I",        # isort
+    "B006",     # Mutable argument default
+]
 ignore = []
 
 [lint.mccabe]


### PR DESCRIPTION
## Summary

Based on #1575
Enable ruff rule B006 (mutable-argument-default) and fix all violations in the core/ directory.

## Changes
- Fix 8 mutable argument default violations:
  * permission_check.py: Use None instead of mutable list default
  * models.py: Use None instead of mutable dict default
  * test_delta.py: Use None instead of mutable list defaults (4 violations)
  * utils2/jobs.py: Use None instead of mutable list default
  * docker-qgis/qfc_worker/commands/apply_deltas.py: Use None instead of mutable set default
- Add proper type annotations (| None) for optional parameters
- Add missing blank lines after if blocks (flake8 compliance)

## Notes
All violations in core/ are now resolved. Future code that violates B006 will be caught by the linter.