### PR TITLE
refactor: replace `cached_property` import from `django.utils.functional` to `functools`

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -6,6 +6,7 @@ import string
 import uuid
 from datetime import datetime, timedelta
 from enum import Enum
+from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
@@ -28,7 +29,6 @@ from django.db.models import Value as V
 from django.db.models.aggregates import Count, Sum
 from django.db.models.fields.json import JSONField
 from django.urls import reverse, reverse_lazy
-from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
 from django_stubs_ext import StrOrPromise
 from encrypted_fields.fields import EncryptedTextField

--- a/docker-app/qfieldcloud/core/paginators.py
+++ b/docker-app/qfieldcloud/core/paginators.py
@@ -1,9 +1,9 @@
 import inspect
+from functools import cached_property
 
 from django.conf import settings
 from django.core.paginator import Paginator
 from django.db import connection
-from django.utils.functional import cached_property
 from django.utils.inspect import method_has_no_args
 
 


### PR DESCRIPTION
In summary if you are using `Python 3.12+` prefer functools version otherwise use Django's version if thread safety is not an issue otherwise you might want to use the functools version.