### PR TITLE
ci: drop legacy storage key in test environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,17 +64,6 @@ jobs:
 
           cat <<EOF >> .env
           STORAGES='{
-              "legacy_storage": {
-                  "BACKEND": "qfieldcloud.filestorage.backend.QfcS3Boto3Storage",
-                  "OPTIONS": {
-                      "access_key": "rustfsadmin",
-                      "secret_key": "rustfsadmin",
-                      "bucket_name": "qfieldcloud-local-legacy",
-                      "region_name": "",
-                      "endpoint_url": "http://172.17.0.1:8009"
-                  },
-                  "QFC_IS_LEGACY": true
-              },
               "webdav": {
                   "BACKEND": "qfieldcloud.filestorage.backend.QfcWebDavStorage",
                   "OPTIONS": {


### PR DESCRIPTION
Spotted in #1596 that the `legacy_storage` key was still declared in the CI test environment, it should not.