### PR TITLE
feat: Make the File and FileVersion Admin usable, meaningful, but only readonly

### DIFF
--- a/docker-app/qfieldcloud/filestorage/admin.py
+++ b/docker-app/qfieldcloud/filestorage/admin.py
@@ -1,11 +1,25 @@
+from typing import Any
+
 from django.contrib import admin
 
-from qfieldcloud.core.admin import qfc_admin_site
+from qfieldcloud.core.admin import QFieldCloudModelAdmin, qfc_admin_site
+from qfieldcloud.filestorage.models import File, FileVersion
 
-from .models import File, FileVersion
 
+class FileAdmin(QFieldCloudModelAdmin):
+    readonly_fields = [
+        "id",
+        "project",
+        "package_job",
+        "name",
+        "file_type",
+        "latest_version",
+        "latest_version_count",
+        "uploaded_at",
+        "uploaded_by",
+        "created_at",
+    ]
 
-class FileAdmin(admin.ModelAdmin):
     list_display = [
         "id",
         "project",
@@ -16,26 +30,67 @@ class FileAdmin(admin.ModelAdmin):
         "uploaded_by",
     ]
 
-    list_display_links = [
-        "project",
-        "latest_version",
-        "uploaded_by",
-    ]
+    search_fields = (
+        "name__istartswith",
+        "latest_version__etag__istartswith",
+        "uploaded_by__username__istartswith",
+    )
+
+    autocomplete_fields = ("latest_version",)
+
+    ordering = ("-uploaded_at",)
+
+    def has_add_permission(self, *_args: Any, **_kwargs: Any) -> bool:
+        return False
+
+    def has_change_permission(self, *_args: Any, **_kwargs: Any) -> bool:
+        return False
 
 
-class FileVersionAdmin(admin.ModelAdmin):
-    list_display = [
+class FileVersionAdmin(QFieldCloudModelAdmin):
+    readonly_fields = [
         "id",
         "file",
-        "md5sum",
+        "content",
+        "file_storage",
+        "md5sum_hex",
+        "etag",
         "size",
         "uploaded_at",
         "uploaded_by",
     ]
-    list_display_links = [
+
+    list_display = [
+        "id",
         "file",
+        "md5sum_hex",
+        "etag",
+        "size",
+        "uploaded_at",
         "uploaded_by",
     ]
+
+    search_fields = (
+        "file__name__istartswith",
+        "md5sum__icontains",
+        "etag__istartswith",
+        "uploaded_by__username__istartswith",
+    )
+
+    autocomplete_fields = ("file",)
+
+    ordering = ("-uploaded_at",)
+
+    def has_add_permission(self, *_args: Any, **_kwargs: Any) -> bool:
+        # TODO @suricactus: Add the possibility to upload files via Django admin, see https://app.clickup.com/t/2192114/QF-8215
+        return False
+
+    def has_change_permission(self, *_args: Any, **_kwargs: Any) -> bool:
+        return False
+
+    @admin.display(description="MD5 HEX Checksum")
+    def md5sum_hex(self, obj: FileVersion) -> str | None:
+        return obj.md5sum.hex()
 
 
 qfc_admin_site.register(File, FileAdmin)

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -677,7 +677,12 @@ QFIELDCLOUD_TEST_SKIP_VIEW_ADMIN_URLS = (
     "/admin/axes/accesslog/add/",
     "/admin/auditlog/logentry/add/",
     "/admin/account/emailaddress/admin/export_emails_to_csv/",
+    "/admin/filestorage/file/add/",
+    "/admin/filestorage/fileversion/add/",
 )
+
+# Admin sort URLs which will be skipped from checking if they return HTTP 200
+QFIELDCLOUD_TEST_SKIP_SORT_ADMIN_URLS = ("/admin/django_cron/cronjoblog/?o=4",)
 
 # Sets the default admin list view per page, the Django default is 100
 QFIELDCLOUD_ADMIN_LIST_PER_PAGE = 20
@@ -687,9 +692,6 @@ QFIELDCLOUD_ADMIN_EXACT_COUNT_LIMIT = 10000
 
 # Default limit for paginating data from views using QfcLimitOffsetPagination
 QFIELDCLOUD_API_DEFAULT_PAGE_LIMIT = 50
-
-# Admin sort URLs which will be skipped from checking if they return HTTP 200
-QFIELDCLOUD_TEST_SKIP_SORT_ADMIN_URLS = ("/admin/django_cron/cronjoblog/?o=4",)
 
 APPLY_DELTAS_LIMIT = 1000
 


### PR DESCRIPTION
Preivously the File and FileVersion admin were the bare minimum. Viewing/editing is practically unusable.

Now add a few more columns, sorting and search of the fields. The records display readonly. If one needs to upload a file, a dedicated view calling `FileVersion.add_version` must be developed.

Since each `File` instance is having the `latest_file_versions` field, then Django Admin is rendering a dropdown list of all available `FileVersion` records, which is obviously giving great strain on the server.


| before | after |
|-|-|
| <img width="3165" height="1658" alt="image" src="https://github.com/user-attachments/assets/45fb3801-6116-448c-8cbe-d9bf65acf58b" /> | <img width="3165" height="1658" alt="image" src="https://github.com/user-attachments/assets/0a1672ab-78b5-4216-b59d-278b115aab26" /> |
| <img width="3165" height="1658" alt="image" src="https://github.com/user-attachments/assets/f3e338c7-e9d4-466b-9ea0-074415815197" /> | <img width="3165" height="1658" alt="image" src="https://github.com/user-attachments/assets/ea0cd536-c78d-4981-8fff-c8ca0576973c" /> |
| <img width="3165" height="1658" alt="image" src="https://github.com/user-attachments/assets/ab8bdfbb-7981-41b8-b611-70e090d69e41" /> | <img width="3165" height="1658" alt="image" src="https://github.com/user-attachments/assets/5be7a414-bad2-4b48-9a3d-c37608df5c01" /> |
|  <img width="3165" height="1658" alt="image" src="https://github.com/user-attachments/assets/0d0fbde4-016f-4bed-b8fd-946ffe596d98" /> | <img width="3165" height="1658" alt="image" src="https://github.com/user-attachments/assets/44ef558d-1434-460f-9cf2-97cd1bd3254d" /> |

The clickable links on the left were useless, as they pointing to the File(Version) model, not to the foreign key.

This will be restored automtically as functionality once #1585 is merged.