### PR TITLE
tests: Remove the usage of `unittest.assert((Not)Equals` that was dropped in 3.12

### DIFF
--- a/docker-app/qfieldcloud/core/tests/test_jobs.py
+++ b/docker-app/qfieldcloud/core/tests/test_jobs.py
@@ -41,9 +41,9 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
     def assertLayerData(
         self, layer_data: dict, is_valid: bool, is_localized: bool, error_code: str
     ) -> None:
-        self.assertEquals(layer_data["is_valid"], is_valid)
-        self.assertEquals(layer_data["is_localized"], is_localized)
-        self.assertEquals(layer_data["error_code"], error_code)
+        self.assertEqual(layer_data["is_valid"], is_valid)
+        self.assertEqual(layer_data["is_localized"], is_localized)
+        self.assertEqual(layer_data["error_code"], error_code)
 
     def test_bad_layer_handler_values_for_process_projectfile_job(self):
         # Test that BadLayerHandler is parsing data properly during process projectfile jobs

--- a/docker-app/qfieldcloud/core/tests/test_packages.py
+++ b/docker-app/qfieldcloud/core/tests/test_packages.py
@@ -740,7 +740,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             package_job=package_job_1,
         )
 
-        self.assertEquals(package_files_p1_qs.count(), 2)
+        self.assertEqual(package_files_p1_qs.count(), 2)
 
         # repackage the project for the same user.
         package_job_2 = repackage(self.project1, self.user1)
@@ -754,7 +754,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             package_job=package_job_1,
         )
 
-        self.assertEquals(package_files_p1_qs.count(), 0)
+        self.assertEqual(package_files_p1_qs.count(), 0)
 
         # make sure new package files are there.
         package_files_p2_qs = File.objects.filter(
@@ -763,7 +763,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             package_job=package_job_2,
         )
 
-        self.assertEquals(package_files_p2_qs.count(), 2)
+        self.assertEqual(package_files_p2_qs.count(), 2)
 
         # make sure the other user's package files are there.
         other_user_package_files_qs = File.objects.filter(
@@ -772,7 +772,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             package_job=other_user_package_job,
         )
 
-        self.assertEquals(other_user_package_files_qs.count(), 2)
+        self.assertEqual(other_user_package_files_qs.count(), 2)
 
     def test_needs_repackaging(self):
         # 0. Create two users, where one owns the project and the other is a project collaborator.

--- a/docker-app/qfieldcloud/core/tests/test_packages.py
+++ b/docker-app/qfieldcloud/core/tests/test_packages.py
@@ -137,7 +137,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
                 response = self.client.get(f"/api/v1/packages/{project.id}/latest/")
                 package_payload = response.json()
 
-                self.assertNotEquals(package_payload.get("code"), "invalid_job")
+                self.assertNotEqual(package_payload.get("code"), "invalid_job")
                 self.assertLess(
                     package_payload["packaged_at"], timezone.now().isoformat()
                 )

--- a/docker-app/qfieldcloud/core/tests/test_project.py
+++ b/docker-app/qfieldcloud/core/tests/test_project.py
@@ -891,11 +891,11 @@ class QfcTestCase(APITransactionTestCase):
 
         response = self.client.get("/api/v1/projects/")
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         payload = response.json()
 
-        self.assertEquals(len(payload), 1)
+        self.assertEqual(len(payload), 1)
 
         project_json = payload[0]
 

--- a/docker-app/qfieldcloud/core/tests/test_secret_packages.py
+++ b/docker-app/qfieldcloud/core/tests/test_secret_packages.py
@@ -104,13 +104,13 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
 
         latest_package_jobs_qs = self.p1.latest_package_jobs()
 
-        self.assertEquals(latest_package_jobs_qs.count(), 2)
+        self.assertEqual(latest_package_jobs_qs.count(), 2)
 
         u1_latest_package_job = latest_package_jobs_qs.get(triggered_by=self.u1)
         u2_latest_package_job = latest_package_jobs_qs.get(triggered_by=self.u2)
 
-        self.assertEquals(u1_package_job.id, u1_latest_package_job.id)
-        self.assertEquals(u2_package_job.id, u2_latest_package_job.id)
+        self.assertEqual(u1_package_job.id, u1_latest_package_job.id)
+        self.assertEqual(u2_package_job.id, u2_latest_package_job.id)
 
     def test_create_org_level_packages(self):
         # upload data & QGIS project files to the project.
@@ -144,8 +144,8 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
 
         latest_package_jobs_qs = self.p1.latest_package_jobs()
 
-        self.assertEquals(latest_package_jobs_qs.first(), u1_package_job)
-        self.assertEquals(latest_package_jobs_qs.count(), 1)
+        self.assertEqual(latest_package_jobs_qs.first(), u1_package_job)
+        self.assertEqual(latest_package_jobs_qs.count(), 1)
 
         # create a package for user u2
         u2_package_job = repackage(self.p1, self.u2)
@@ -153,8 +153,8 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
         latest_package_jobs_qs = self.p1.latest_package_jobs()
 
         self.assertNotEqual(u1_package_job, u2_package_job)
-        self.assertEquals(latest_package_jobs_qs.count(), 2)
-        self.assertEquals(latest_package_jobs_qs.last(), u2_package_job)
+        self.assertEqual(latest_package_jobs_qs.count(), 2)
+        self.assertEqual(latest_package_jobs_qs.last(), u2_package_job)
 
     def test_create_secrets_and_packages(self):
         # upload data & QGIS project files to the project.
