### PR TITLE
tests: Add a new CI step running template validity and django checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,3 +150,42 @@ jobs:
       #   timeout-minutes: 30
       #   with:
       #     limit-access-to-actor: true
+
+  django_checks:
+    name: Run Django checks
+    runs-on: ubuntu-24.04
+    continue-on-error: true
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Export the env variables file
+        run: |
+          cp .env.example .env
+          sed -ri 's/^ENVIRONMENT=(.*)/ENVIRONMENT=test/g' .env
+          sed -ri 's/^COMPOSE_FILE=(.*)/COMPOSE_FILE=\1:docker-compose.override.test.yml/g' .env
+          eval $(egrep "^[^#;]" .env | xargs -d'\n' -n1 | sed -E 's/(\w+)=(.*)/export \1='"'"'\2'"'"'/g')
+
+      - name: Pull docker containers
+        run: docker compose pull
+
+      - name: Build and run docker containers
+        run: |
+          docker compose up -d --build
+
+      - name: Initial manage.py commands
+        run: |
+          docker compose run app python manage.py makemigrations --no-input --check
+          docker compose run app python manage.py migrate
+          docker compose run app python manage.py collectstatic
+
+      - name: Validate templates
+        run: |
+          docker compose run --rm app python manage.py validate_templates
+
+      - name: "failure logs"
+        if: failure()
+        run: |
+          docker compose logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,6 +181,10 @@ jobs:
           docker compose run app python manage.py migrate
           docker compose run app python manage.py collectstatic
 
+      - name: Django check
+        run: |
+          docker compose run --rm app python manage.py check --deploy --fail-level=ERROR
+
       - name: Validate templates
         run: |
           docker compose run --rm app python manage.py validate_templates

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Pre-commit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -157,7 +157,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,19 +107,19 @@ jobs:
 
       - name: Initial manage.py commands
         run: |
-          docker compose run app python manage.py makemigrations --no-input --check
-          docker compose run app python manage.py migrate
-          docker compose run app python manage.py collectstatic
+          docker compose run --rm app python manage.py makemigrations --no-input --check
+          docker compose run --rm app python manage.py migrate
+          docker compose run --rm app python manage.py collectstatic
 
       - name: Run mandatory unit and integration tests
         if: matrix.django_app != '__flaky__'
         run: |
-          docker compose run app python manage.py test --keepdb -v2 --exclude-tag="flaky" qfieldcloud.${{ matrix.django_app }}
+          docker compose run --rm app python manage.py test --keepdb -v2 --exclude-tag="flaky" qfieldcloud.${{ matrix.django_app }}
 
       - name: Run flaky unit and integration tests
         if: matrix.django_app == '__flaky__'
         run: |
-          docker compose run app python manage.py test --keepdb -v2 --tag="flaky" qfieldcloud
+          docker compose run --rm app python manage.py test --keepdb -v2 --tag="flaky" qfieldcloud
 
       - name: Run Object Storage Cleaner tests
         if: matrix.django_app == 'filestorage' && matrix.storage == 'default'
@@ -177,9 +177,9 @@ jobs:
 
       - name: Initial manage.py commands
         run: |
-          docker compose run app python manage.py makemigrations --no-input --check
-          docker compose run app python manage.py migrate
-          docker compose run app python manage.py collectstatic
+          docker compose run --rm app python manage.py makemigrations --no-input --check
+          docker compose run --rm app python manage.py migrate
+          docker compose run --rm app python manage.py collectstatic
 
       - name: Django check
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,7 @@ jobs:
         run: |
           docker compose run --rm app python manage.py makemigrations --no-input --check
           docker compose run --rm app python manage.py migrate
-          docker compose run --rm app python manage.py collectstatic
+          docker compose run --rm app python manage.py collectstatic --no-input
 
       - name: Run mandatory unit and integration tests
         if: matrix.django_app != '__flaky__'
@@ -179,7 +179,7 @@ jobs:
         run: |
           docker compose run --rm app python manage.py makemigrations --no-input --check
           docker compose run --rm app python manage.py migrate
-          docker compose run --rm app python manage.py collectstatic
+          docker compose run --rm app python manage.py collectstatic --no-input
 
       - name: Django check
         run: |

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -98,6 +98,7 @@ INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.contenttypes",
     "django.contrib.gis",
+    "django.contrib.humanize",
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -970,6 +970,20 @@ JAZZMIN_SETTINGS = {
 
 
 ###########################
+# List of apps to ignore when ensuring Django templates validity.
+###########################
+
+# Ignore the following apps
+# NOTE Ideally `VALIDATE_TEMPLATES_IGNORES` should be used, but it uses only the basename of the ignored files, see https://github.com/django-extensions/django-extensions/blob/4.1/django_extensions/management/commands/validate_templates.py#L64-L69
+# See https://django-extensions.readthedocs.io/en/latest/validate_templates.html#validate-templates-ignore-apps
+VALIDATE_TEMPLATES_IGNORE_APPS = [
+    "allauth",
+    "django_filters",
+    "jazzmin",
+]
+
+
+###########################
 # CORS settings
 # Managed via django-cors-headers.
 # Origins and credentials are configured through environment variables,


### PR DESCRIPTION
See https://django-extensions.readthedocs.io/en/latest/validate_templates.html .

Ideally `VALIDATE_TEMPLATES_IGNORES` should be used, but it uses only the basename of the ignored files, see https://github.com/django-extensions/django-extensions/blob/4.1/django_extensions/management/commands/validate_templates.py#L64-L69 .

Basenames are just way too generic for our usecase, e.g. `create_form.html`