### PR TITLE
chore: configure `dependabot` to regularly bump github actions versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This should make dependabot automatically open mergeable PRs on a monthly basis, so that we regularly bump the versions of the used GitHub Actions.

Already there on QFieldSync : https://github.com/opengisch/qfieldsync/pull/772

See GitHub doc : https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/keeping-your-actions-up-to-date-with-dependabot#example-dependabotyml-file-for-github-actions