### PR TITLE
feat: make the jobs `error_stack` a multiline string instead array of multiline strings

### DIFF
--- a/docker-app/qfieldcloud/core/tests/test_delta.py
+++ b/docker-app/qfieldcloud/core/tests/test_delta.py
@@ -118,11 +118,8 @@ class QfcTestCase(APITransactionTestCase):
 
             if job.feedback:
                 if "error_stack" in job.feedback:
-                    msg += "\n\nError:\n================"
-                    for single_error_stack in job.feedback["error_stack"]:
-                        msg += "\n"
-                        msg += single_error_stack
-
+                    msg += "\n\nError stack:\n================"
+                    msg += job.feedback["error_stack"]
                     msg += f"  {job.feedback['error']}\n================"
 
                 feedback = json.dumps(job.feedback, indent=2, sort_keys=True)

--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -1,12 +1,11 @@
 import json
 import logging
 import shutil
-import sys
 import tempfile
-import traceback
 import uuid
 from datetime import timedelta
 from pathlib import Path
+from traceback import TracebackException
 from typing import Any, Iterable
 
 import docker
@@ -71,10 +70,11 @@ class JobRun:
             self.shared_tempdir = Path(tempfile.mkdtemp(dir=TMP_FILE))
         except Exception as err:
             feedback: dict[str, Any] = {}
-            (_type, _value, tb) = sys.exc_info()
+            tb = TracebackException.from_exception(err)
             feedback["error"] = str(err)
             feedback["error_origin"] = "worker_wrapper"
-            feedback["error_stack"] = traceback.format_tb(tb)
+            feedback["error_class"] = type(err).__name__
+            feedback["error_stack"] = "".join(tb.format())
 
             msg = "Uncaught exception when constructing a JobRun:\n"
             msg += json.dumps(msg, indent=2, sort_keys=True)
@@ -274,10 +274,11 @@ class JobRun:
                     if not isinstance(feedback, dict):
                         feedback = {"error_feedback": feedback}
 
-                    (_type, _value, tb) = sys.exc_info()
+                    tb = TracebackException.from_exception(err)
                     feedback["error"] = str(err)
                     feedback["error_origin"] = "worker_wrapper"
-                    feedback["error_stack"] = traceback.format_tb(tb)
+                    feedback["error_class"] = type(err).__name__
+                    feedback["error_stack"] = "".join(tb.format())
 
             feedback["container_exit_code"] = exit_code
 
@@ -313,10 +314,11 @@ class JobRun:
 
         # Global error handler when handling a job
         except Exception as err:  # noqa: BLE001
-            (_type, _value, tb) = sys.exc_info()
+            tb = TracebackException.from_exception(err)
             feedback["error"] = str(err)
             feedback["error_origin"] = "worker_wrapper"
-            feedback["error_stack"] = traceback.format_tb(tb)
+            feedback["error_class"] = type(err).__name__
+            feedback["error_stack"] = "".join(tb.format())
 
             if isinstance(err, requests.exceptions.ReadTimeout):
                 feedback["error_timeout"] = True

--- a/docker-qgis/qfc_worker/workflow.py
+++ b/docker-qgis/qfc_worker/workflow.py
@@ -292,9 +292,9 @@ def run_workflow(
         else:
             feedback["error_type"] = "UNKNOWN"
 
-        _type, _value, tb = sys.exc_info()
+        tb = traceback.TracebackException.from_exception(err)
         feedback["error_class"] = type(err).__name__
-        feedback["error_stack"] = traceback.format_tb(tb)
+        feedback["error_stack"] = "".join(tb.format())
     finally:
         feedback["steps"] = []
         feedback["outputs"] = {}


### PR DESCRIPTION
What is more, if we have a chain `raise Exception from err`, it will also print the error chain, instead of the last error only.

We long struggled with the readability of the `job.feedback.error_stack` field. Because JSON representation make it very ugly to read multiline strings `"line\nsecond"`, back then I made it an array, for slightly better UX.

But this still makes it hard to consume, so let's convert the tb to a string. Nobody expects anything about this field, it's pure human-read field.

---
Tested every single try/except block with a 1/0 exception.