### PR TITLE
Remove is_attachment_download_on_demand from the read-only fields within the ProjectSerializer

### DIFF
--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -221,7 +221,6 @@ class ProjectSerializer(serializers.ModelSerializer):
             "status",
             "user_role",
             "user_role_origin",
-            "is_attachment_download_on_demand",
             "file_storage_bytes",
         )
         model = Project


### PR DESCRIPTION
Discovered while trying to add a [x] on-demand attachments download checkbox within QFieldSync's cloud project properties dialog.