### PR TITLE
fix: Fix django-axes warning for not using an `ip_address` to block attempts

### DIFF
--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -591,8 +591,8 @@ QFIELDCLOUD_SSO_PROVIDER_STYLES = {
 AXES_LOCKOUT_TEMPLATE = "axes/lockedout.html"
 # The integer number of login attempts allowed before a record is created for the failed logins. Default: 3
 AXES_FAILURE_LIMIT = 5
-# Configures the limiter to handle username only (see https://django-axes.readthedocs.io/en/latest/2_installation.html#version-7-breaking-changes-and-upgrading-from-django-axes-version-6)
-AXES_LOCKOUT_PARAMETERS = ["username"]
+# Configures the limiter to handle a combo of username and IP, see https://django-axes.readthedocs.io/en/latest/5_customization.html#customizing-lockout-parameters
+AXES_LOCKOUT_PARAMETERS = [["username", "ip_address"]]
 # If set, defines a period of inactivity after which old failed login attempts will be cleared. If an integer, will be interpreted as a number of hours. Default: None
 AXES_COOLOFF_TIME = lambda _request: timedelta(minutes=30)  # noqa: E731
 # If True, a successful login will reset the number of failed logins. Default: False


### PR DESCRIPTION
We should not "normalize" warnings, and one of them that is there for quite some times is:
```
WARNINGS:
?: (axes.W006) AXES_LOCKOUT_PARAMETERS does not contain 'ip_address'. This configuration allows attackers to bypass rate limits by rotating User-Agents or Cookies.
	HINT: Add 'ip_address' to AXES_LOCKOUT_PARAMETERS.
```
The main reason why it has not been tackled yet was because we didn't want to lock out a room of users behind the same IP.

Turned out we can configure lockout params to be a combo:
```
AXES_LOCKOUT_PARAMETERS = [["username", "ip_address"]]
```

See https://django-axes.readthedocs.io/en/latest/5_customization.html#customizing-lockout-parameters