### PR TITLE
feat: add process projectfile job trigger button in project admin

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -66,6 +66,7 @@ from qfieldcloud.core.models import (
     Organization,
     OrganizationMember,
     Person,
+    ProcessProjectfileJob,
     Project,
     ProjectCollaborator,
     Secret,
@@ -1291,6 +1292,24 @@ class ProjectAdmin(QFieldCloudModelAdmin):
                 form_obj.instance.updated_by = request.user
 
         super().save_formset(request, form, formset, change)
+
+    def get_urls(self) -> list:
+        urls = super().get_urls()
+        return [
+            path(
+                "<path:object_id>/run-process-projectfile-job/",
+                self.admin_site.admin_view(self.run_process_projectfile_job),
+                name="run_process_projectfile_job",
+            ),
+            *urls,
+        ]
+
+    def run_process_projectfile_job(
+        self, request: HttpRequest, object_id: str
+    ) -> HttpResponse:
+        project = Project.objects.get(pk=object_id)
+        jobs.queue_job(project, ProcessProjectfileJob)
+        return HttpResponseRedirect("..")
 
 
 class DeltaInline(admin.TabularInline):

--- a/docker-app/qfieldcloud/core/templates/admin/project_change_form.html
+++ b/docker-app/qfieldcloud/core/templates/admin/project_change_form.html
@@ -4,6 +4,12 @@
 {% block submit_buttons_bottom %}
   {{ block.super }}
 
+  {% if original %}
+  <div class="form-group">
+    <a href="{% url 'admin:run_process_projectfile_job' original.pk %}" class="btn btn-info form-control">{% trans 'Run process projectfile job' %}</a>
+  </div>
+  {% endif %}
+
   <div class="submit-row">
     <a href="{% url 'admin:core_job_changelist' %}?q={{original.id}}">{% trans 'Project jobs' %}</a>
     |


### PR DESCRIPTION
Adding a new `Run process projectfile job` button in Project Admin, that will create a new `ProcessProjectfileJob` for this Project using the new `queue_job` utils function.

---

Last button in the following Project Admin screenshot :

<img width="396" height="356" alt="image" src="https://github.com/user-attachments/assets/d07e5865-e243-4116-a91d-b34d56a5184b" />

---

Inspired by the existing `Re-run job` Job admin button : https://github.com/opengisch/QFieldCloud/blob/ca81ad6cfdc1b09c5fea0fac441650384fc4a85b/docker-app/qfieldcloud/core/admin.py#L1504-L1506

Superseds #1614 