### PR TITLE
feat: add `signup_url` to the server info endpoint

### DIFF
--- a/docker-app/qfieldcloud/core/serializers.py
+++ b/docker-app/qfieldcloud/core/serializers.py
@@ -870,3 +870,4 @@ class AuthProviderSerializer(serializers.Serializer):
 class ServerInfoSerializer(serializers.Serializer):
     whitelabel = WhitelabelSerializer()
     auth_providers = AuthProviderSerializer(many=True, required=False, default=list)
+    signup_url = serializers.URLField(allow_null=True, required=False)

--- a/docker-app/qfieldcloud/core/tests/test_server_views.py
+++ b/docker-app/qfieldcloud/core/tests/test_server_views.py
@@ -62,3 +62,28 @@ class QfcTestCase(APITransactionTestCase):
         system_info = data["whitelabel"]
 
         self.assertEqual(system_info["site_title"], "My Custom Title")
+
+    def test_server_info_signup_url_open(self):
+        """
+        Test that signup_url is an absolute URL to the signup page when signup is open.
+        By default, the adapter is open to signup.
+        """
+        response = self.client.get("/api/v1/server/info/")
+        data = response.json()
+
+        self.assertIn("signup_url", data)
+
+        signup_url = data["signup_url"]
+        self.assertIsNotNone(signup_url)
+        self.assertEqual(signup_url, "http://testserver/accounts/signup/")
+
+    @override_settings(
+        ACCOUNT_ADAPTER="qfieldcloud.core.adapters.AccountAdapterSignUpClosed"
+    )
+    def test_server_info_signup_url_closed(self):
+        """Test that signup_url is null when signup is closed"""
+        response = self.client.get("/api/v1/server/info/")
+        data = response.json()
+
+        self.assertIn("signup_url", data)
+        self.assertIsNone(data["signup_url"])

--- a/docker-app/qfieldcloud/core/utils2/view_utils.py
+++ b/docker-app/qfieldcloud/core/utils2/view_utils.py
@@ -1,7 +1,21 @@
 from typing import Any
 
+from allauth.account.utils import get_adapter
 from django.http import Http404, HttpRequest
+from django.urls import reverse
 
 
 def blocked_view(request: HttpRequest, *args: Any, **kwargs: Any) -> None:
     raise Http404
+
+
+def get_signup_url(request: HttpRequest) -> str | None:
+    """
+    Get the signup url if the adapter is open to signup, else return None.
+    """
+    adapter = get_adapter()
+
+    if adapter.is_open_for_signup(request):
+        return request.build_absolute_uri(reverse("account_signup"))
+    else:
+        return None

--- a/docker-app/qfieldcloud/core/views/server_views.py
+++ b/docker-app/qfieldcloud/core/views/server_views.py
@@ -3,6 +3,7 @@ from django.views.decorators.cache import cache_page
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from qfieldcloud.authentication.sso.auth_providers import get_auth_providers
 from qfieldcloud.core.serializers import ServerInfoSerializer
+from qfieldcloud.core.utils2.view_utils import get_signup_url
 from qfieldcloud.core.whitelabel import get_whitelabel_settings
 from rest_framework import status, views
 from rest_framework.permissions import AllowAny
@@ -23,6 +24,7 @@ class ServerInfoView(views.APIView):
             {
                 "whitelabel": get_whitelabel_settings(),
                 "auth_providers": get_auth_providers(request),
+                "signup_url": get_signup_url(request),
             },
             context={"request": request},
         )


### PR DESCRIPTION
Depending on if the configured QFieldCloud adapter is open to sign up or not, it will respectively return the absolute URL for sign up or a null value.

FYI @nirvn 