### PR TITLE
chore: Add ruff rule BLE001 to checks for except clauses that catch all exceptions

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -1035,12 +1035,12 @@ class SecretAdmin(QFieldCloudModelAdmin):
 
         try:
             project = Project.objects.get(id=project_id)
-        except Exception:
+        except Project.DoesNotExist:
             project = None
 
         try:
             organization = Organization.objects.get(id=organization_id)
-        except Exception:
+        except Organization.DoesNotExist:
             organization = None
 
         return {

--- a/docker-app/qfieldcloud/core/cron.py
+++ b/docker-app/qfieldcloud/core/cron.py
@@ -35,7 +35,8 @@ class ResendFailedInvitationsJob(CronJobBase):
             try:
                 send_invitation(invitation)
                 invitation_emails.append(invitation.email)
-            except Exception as err:
+            # Catch any exception `send_invitation` can raise, as we don't want the CRON to fail because of a single failed email sending.
+            except Exception as err:  # noqa: BLE001
                 logger.error(err)
 
         logger.info(

--- a/docker-app/qfieldcloud/core/management/commands/createuser.py
+++ b/docker-app/qfieldcloud/core/management/commands/createuser.py
@@ -36,6 +36,8 @@ class Command(BaseCommand):
                 print(f"User {username} has been successfully created\n")
             else:
                 print(f"User {username} already exists\n")
-        except Exception as e:
-            print("ERROR: Unable to create user\n%s\n" % e)
+
+        # Catch any other unknown error and print it
+        except Exception as err:  # noqa: BLE001
+            print("ERROR: Unable to create user\n%s\n" % err)
             exit(1)

--- a/docker-app/qfieldcloud/core/tests/test_delta.py
+++ b/docker-app/qfieldcloud/core/tests/test_delta.py
@@ -133,14 +133,10 @@ class QfcTestCase(APITransactionTestCase):
         super().fail(msg)
 
     def assertHttpOk(self, response: response.Response):
-        try:
-            self.assertTrue(
-                rest_framework.status.is_success(response.status_code), response.json()
-            )
-        except Exception:
-            self.assertTrue(
-                rest_framework.status.is_success(response.status_code), response.content
-            )
+        self.assertTrue(
+            status.is_success(response.status_code),
+            f"Response: {response.content}",
+        )
 
     def upload_project_files(self, project) -> Project:
         # Verify the original geojson file

--- a/docker-app/qfieldcloud/core/utils2/pg_service_file.py
+++ b/docker-app/qfieldcloud/core/utils2/pg_service_file.py
@@ -20,5 +20,9 @@ def validate_pg_service_conf(value: str) -> None:
             )
     except ValidationError as err:
         raise err
-    except Exception:
-        raise ValidationError(_("Failed to parse the `.pg_service.conf` file."))
+
+    # Convert any other error to a `ValidationError` to ensure the caller can handle it properly.
+    except Exception as err:  # noqa: BLE001
+        raise ValidationError(
+            _("Failed to parse the `.pg_service.conf` file.")
+        ) from err

--- a/docker-app/qfieldcloud/core/utils2/sentry.py
+++ b/docker-app/qfieldcloud/core/utils2/sentry.py
@@ -52,7 +52,7 @@ def report_serialization_diff_to_sentry(
 
         return True
 
-    except Exception as error:
-        logger.error(f"Unable to send file to Sentry: failed on {error}")
-        sentry_sdk.capture_exception(error)
+    except Exception as err:  # noqa: BLE001
+        logger.error(f"Unable to send file to Sentry: failed on {err}")
+        sentry_sdk.capture_exception(err)
         return False

--- a/docker-app/qfieldcloud/core/views/deltas_views.py
+++ b/docker-app/qfieldcloud/core/views/deltas_views.py
@@ -173,7 +173,7 @@ class ListCreateDeltasView(generics.ListCreateAPIView):
         try:
             deltafile_json = json.loads(deltafile_data)
             deltafile_id = deltafile_json.get("id")
-        except Exception:
+        except json.JSONDecodeError:
             deltafile_id = None
 
         if deltafile_id:

--- a/docker-app/qfieldcloud/core/views/redirect_views.py
+++ b/docker-app/qfieldcloud/core/views/redirect_views.py
@@ -17,7 +17,7 @@ def redirect_to_admin_project_view(
             name=project_name,
             owner__username=username,
         )
-    except Exception:
+    except Project.DoesNotExist:
         raise Http404()
 
     return redirect(reverse("admin:core_project_change", args=(project.id,)))

--- a/docker-app/qfieldcloud/filestorage/backend.py
+++ b/docker-app/qfieldcloud/filestorage/backend.py
@@ -41,7 +41,8 @@ class QfcS3Boto3Storage(QfcBackendStorageMixin, S3Storage):
         try:
             bucket_name = self.bucket.name
             self.bucket.meta.client.head_bucket(Bucket=bucket_name)
-        except Exception:
+        # Boto3 can raise any kind of error, so we catch all exceptions here to ensure the method returns False if anything goes wrong during the check.
+        except Exception:  # noqa: BLE001
             return False
 
         return True

--- a/docker-app/qfieldcloud/filestorage/tests/test_files_api.py
+++ b/docker-app/qfieldcloud/filestorage/tests/test_files_api.py
@@ -63,7 +63,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
 
             versions_count = file.versions.count()
             latest_version = file.latest_version
-        except Exception:
+        except File.DoesNotExist:
             versions_count = 0
             latest_version = None
 

--- a/docker-app/qfieldcloud/filestorage/utils.py
+++ b/docker-app/qfieldcloud/filestorage/utils.py
@@ -56,7 +56,7 @@ def is_valid_filename(filename: str) -> bool:
     try:
         validate_filename(filename)
         return True
-    except Exception:
+    except ValidationError:
         return False
 
 

--- a/docker-app/qfieldcloud/settings_utils.py
+++ b/docker-app/qfieldcloud/settings_utils.py
@@ -37,7 +37,7 @@ def get_storages_config() -> StoragesConfig:
     if storages_json:
         try:
             raw_storages = json.loads(storages_json)
-        except Exception:
+        except json.JSONDecodeError:
             raise ConfigValidationError(
                 "Envvar STORAGES should be a parsable JSON string!"
             )
@@ -81,7 +81,7 @@ def get_socialaccount_providers_config() -> dict:
 
     try:
         providers = json.loads(providers_json)
-    except Exception:
+    except json.JSONDecodeError:
         raise ConfigValidationError(
             "Envvar SOCIALACCOUNT_PROVIDERS should be a parsable JSON string!"
         )

--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -246,13 +246,15 @@ class JobRun:
 
                 try:
                     self.job.refresh_from_db()
-                except Exception as err:
+                except Job.DoesNotExist as err:
                     logger.error(
                         "Failed to update job status, probably does not exist in the database.",
                         exc_info=err,
                     )
+
                     # No further action required, probably received by wrapper's autoclean mechanism when the `Project` is deleted
                     return
+
             elif exit_code == TIMEOUT_ERROR_EXIT_CODE:
                 feedback["error"] = "Worker timeout error."
                 feedback["error_type"] = "TIMEOUT"

--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -437,7 +437,7 @@ class JobRun:
                     b"Job has been cancelled by parent process!",
                 )
 
-        except Exception as err:
+        except requests.exceptions.ConnectionError as err:
             logger.exception("Timeout error.", exc_info=err)
 
         # `docker_started_at`/`docker_finished_at` tracks the time spent on docker only

--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -307,7 +307,8 @@ class JobRun:
             self.job.status = Job.Status.FINISHED
             self.job.save(update_fields=["status", "finished_at"])
 
-        except Exception as err:
+        # Global error handler when handling a job
+        except Exception as err:  # noqa: BLE001
             (_type, _value, tb) = sys.exc_info()
             feedback["error"] = str(err)
             feedback["error_origin"] = "worker_wrapper"

--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -266,7 +266,9 @@ class JobRun:
 
                         if feedback.get("error"):
                             feedback["error_origin"] = "container"
-                except Exception as err:
+
+                # Global error handler when handling the feedback from a job
+                except Exception as err:  # noqa: BLE001
                     if not isinstance(feedback, dict):
                         feedback = {"error_feedback": feedback}
 

--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -16,7 +16,7 @@ import requests
 import sentry_sdk
 from constance import config
 from django.conf import settings
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.forms.models import model_to_dict
 from django.utils import timezone
 from docker.models.containers import Container
@@ -333,7 +333,7 @@ class JobRun:
                     )
 
                 self.job.save(update_fields=["status", "feedback", "finished_at"])
