### PR TITLE
chore: add queue_job utils function

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -66,6 +66,7 @@ from qfieldcloud.core.models import (
     Organization,
     OrganizationMember,
     Person,
+    ProcessProjectfileJob,
     Project,
     ProjectCollaborator,
     Secret,
@@ -1291,6 +1292,24 @@ class ProjectAdmin(QFieldCloudModelAdmin):
                 form_obj.instance.updated_by = request.user
 
         super().save_formset(request, form, formset, change)
+
+    def get_urls(self) -> list:
+        urls = super().get_urls()
+        return [
+            path(
+                "<path:object_id>/run-process-projectfile-job/",
+                self.admin_site.admin_view(self.run_process_projectfile_job),
+                name="run_process_projectfile_job",
+            ),
+            *urls,
+        ]
+
+    def run_process_projectfile_job(
+        self, request: HttpRequest, object_id: str
+    ) -> HttpResponse:
+        project = Project.objects.get(pk=object_id)
+        jobs.queue_job(project, ProcessProjectfileJob)
+        return HttpResponseRedirect("..")
 
 
 class DeltaInline(admin.TabularInline):

--- a/docker-app/qfieldcloud/core/templates/admin/project_change_form.html
+++ b/docker-app/qfieldcloud/core/templates/admin/project_change_form.html
@@ -4,6 +4,12 @@
 {% block submit_buttons_bottom %}
   {{ block.super }}
 
+  {% if original %}
+  <div class="form-group">
+    <a href="{% url 'admin:run_process_projectfile_job' original.pk %}" class="btn btn-info form-control">{% trans 'Run process projectfile job' %}</a>
+  </div>
+  {% endif %}
+
   <div class="submit-row">
     <a href="{% url 'admin:core_job_changelist' %}?q={{original.id}}">{% trans 'Project jobs' %}</a>
     |

--- a/docker-app/qfieldcloud/core/tests/test_jobs.py
+++ b/docker-app/qfieldcloud/core/tests/test_jobs.py
@@ -9,8 +9,10 @@ from rest_framework.test import APITransactionTestCase
 from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core.models import (
     Job,
+    Organization,
     PackageJob,
     Person,
+    ProcessProjectfileJob,
     Project,
     ProjectCollaborator,
     ProjectSeed,
@@ -23,6 +25,7 @@ from qfieldcloud.core.tests.utils import (
     wait_for_project_ok_status,
 )
 from qfieldcloud.core.utils2 import project_seed
+from qfieldcloud.core.utils2.jobs import queue_job
 
 logging.disable(logging.CRITICAL)
 
@@ -532,3 +535,132 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
             set(cloned_project.project_details["layers_by_id"].keys()),
             set(self.p1.project_details["layers_by_id"].keys()),
         )
+
+    def test_queue_job_single_project_person_owner_no_triggered_by(self):
+        jobs = queue_job(self.p1, ProcessProjectfileJob)
+
+        self.assertEqual(len(jobs), 1)
+
+        job = jobs[0]
+
+        self.assertEqual(job.created_by_id, self.u1.id)
+        self.assertEqual(job.triggered_by_id, self.u1.id)
+        self.assertEqual(job.project_id, self.p1.id)
+
+    def test_queue_job_single_project_with_explicit_triggered_by(self):
+        u2 = Person.objects.create_user(username="u2", password="abc123")
+        jobs = queue_job(self.p1, ProcessProjectfileJob, triggered_by=u2)
+
+        self.assertEqual(len(jobs), 1)
+
+        job = jobs[0]
+
+        self.assertEqual(job.created_by_id, u2.id)
+        self.assertEqual(job.triggered_by_id, u2.id)
+
+    def test_queue_job_multiple_projects_as_list(self):
+        p2 = Project.objects.create(name="p2", is_public=False, owner=self.u1)
+
+        jobs = queue_job([self.p1, p2], ProcessProjectfileJob)
+
+        self.assertEqual(len(jobs), 2)
+
+        for job in jobs:
+            self.assertIn(job.project_id, [self.p1.id, p2.id])
+            self.assertEqual(job.created_by_id, self.u1.id)
+            self.assertEqual(job.triggered_by_id, self.u1.id)
+
+    def test_queue_job_multiple_projects_as_queryset(self):
+        p2 = Project.objects.create(name="p2", is_public=False, owner=self.u1)
+        project_qs = Project.objects.filter(owner=self.u1)
+
+        jobs = queue_job(project_qs, ProcessProjectfileJob)
+
+        self.assertEqual(len(jobs), 2)
+        self.assertEqual(len(jobs), project_qs.count())
+
+        for job in jobs:
+            self.assertIn(job.project_id, [self.p1.id, p2.id])
+            self.assertEqual(job.created_by_id, self.u1.id)
+            self.assertEqual(job.triggered_by_id, self.u1.id)
+
+    def test_queue_job_organization_owner_no_triggered_by(self):
+        org_owner = Person.objects.create_user(username="org_owner", password="abc123")
+        org = Organization.objects.create(username="org1", organization_owner=org_owner)
+        project_org = Project.objects.create(
+            name="org_project", is_public=False, owner=org
+        )
+
+        jobs = queue_job(project_org, ProcessProjectfileJob)
+
+        self.assertEqual(len(jobs), 1)
+
+        job = jobs[0]
+
+        self.assertEqual(job.created_by_id, org_owner.id)
+        self.assertEqual(job.triggered_by_id, org_owner.id)
+
+    def test_queue_job_organization_owner_with_explicit_triggered_by(self):
+        org_owner = Person.objects.create_user(username="org_owner", password="abc123")
+        org = Organization.objects.create(username="org1", organization_owner=org_owner)
+        project_org = Project.objects.create(
+            name="org_project", is_public=False, owner=org
+        )
+
+        jobs = queue_job(project_org, ProcessProjectfileJob, triggered_by=self.u1)
+
+        self.assertEqual(len(jobs), 1)
+
+        job = jobs[0]
+
+        self.assertNotEqual(job.created_by_id, org_owner.id)
+        self.assertEqual(job.created_by_id, self.u1.id)
+        self.assertNotEqual(job.triggered_by_id, org_owner.id)
+        self.assertEqual(job.triggered_by_id, self.u1.id)
+
+    def test_queue_job_invalid_job_model_raises(self):
+        with self.assertRaises(AssertionError):
+            queue_job(self.p1, PackageJob)
+
+    def test_queue_job_processed_by_worker(self):
+        self._upload_files(
+            self.u1,
+            self.p1,
+            files=[("project.qgs", "delta/project_with_virtual.qgs")],
+        )
+        wait_for_project_ok_status(self.p1)
+
+        jobs = queue_job(self.p1, ProcessProjectfileJob)
+
+        self.assertEqual(len(jobs), 1)
+
+        job = jobs[0]
+
+        wait_for_project_ok_status(self.p1)
+
+        job.refresh_from_db()
+        self.assertEqual(job.status, Job.Status.FINISHED)
+
+    def test_queue_job_queryset_all_jobs_complete(self):
+        p2 = Project.objects.create(name="p2", is_public=False, owner=self.u1)
+
+        for project in [self.p1, p2]:
+            self._upload_files(
+                self.u1,
+                project,
+                files=[("project.qgs", "delta/project_with_virtual.qgs")],
+            )
+            wait_for_project_ok_status(project)
+
+        project_qs = Project.objects.filter(owner=self.u1)
+        jobs = queue_job(project_qs, ProcessProjectfileJob)
+
+        self.assertEqual(len(jobs), 2)
+
+        for project in [self.p1, p2]:
+            wait_for_project_ok_status(project)
+
+        for job in jobs:
+            job.refresh_from_db()
+
+            self.assertEqual(job.status, Job.Status.FINISHED)

--- a/docker-app/qfieldcloud/core/utils2/jobs.py
+++ b/docker-app/qfieldcloud/core/utils2/jobs.py
@@ -158,8 +158,11 @@ def queue_job(
     triggered_by: models.Person | None = None,
 ) -> list[models.Job]:
     """
-    Queues a job of the given type for a (some) given project(s), triggered by the given person - if a person is provided.
+    Queues a job of the given type for given project(s), triggered by the given person.
+
     If triggered by person is not provided, the job will appear to be triggered by the project owner or the project's organization owner.
+
+    This function is not running in a transaction by default, it's caller's responsibility to determine this.
     """
 
     assert job_model in TRIGGERABLE_JOBS

--- a/docker-app/qfieldcloud/core/utils2/jobs.py
+++ b/docker-app/qfieldcloud/core/utils2/jobs.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Iterable
 
 from django.conf import settings
 from django.db import transaction
@@ -8,6 +9,9 @@ import qfieldcloud.core.models as models
 from qfieldcloud.core import exceptions
 
 logger = logging.getLogger(__name__)
+
+# the job types that can be triggered by the `queue_job` function.
+TRIGGERABLE_JOBS = [models.ProcessProjectfileJob]
 
 
 @transaction.atomic
@@ -146,3 +150,50 @@ def repackage_if_needed(
         )
 
     return package_job
+
+
+def queue_job(
+    projects: models.Project | Iterable[models.Project],
+    job_model: type[models.Job],
+    triggered_by: models.Person | None = None,
+) -> list[models.Job]:
+    """
+    Queues a job of the given type for a (some) given project(s), triggered by the given person - if a person is provided.
+    If triggered by person is not provided, the job will appear to be triggered by the project owner or the project's organization owner.
+    """
+
+    assert job_model in TRIGGERABLE_JOBS
+
+    if isinstance(projects, models.Project):
+        projects = [projects]
+
+    if isinstance(projects, models.ProjectQueryset):
+        projects = projects.select_related("owner")
+
+    jobs: list[models.Job] = []
+
+    for project in projects:
+        if triggered_by:
+            assert triggered_by.is_person
+
+            triggered_by_id = triggered_by.id
+        else:
+            if project.owner.is_organization:
+                triggered_by_id = project.owner.organization_owner_id
+            else:
+                triggered_by_id = project.owner_id
+
+        jobs.append(
+            job_model(
+                project=project,
+                created_by_id=triggered_by_id,
+                triggered_by_id=triggered_by_id,
+            )
+        )
+
+    # here, using `job_model.objects.bulk_create(jobs)` could be more efficient,
+    # though it throws `ValueError: Can't bulk create a multi-table inherited model`.
+    for job in jobs:
+        job.save()
+
+    return jobs


### PR DESCRIPTION
This utils function can be used to trigger jobs for given project(s). At the moment, only `ProcessProjectfileJob` can be triggered this way.