### PR TITLE
doc: allow `/swagger.yaml` url in CORS settings

### DIFF
--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -985,7 +985,7 @@ CORS_ALLOWED_ORIGINS = parse_string_to_list(
 )
 
 # Only allow CORS on API + swagger endpoints - static files and pages are unaffected.
-CORS_URLS_REGEX = r"^/(api/.*|swagger/)$"
+CORS_URLS_REGEX = r"^/(api/.*|swagger(.yaml|/))$"
 
 # Whether to include credentials (cookies, authorization headers) in
 # cross-origin requests. Required when clients send auth tokens.


### PR DESCRIPTION
Previously, only the `/swagger/` URL was CORS-allowed, though the QField-docs tries to access the `/swagger.yaml` URL with swagger JS.

See [docs page](https://docs.qfield.org/reference/qfieldcloud/api/) + [docs Swagger JS implementation](https://raw.githubusercontent.com/opengisch/QField-docs/825fca4d411fe6b7a6e22fe88b1f77f9b4bfba44/documentation/reference/qfieldcloud/api.en.md).