### PR TITLE
Always run lint, not only on non-draft requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ on:
 
 jobs:
   lint:
-    if: '! github.event.pull_request.draft'
     name: Lint code base
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
This line was added from times nobody wants to remember.