### PR TITLE
refactor: Change the deprecated in 5.1 `CheckConstraint.check` to `CheckConstraint.condition`

### DIFF
--- a/docker-app/qfieldcloud/core/migrations/0085_alter_secret_options_and_more.py
+++ b/docker-app/qfieldcloud/core/migrations/0085_alter_secret_options_and_more.py
@@ -100,7 +100,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="secret",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     ("project__isnull", True),
                     ("organization__isnull", True),
                     _connector="XOR",

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -2691,7 +2691,7 @@ class Secret(models.Model):
             ),
             models.CheckConstraint(
                 # we want either the project to be set or the organization, but never both set or unset, therefore ^ (XOR)
-                check=Q(project__isnull=True) ^ Q(organization__isnull=True),
+                condition=Q(project__isnull=True) ^ Q(organization__isnull=True),
                 name="secret_assigned_to_organization_or_user",
             ),
         ]


### PR DESCRIPTION


> The check keyword argument of CheckConstraint is deprecated in favor of condition.

See https://docs.djangoproject.com/en/5.1/releases/5.1/#id2 (three from the bottom)

See https://github.com/django/django/pull/17876