### PR TITLE
tests: Fix object storage cleaner tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,7 +122,7 @@ jobs:
           docker compose run app python manage.py test --keepdb -v2 --tag="flaky" qfieldcloud
 
       - name: Run Object Storage Cleaner tests
-        if: matrix.django_app == 'filestorage' && matrix.storage == 'default'
+        if: matrix.django_app == 'filestorage'
         run: |
           docker compose run --rm \
             -e AWS_ACCESS_KEY_ID=rustfsadmin \


### PR DESCRIPTION
They were dependent on the `storage` matrix field, which was deleted with legacy storage cleanup.