### PR TITLE
chore: Add more debug options within the app container

### DIFF
--- a/docker-app/Dockerfile
+++ b/docker-app/Dockerfile
@@ -69,7 +69,9 @@ COPY --from=build /usr/local/lib/python3.10/site-packages/ /usr/local/lib/python
 
 # install debug dependencies
 ARG DEBUG_BUILD
-RUN if [ "$DEBUG_BUILD" = "1" ]; then pip3 install debugpy ipython; fi
+
+RUN if [ "$DEBUG_BUILD" = "1" ]; then apt update && apt install -y gdb procps; fi
+RUN if [ "$DEBUG_BUILD" = "1" ]; then pip3 install debugpy ipython memray py-spy; fi
 
 # add app group
 RUN addgroup --system app && adduser --system app --ingroup app

--- a/docker-compose.override.local.yml
+++ b/docker-compose.override.local.yml
@@ -4,6 +4,14 @@ services:
     build:
       args:
         - DEBUG_BUILD=1
+
+    # TODO @suricactus: Most probably this needs to be removed once QF-5033 Bump Python to 3.14.1+in the Django image is merged
+    # required to allow `memray` to inspect memory usage of the app container
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - seccomp=unconfined
+
     ports:
       # allow direct access without nginx
       - ${DJANGO_DEV_PORT}:8000


### PR DESCRIPTION
`memray` and `py-spy` proved useful and it should be easy for us to enable them whenever needed. Adding them to the local dev container in debug mode will be handy to monitor how the Django app behaves.

Sample use locally:

```
py-spy top --pid $(pgrep -f ppid)
py-spy attach --pid $(pgrep -f ppid)

```