@@ -199,7 +199,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
 
         latest_package_jobs_qs = self.p1.latest_package_jobs()
 
-        self.assertEquals(latest_package_jobs_qs.count(), 1)
+        self.assertEqual(latest_package_jobs_qs.count(), 1)
         self.assertIn(package_job_2, latest_package_jobs_qs)
         self.assertNotIn(package_job_1, latest_package_jobs_qs)
 
@@ -209,7 +209,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             file_type=File.FileType.PACKAGE_FILE,
         )
 
-        self.assertEquals(package_job_1_files.count(), 0)
+        self.assertEqual(package_job_1_files.count(), 0)
 
     def test_org_secret_retrieved_by_worker(self):
         cur = self.conn.cursor()

--- a/docker-app/qfieldcloud/filestorage/tests/test_range.py
+++ b/docker-app/qfieldcloud/filestorage/tests/test_range.py
@@ -40,11 +40,11 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
         )
 
     def test_parsing_range_function_succeeds(self):
-        self.assertEquals(parse_range_header("bytes=4-8", 10), (4, 8))
+        self.assertEqual(parse_range_header("bytes=4-8", 10), (4, 8))
 
         start_byte, end_byte = parse_range_header("bytes=2-", 10)
 
-        self.assertEquals(start_byte, 2)
+        self.assertEqual(start_byte, 2)
         self.assertIsNone(end_byte)
 
     def test_parsing_wrong_invalid_range_function_succeeds(self):
@@ -148,29 +148,29 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
                     self.u1, project, "file.name", headers={"Range": "bytes=0-2"}
                 )
 
-                self.assertEquals(r1.status_code, status.HTTP_206_PARTIAL_CONTENT)
-                self.assertEquals(r1.content, b"abc")
+                self.assertEqual(r1.status_code, status.HTTP_206_PARTIAL_CONTENT)
+                self.assertEqual(r1.content, b"abc")
 
                 r2 = self._download_file(
                     self.u1, project, "file.name", headers={"Range": "bytes=5-8"}
                 )
 
-                self.assertEquals(r2.status_code, status.HTTP_206_PARTIAL_CONTENT)
-                self.assertEquals(r2.content, b"fghi")
+                self.assertEqual(r2.status_code, status.HTTP_206_PARTIAL_CONTENT)
+                self.assertEqual(r2.content, b"fghi")
 
                 r3 = self._download_file(
                     self.u1, project, "file.name", headers={"Range": "bytes=7-"}
                 )
 
-                self.assertEquals(r3.status_code, status.HTTP_206_PARTIAL_CONTENT)
-                self.assertEquals(r3.content, b"hijkl")
+                self.assertEqual(r3.status_code, status.HTTP_206_PARTIAL_CONTENT)
+                self.assertEqual(r3.content, b"hijkl")
 
                 r4 = self._download_file(
                     self.u1, project, "file.name", headers={"Range": "bytes=0-"}
                 )
 
-                self.assertEquals(r4.status_code, status.HTTP_206_PARTIAL_CONTENT)
-                self.assertEquals(r4.content, b"abcdefghijkl")
+                self.assertEqual(r4.status_code, status.HTTP_206_PARTIAL_CONTENT)
+                self.assertEqual(r4.content, b"abcdefghijkl")
 
     @override_settings(QFIELDCLOUD_MINIMUM_RANGE_HEADER_LENGTH=3)
     def test_minimum_range_header_length(self):
@@ -190,15 +190,15 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
                     self.u1, project, "file.name", headers={"Range": "bytes=0-2"}
                 )
 
-                self.assertEquals(r1.status_code, status.HTTP_206_PARTIAL_CONTENT)
-                self.assertEquals(r1.content, b"abc")
+                self.assertEqual(r1.status_code, status.HTTP_206_PARTIAL_CONTENT)
+                self.assertEqual(r1.content, b"abc")
 
                 # download parts of the file, with specific ranges
                 r1 = self._download_file(
                     self.u1, project, "file.name", headers={"Range": "bytes=0-1"}
                 )
 
-                self.assertEquals(
+                self.assertEqual(
                     r1.status_code, status.HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE
                 )
 
@@ -212,7 +212,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
                     self.u1, project, "file.name", headers={"Range": "bytes=abc-"}
                 )
 
-                self.assertEquals(
+                self.assertEqual(
                     r1.status_code, status.HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE
                 )
 
@@ -220,7 +220,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
                     self.u1, project, "file.name", headers={"Range": "bytes=-def"}
                 )
 
-                self.assertEquals(
+                self.assertEqual(
                     r2.status_code, status.HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE
                 )
 
@@ -228,7 +228,7 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
                     self.u1, project, "file.name", headers={"Range": "bytes=-1-"}
                 )
 
-                self.assertEquals(
+                self.assertEqual(
                     r3.status_code, status.HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE
                 )
 
@@ -236,6 +236,6 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
                     self.u1, project, "file.name", headers={"Range": "bytes=1-55"}
                 )
 
-                self.assertEquals(
+                self.assertEqual(
                     r4.status_code, status.HTTP_416_REQUESTED_RANGE_NOT_SATISFIABLE
                 )


### PR DESCRIPTION
See https://bugs.python.org/issue45162