### PR TITLE
fix: remove `parser_classes` from `ProjectViewSet`

### DIFF
--- a/docker-app/qfieldcloud/core/views/projects_views.py
+++ b/docker-app/qfieldcloud/core/views/projects_views.py
@@ -25,7 +25,7 @@ from qfieldcloud.subscription.exceptions import QuotaError
 from rest_framework import filters as drf_filters
 from rest_framework import generics, permissions, status, viewsets
 from rest_framework.decorators import action
-from rest_framework.parsers import JSONParser, MultiPartParser
+from rest_framework.parsers import MultiPartParser
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -116,7 +116,6 @@ class ProjectViewSet(viewsets.ModelViewSet):
     serializer_class = ProjectSerializer
     lookup_url_kwarg = "projectid"
     permission_classes = [permissions.IsAuthenticated, ProjectViewSetPermissions]
-    parser_classes = [JSONParser, MultiPartParser]
     pagination_class = pagination.QfcLimitOffsetPagination()
     filter_backends = [
         drf_filters.SearchFilter,


### PR DESCRIPTION
The CLI/SDK was failing to create projects since the `create_project` function in sdk see [sdk.py L510](https://github.com/opengisch/qfieldcloud-sdk-python/blob/cbad4a966007e5a447eaccee916576fe5185c8c0/qfieldcloud_sdk/sdk.py#L510) is sending a request with the content type `application/x-www-form-urlencoded`.

To fix this issue I removed the `parser_classes` since the default will include all three `JSONParser`, `MultiPartParser` and `FormParser` see [rest settings](https://github.com/encode/django-rest-framework/blob/22e231cf2f77b4cfe929de875d958b93916b1a8b/rest_framework/settings.py#L35)

Reproduced Using cli e.g:

```
qfieldcloud-cli create-project 'TestProject'
```