### PR TITLE
Fix billing subscription failing to load edit page and pointing to the useless `UserAccount`

### DIFF
--- a/docker-app/qfieldcloud/subscription/admin.py
+++ b/docker-app/qfieldcloud/subscription/admin.py
@@ -142,7 +142,7 @@ class SubscriptionAdmin(QFieldCloudModelAdmin):
 
     list_display = (
         "id",
-        "account",
+        "account__link",
         "account__user__email",
         "plan__link",
         "active_since",
@@ -206,6 +206,12 @@ class SubscriptionAdmin(QFieldCloudModelAdmin):
             )
 
         return self.readonly_fields
+
+    @admin.display(description=_("Account"))
+    def account__link(self, instance):
+        return model_admin_url(
+            instance.account.user, instance.account.user.username_with_full_name
+        )
 
     # NOTE if the property is computed property, it cannot be `list_display`/`readonly_fields`
     @admin.display(description=_("Active"), boolean=True)


### PR DESCRIPTION
```
AttributeError at /admin/billing/billingsubscription/11861/change/
Unable to lookup 'account__link' on BillingSubscription or BillingSubscriptionAdmin or BillingSubscriptionForm
```