### PR TITLE
refactor: add a deprecation summary note to auth/providers endpoint

### DIFF
--- a/docker-app/qfieldcloud/authentication/views.py
+++ b/docker-app/qfieldcloud/authentication/views.py
@@ -128,6 +128,7 @@ class UserView(RetrieveAPIView):
 @extend_schema_view(
     get=extend_schema(
         description="Lists the available authentication providers.",
+        summary="This endpoint is deprecated and will be removed in the future. Please use `/server/info/` endpoint instead.",
         deprecated=True,
     ),
 )


### PR DESCRIPTION
To make it more noticable and easier to view in the swagger docs, I added a summary note to the view


<img width="1450" height="356" alt="image" src="https://github.com/user-attachments/assets/feca6e7d-e2c8-48ec-ba28-b4c1064699d0" />
