### PR TITLE
chore: Drop all references to `skip_metadata` query param on the `GET /files` endpoint

### DIFF
--- a/docker-app/qfieldcloud/core/templates/admin/project_files_widget.html
+++ b/docker-app/qfieldcloud/core/templates/admin/project_files_widget.html
@@ -146,10 +146,7 @@
             const refreshFiles = () => {
                 refreshTableContents({ isLoading: true });
 
-                const params = {
-                    skip_metadata: "1",
-                };
-                return apiCall(`files/${projectId}/`, { params })
+                return apiCall(`files/${projectId}/`, { })
                     .then((resp) => resp.json())
                     .then((files) => refreshTableContents({ files }))
                     .catch((error) => refreshTableContents({ error }));

--- a/docker-app/qfieldcloud/core/tests/test_qgis_file.py
+++ b/docker-app/qfieldcloud/core/tests/test_qgis_file.py
@@ -261,7 +261,6 @@ class QfcTestCase(APITransactionTestCase):
             Project.objects.get(pk=self.project1.pk).project_files_count, 1
         )
 
-        # List files without `skip_metadata` param
         response = self.client.get(f"/api/v1/files/{self.project1.id}/")
         self.assertTrue(status.is_success(response.status_code))
 
@@ -275,36 +274,6 @@ class QfcTestCase(APITransactionTestCase):
             json[0]["sha256"],
             "8663bab6d124806b9727f89bb4ab9db4cbcc3862f6bbf22024dfa7212aa4ab7d",
         )
-        self.assertEqual(
-            json[0]["md5sum"],
-            "9af2f8218b150c351ad802c6f3d66abe",
-        )
-
-        # List files with `skip_metadata=0` param
-        response = self.client.get(f"/api/v1/files/{self.project1.id}/?skip_metadata=0")
-        self.assertEqual(json[0]["name"], "file.txt")
-        self.assertEqual(json[0]["size"], 13)
-        self.assertIn("sha256", json[0])
-        self.assertIn("md5sum", json[0])
-        self.assertEqual(
-            json[0]["sha256"],
-            "8663bab6d124806b9727f89bb4ab9db4cbcc3862f6bbf22024dfa7212aa4ab7d",
-        )
-        self.assertEqual(
-            json[0]["md5sum"],
-            "9af2f8218b150c351ad802c6f3d66abe",
-        )
-
-        # List files with `skip_metadata=1` param
-        response = self.client.get(f"/api/v1/files/{self.project1.id}/?skip_metadata=1")
-        self.assertTrue(status.is_success(response.status_code))
-
-        json = response.json()
-
-        self.assertEqual(json[0]["name"], "file.txt")
-        self.assertEqual(json[0]["size"], 13)
-
-        self.assertIn("md5sum", json[0])
         self.assertEqual(
             json[0]["md5sum"],
             "9af2f8218b150c351ad802c6f3d66abe",

--- a/docker-app/qfieldcloud/filestorage/views.py
+++ b/docker-app/qfieldcloud/filestorage/views.py
@@ -9,7 +9,6 @@ from django.http.response import HttpResponseBase
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from drf_spectacular.utils import (
-    OpenApiParameter,
     OpenApiTypes,
     extend_schema,
     extend_schema_view,
@@ -75,16 +74,6 @@ class FileCrudViewPermissions(permissions.BasePermission):
     get=extend_schema(
         description="Get all the project's file versions",
         responses={200: serializers.ListSerializer(child=FileWithVersionsSerializer())},
-        parameters=[
-            OpenApiParameter(
-                name="skip_metadata",
-                type=OpenApiTypes.INT,
-                required=False,
-                default=0,
-                enum=[1, 0],
-                description="Skip obtaining file metadata (e.g. `sha256`). Makes responses much faster. In the future `skip_metadata=1` might be default behaviour.",
-            ),
-        ],
     ),
 )
 class FileListView(generics.ListAPIView):


### PR DESCRIPTION
This is a legacy storage artifact that was used to choose whether to send an expensive additional per file request to the Object storage to get the SHA256 sum of the file.

Now we calculate the value by default and there is no such need.