### PR TITLE
feat: block 3rd party auth for Organizations

### DIFF
--- a/docker-app/qfieldcloud/authentication/tests/test_social_login.py
+++ b/docker-app/qfieldcloud/authentication/tests/test_social_login.py
@@ -1,0 +1,157 @@
+import logging
+from unittest.mock import MagicMock
+
+from allauth.account.models import EmailAddress
+from allauth.socialaccount.models import SocialLogin
+from allauth.socialaccount.providers.dummy.provider import DummyProvider
+from django.test import TestCase, override_settings
+
+from qfieldcloud.core.adapters import SocialAccountAdapter
+from qfieldcloud.core.models import Organization, Person, User
+from qfieldcloud.core.tests.utils import setup_subscription_plans
+
+logging.disable(logging.CRITICAL)
+
+
+class QfcTestCase(TestCase):
+    def setUp(self):
+        setup_subscription_plans()
+        self.dummy_provider = DummyProvider(request=MagicMock(), app=None)
+
+    @override_settings(
+        SOCIALACCOUNT_PROVIDERS={"dummy": {"EMAIL_AUTHENTICATION": True}}
+    )
+    def test_3rd_party_auth_does_not_link_to_organization(self):
+        Organization.objects.create(
+            username="the_org",
+            organization_owner=Person.objects.create(username="org_owner"),
+            email="the_email@qfield.cloud",
+        )
+
+        email_address = EmailAddress(email="the_email@qfield.cloud")
+        sociallogin = SocialLogin(
+            provider=self.dummy_provider, email_addresses=[email_address]
+        )
+
+        adapter = SocialAccountAdapter()
+        match_result = adapter.authenticate_by_email(sociallogin)
+
+        self.assertIsNone(match_result)
+
+    @override_settings(
+        SOCIALACCOUNT_PROVIDERS={"dummy": {"EMAIL_AUTHENTICATION": True}}
+    )
+    def test_3rd_party_auth_does_not_link_to_unverified_email(self):
+        Person.objects.create(
+            username="the_person",
+            email="the_email@qfield.cloud",
+        )
+
+        email_address = EmailAddress(email="the_email@qfield.cloud")
+        sociallogin = SocialLogin(
+            provider=self.dummy_provider, email_addresses=[email_address]
+        )
+
+        adapter = SocialAccountAdapter()
+        match_result = adapter.authenticate_by_email(sociallogin)
+
+        self.assertIsNone(match_result)
+
+    @override_settings(
+        SOCIALACCOUNT_PROVIDERS={"dummy": {"EMAIL_AUTHENTICATION": True}}
+    )
+    def test_3rd_party_auth_links_to_user_and_not_organization(self):
+        # an organization and a person user share the same email address.
+        # note that the Organization is created first.
+        organization = Organization.objects.create(
+            username="the_org",
+            organization_owner=Person.objects.create(username="org_owner"),
+            email="shared@qfield.cloud",
+        )
+
+        person = Person.objects.create(
+            username="the_person",
+            email="shared@qfield.cloud",
+        )
+
+        EmailAddress.objects.create(
+            user=person,
+            email="shared@qfield.cloud",
+            verified=True,
+            primary=True,
+        )
+
+        email_address = EmailAddress(email="shared@qfield.cloud")
+        sociallogin = SocialLogin(
+            provider=self.dummy_provider, email_addresses=[email_address]
+        )
+
+        adapter = SocialAccountAdapter()
+        match_result = adapter.authenticate_by_email(sociallogin)
+
+        self.assertIsNotNone(match_result)
+
+        matched_user, matched_email = match_result
+
+        # social account must be linked to the person user, not the organization.
+        self.assertEqual(matched_user.type, User.Type.PERSON)
+        self.assertEqual(matched_user.pk, person.pk)
+        self.assertNotEqual(matched_user.pk, organization.pk)
+        self.assertEqual(matched_email, "shared@qfield.cloud")
+        self.assertEqual(matched_user.email, "shared@qfield.cloud")
+
+    @override_settings(
+        SOCIALACCOUNT_EMAIL_AUTHENTICATION=False,
+        SOCIALACCOUNT_PROVIDERS={"dummy": {"EMAIL_AUTHENTICATION": False}},
+    )
+    def test_3rd_party_auth_does_not_link_when_not_allowed(self):
+        person = Person.objects.create(
+            username="the_person",
+            email="the_email@qfield.cloud",
+        )
+
+        EmailAddress.objects.create(
+            user=person,
+            email="the_email@qfield.cloud",
+            verified=True,
+            primary=True,
+        )
+
+        email_address = EmailAddress(email="the_email@qfield.cloud")
+        sociallogin = SocialLogin(
+            provider=self.dummy_provider, email_addresses=[email_address]
+        )
+
+        adapter = SocialAccountAdapter()
+        match_result = adapter.authenticate_by_email(sociallogin)
+
+        self.assertIsNone(match_result)
+
+    def test_3rd_party_auth_links_mail_case_insensitive(self):
+        person = Person.objects.create(
+            username="the_person",
+            email="The_Email@qfield.cloud",
+        )
+
+        EmailAddress.objects.create(
+            user=person,
+            email="The_Email@qfield.cloud",
+            verified=True,
+            primary=True,
+        )
+
+        email_address = EmailAddress(email="the_email@qfield.cloud")
+        sociallogin = SocialLogin(
+            provider=self.dummy_provider, email_addresses=[email_address]
+        )
+
+        adapter = SocialAccountAdapter()
+        match_result = adapter.authenticate_by_email(sociallogin)
+
+        self.assertIsNotNone(match_result)
+
+        matched_user, matched_email = match_result
+
+        self.assertEqual(matched_user.pk, person.pk)
+        self.assertEqual(matched_email, "The_Email@qfield.cloud")
+        self.assertEqual(matched_user.email, "The_Email@qfield.cloud")

