### PR TITLE
fix: ensure UTC timezone is set for maintenance timestamps in API status view

### DIFF
--- a/docker-app/qfieldcloud/core/tests/test_status.py
+++ b/docker-app/qfieldcloud/core/tests/test_status.py
@@ -156,13 +156,15 @@ class QfcTestCase(APITransactionTestCase):
         self.assertEqual(data["incident_message"], "Sample incident message.")
 
         self.assertIn("incident_timestamp_utc", data)
-        self.assertEqual(data["incident_timestamp_utc"], "2002-10-18T12:00:00")
+        self.assertEqual(data["incident_timestamp_utc"], "2002-10-18T12:00:00Z")
 
         self.assertIn("maintenance_start_timestamp_utc", data)
-        self.assertEqual(data["maintenance_start_timestamp_utc"], "2002-10-18T12:00:00")
+        self.assertEqual(
+            data["maintenance_start_timestamp_utc"], "2002-10-18T12:00:00Z"
+        )
 
         self.assertIn("maintenance_end_timestamp_utc", data)
-        self.assertEqual(data["maintenance_end_timestamp_utc"], "2002-10-18T14:00:00")
+        self.assertEqual(data["maintenance_end_timestamp_utc"], "2002-10-18T14:00:00Z")
 
         self.assertIn("maintenance_message", data)
         self.assertEqual(data["maintenance_message"], "Sample maintenance message.")

--- a/docker-app/qfieldcloud/core/views/status_views.py
+++ b/docker-app/qfieldcloud/core/views/status_views.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import timezone
 from enum import Enum
 from typing import TypedDict
 
@@ -69,17 +70,17 @@ class APIStatusView(views.APIView):
         if config.MAINTENANCE_IS_PLANNED:
             logger.info(
                 "Maintenance is planned, reporting maintenance details in status API from %s to %s with message: %s",
-                config.MAINTENANCE_START_TIMESTAMP_UTC,
-                config.MAINTENANCE_END_TIMESTAMP_UTC,
+                config.MAINTENANCE_START_TIMESTAMP_UTC.replace(tzinfo=timezone.utc),
+                config.MAINTENANCE_END_TIMESTAMP_UTC.replace(tzinfo=timezone.utc),
                 config.MAINTENANCE_MESSAGE,
             )
 
             results["maintenance_message"] = config.MAINTENANCE_MESSAGE
             results["maintenance_start_timestamp_utc"] = (
-                config.MAINTENANCE_START_TIMESTAMP_UTC
+                config.MAINTENANCE_START_TIMESTAMP_UTC.replace(tzinfo=timezone.utc)
             )
             results["maintenance_end_timestamp_utc"] = (
-                config.MAINTENANCE_END_TIMESTAMP_UTC
+                config.MAINTENANCE_END_TIMESTAMP_UTC.replace(tzinfo=timezone.utc)
             )
 
         return Response(results, status=status.HTTP_200_OK)

--- a/docker-app/qfieldcloud/core/views/status_views.py
+++ b/docker-app/qfieldcloud/core/views/status_views.py
@@ -60,12 +60,14 @@ class APIStatusView(views.APIView):
         if config.INCIDENT_IS_ACTIVE:
             logger.warning(
                 "Incident is active, reporting incident details in status API since %s with message: %s",
-                config.INCIDENT_TIMESTAMP_UTC,
+                config.INCIDENT_TIMESTAMP_UTC.replace(tzinfo=timezone.utc),
                 config.INCIDENT_MESSAGE,
             )
 
             results["incident_message"] = config.INCIDENT_MESSAGE
-            results["incident_timestamp_utc"] = config.INCIDENT_TIMESTAMP_UTC
+            results["incident_timestamp_utc"] = config.INCIDENT_TIMESTAMP_UTC.replace(
+                tzinfo=timezone.utc
+            )
 
         if config.MAINTENANCE_IS_PLANNED:
             logger.info(


### PR DESCRIPTION
When calling `/status` API we get :

```json
{
    "database": "ok",
    "storage": "ok",
    "status_page_url": "https://status.qfield.cloud/",
    "incident_message": "QFieldCloud is currently experiencing stability issues. Our team is investigating the problem.",
    "incident_timestamp_utc": "2026-05-25T18:33:50+02:00",
    "maintenance_message": "QFieldCloud will be undergoing maintenance. During this time, the service might be unavailable.",
    "maintenance_start_timestamp_utc": "2026-05-25T18:00:00+02:00",
    "maintenance_end_timestamp_utc": "2026-05-25T20:00:00+02:00"
}
```

It should be in UTC instead without actually converting the time.

Now :

```json
{
    "database": "ok",
    "storage": "ok",
    "status_page_url": "https://status.qfield.cloud/",
    "incident_message": "QFieldCloud is currently experiencing stability issues. Our team is investigating the problem.",
    "incident_timestamp_utc": "2026-05-25T18:33:50Z",
    "maintenance_message": "QFieldCloud will be undergoing maintenance. During this time, the service might be unavailable.",
    "maintenance_start_timestamp_utc": "2026-05-25T18:00:00Z",
    "maintenance_end_timestamp_utc": "2026-05-25T20:00:00Z"
}
```