-            except Exception as err:
+            except IntegrityError as err:
                 logger.error(
                     "Failed to handle exception and update the job status", exc_info=err
                 )

--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -287,7 +287,8 @@ class JobRun:
 
                 try:
                     self.after_docker_exception()
-                except Exception as err:
+                # `after_docker_exception` can raise anything, as it is developed externally
+                except Exception as err:  # noqa: BLE001
                     logger.error(
                         "Failed to run the `after_docker_exception` handler.",
                         exc_info=err,
@@ -326,7 +327,8 @@ class JobRun:
 
                 try:
                     self.after_docker_exception()
-                except Exception as err:
+                # `after_docker_exception` can raise anything, as it is developed externally
+                except Exception as err:  # noqa: BLE001
                     logger.error(
                         "Failed to run the `after_docker_exception` handler.",
                         exc_info=err,

--- a/docker-qgis/qfc_worker/commands/apply_deltas.py
+++ b/docker-qgis/qfc_worker/commands/apply_deltas.py
@@ -652,7 +652,7 @@ def rollback_deltas(
         # NOTE pathlib operations will raise in case of error
         try:
             layer_backup_path.rename(layer_path)
-        except Exception as err:
+        except (FileExistsError, FileNotFoundError, PermissionError, OSError) as err:
             # TODO nothing better to do here?
             is_success = False
             logger.warning(
@@ -684,9 +684,8 @@ def cleanup_backups(layer_paths: set[str]) -> bool:
         layer_path = Path(layer_path_str)
         layer_backup_path = get_backup_path(layer_path)
         try:
-            if layer_backup_path.exists():
-                layer_backup_path.unlink()
-        except Exception as err:
+            layer_backup_path.unlink(missing_ok=True)
+        except (IsADirectoryError, PermissionError, OSError) as err:
             is_success = False
             logger.warning(
                 f"Unable to remove backup: {layer_backup_path}. Reason: {err}"

--- a/docker-qgis/qfc_worker/commands/apply_deltas.py
+++ b/docker-qgis/qfc_worker/commands/apply_deltas.py
@@ -652,7 +652,13 @@ def rollback_deltas(
         # NOTE pathlib operations will raise in case of error
         try:
             layer_backup_path.rename(layer_path)
-        except (FileExistsError, FileNotFoundError, PermissionError, OSError) as err:
+        except (
+            FileExistsError,
+            FileNotFoundError,
+            IsADirectoryError,
+            PermissionError,
+            OSError,
+        ) as err:
             # TODO nothing better to do here?
             is_success = False
             logger.warning(

--- a/docker-qgis/qfc_worker/commands/package.py
+++ b/docker-qgis/qfc_worker/commands/package.py
@@ -72,15 +72,9 @@ def call_libqfieldsync_packager(
         if vl_extent.isNull() or not vl_extent.isFinite():
             logger.info("Failed to obtain the project extent from project layers.")
 
-            try:
-                vl_extent = QgsRectangle.fromWkt(
-                    qfc_worker.utils.extract_project_details(project)["extent"]
-                )
-            except Exception as err:
-                logger.error(
-                    "Failed to get the project extent from the current map canvas.",
-                    exc_info=err,
-                )
+            vl_extent = QgsRectangle.fromWkt(
+                qfc_worker.utils.extract_project_details(project)["extent"]
+            )
 
         if vl_extent.isNull() or not vl_extent.isFinite():
             raise Exception("Failed to obtain the project extent.")

--- a/docker-qgis/qfc_worker/commands/package.py
+++ b/docker-qgis/qfc_worker/commands/package.py
@@ -9,7 +9,7 @@ from libqfieldsync.offline_converter import ExportType, OfflineConverter
 from libqfieldsync.offliners import OfflinerType, PythonMiniOffliner, QgisCoreOffliner
 from libqfieldsync.project import ProjectConfiguration
 from libqfieldsync.utils.file_utils import get_project_in_folder
-from qgis.core import QgsCoordinateTransform, QgsRectangle
+from qgis.core import QgsCoordinateTransform, QgsCsException, QgsRectangle
 
 import qfc_worker.utils
 from qfc_worker.commands_base import QfcBaseCommand
@@ -56,12 +56,13 @@ def call_libqfieldsync_packager(
             if layer_extent.isNull() or not layer_extent.isFinite():
                 continue
 
+            transform = QgsCoordinateTransform(layer.crs(), project.crs(), project)
+
             try:
-                transform = QgsCoordinateTransform(layer.crs(), project.crs(), project)
                 vl_extent.combineExtentWith(
                     transform.transformBoundingBox(layer_extent)
                 )
-            except Exception as err:
+            except QgsCsException as err:
                 logger.error(
                     "Failed to transform the bbox for layer {} from {} to {} CRS.".format(
                         layer.name(), layer.crs(), project.crs()

--- a/docker-qgis/qfc_worker/utils.py
+++ b/docker-qgis/qfc_worker/utils.py
@@ -547,7 +547,8 @@ def is_localhost(hostname: str, port: int | None = None) -> bool:
                     return True
 
         return False
-    except Exception:
+    # if any error occurs, then just assume it's not localhost
+    except Exception:  # noqa: BLE001
         return False
 
 

--- a/docker-qgis/qfc_worker/utils.py
+++ b/docker-qgis/qfc_worker/utils.py
@@ -91,7 +91,7 @@ def _write_log_message(message, tag, level):
     # in 3.16 it was Qgis.None, but since None is a reserved keyword, it was inaccessible
     try:
         Qgis.MessageLevel.NoLevel
-    except Exception:
+    except AttributeError:
         Qgis.MessageLevel.NoLevel = 4
 
     if level == Qgis.MessageLevel.NoLevel:

--- a/docker-qgis/qfc_worker/utils.py
+++ b/docker-qgis/qfc_worker/utils.py
@@ -88,12 +88,6 @@ QtCore.qInstallMessageHandler(_qt_message_handler)
 def _write_log_message(message, tag, level):
     log_level = logging.DEBUG
 
-    # in 3.16 it was Qgis.None, but since None is a reserved keyword, it was inaccessible
-    try:
-        Qgis.MessageLevel.NoLevel
-    except AttributeError:
-        Qgis.MessageLevel.NoLevel = 4
-
     if level == Qgis.MessageLevel.NoLevel:
         log_level = logging.DEBUG
     elif level == Qgis.MessageLevel.Info:

--- a/docker-qgis/qfc_worker/workflow.py
+++ b/docker-qgis/qfc_worker/workflow.py
@@ -266,7 +266,8 @@ def run_workflow(
                 for name, value in zip(step.return_names, return_values):
                     step_returns[step.id][name] = value
 
-    except Exception as err:
+    # Catch all errors to ensure we can return the feedback in a structured way, and log the error properly.
+    except Exception as err:  # noqa: BLE001
         feedback["error"] = str(err)
 
         if isinstance(err, sdk.QfcRequestException):

--- a/docker-qgis/qfc_worker/workflow.py
+++ b/docker-qgis/qfc_worker/workflow.py
@@ -209,7 +209,10 @@ def json_default(obj):
 
     try:
         obj_str += f" {str(obj)}"
-    except Exception:
+    # Typically, we should only expect `TypeError` if `__str__` or `__repr__` are not present.
+    # Expect any kind of error here, as we are using C++ objects that may be already deleted.
+    # e.g. RuntimeError: wrapped C/C++ object of type QgsProject has been deleted
+    except Exception:  # noqa: BLE001
         obj_str += " <non-representable>"
 
     return f"<non-serializable: {obj_str}>"

--- a/ruff.toml
+++ b/ruff.toml
@@ -23,6 +23,8 @@ target-version = "py310"
 extend-select = [
     "I",        # isort
     "B006",     # Mutable argument default
+    "BLE001",   # Checks for except clauses that catch all exceptions, see https://docs.astral.sh/ruff/rules/blind-except/
+
 ]
 ignore = []
 


### PR DESCRIPTION
Overly broad except clauses can lead to unexpected behavior, such as catching KeyboardInterrupt or SystemExit exceptions that prevent the user from exiting the program. 
It can also hide problems e.g. AttributeError  or KeyError  that are caused by developers.
Instead of catching all exceptions, catch only those that are expected to be raised in the try block.

Fixes #1575 .

Check individual commits.

See https://docs.astral.sh/ruff/rules/blind-except/.