--- a/docker-app/qfieldcloud/core/adapters.py
+++ b/docker-app/qfieldcloud/core/adapters.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 from allauth.account import app_settings
 from allauth.account.adapter import DefaultAccountAdapter
-from allauth.account.models import EmailConfirmationHMAC
+from allauth.account.models import EmailAddress, EmailConfirmationHMAC
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.models import SocialLogin
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
@@ -19,7 +19,7 @@ from django.utils import timezone
 from invitations.adapters import BaseInvitationsAdapter
 
 from qfieldcloud.authentication.sso.provider_styles import SSOProviderStyles
-from qfieldcloud.core.models import Person
+from qfieldcloud.core.models import Person, User
 
 logger = logging.getLogger(__name__)
 
@@ -281,3 +281,49 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
             and sociallogin.user.pk == request.user.pk
         ):
             sociallogin.user = request.user
+
+    def authenticate_by_email(
+        self, sociallogin: SocialLogin
+    ) -> tuple[AbstractUser, str] | None:
+        """Authenticate user and find User matching by email.
+        This hook happens the first time an email is submitted for 3rd party authentication.
+
+        Only matches Person type users with a verified email address,
+        since Organization cannot login using a 3rd party IDP.
+        """
+
+        emails = sociallogin.email_addresses
+        if not emails:
+            return None
+
+        matching_users = []
+
+        for email_address in emails:
+            email = email_address.email
+
+            verified_users_ids = EmailAddress.objects.filter(
+                email__iexact=email,
+                primary=True,
+                verified=True,
+            ).values_list("user_id", flat=True)
+
+            users = User.objects.filter(
+                type=User.Type.PERSON,
+                email__iexact=email,
+                is_active=True,
+                pk__in=verified_users_ids,
+            )
+
+            matching_users.extend(users.all())
+
+        for user in matching_users:
+            if not self.can_authenticate_by_email(sociallogin, user.email):
+                continue
+
+            logger.info(
+                f"Authenticated user '{user.username}' with email '{user.email}' for social login."
+            )
+
+            return user, user.email
+
+        return None

--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -1,7 +1,7 @@
 boto3-stubs==1.35.90
 boto3==1.35.90
 deprecated==1.3.1
-django-allauth[socialaccount]==65.15.1
+django-allauth[socialaccount]==65.17.0
 django-auditlog==3.4.1
 django-axes==8.3.1
 django-bootstrap4==26.1

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -73,7 +73,7 @@ django==5.2.13
     #   djangorestframework
     #   drf-spectacular
     #   jsonfield
-django-allauth[socialaccount]==65.15.1
+django-allauth[socialaccount]==65.17.0
     # via -r /requirements/requirements.in
 django-auditlog==3.4.1
     # via -r /requirements/requirements.in


### PR DESCRIPTION
This PR intends to allow Social login only to `PERSON` type Users.  
If a Person and an Organization share the same email address, it makes no sense to log in as the Org, with a 3rd party IDP.

Since [this commit](https://codeberg.org/allauth/django-allauth/commit/2c7c4cbb3b66922544b23dc20c46871723a81d0a), `django-allauth` provides a new `authenticate_by_email` hook, that allows the custom implementations of `DefaultSocialAccountAdapter` to have a specific behavior regarding user <-> email matching.  
QFieldCloud's adapter behavior is filtering Users and keep only the `PERSON` type ones. See provided test scenario.

**TODO**: bump the `django-allauth` dependency to a future release version in the requirements, when the commit will be part of a release.

See #1484 for more infos and background.