### PR TITLE
fix: also install `tzdata-legacy` to support legacy timezones

### DIFF
--- a/docker-app/Dockerfile
+++ b/docker-app/Dockerfile
@@ -66,6 +66,8 @@ RUN apt-get update \
     graphviz \
 # timezone data used by python to determine the user's timezone
     tzdata \
+# needed to support the `US/Pacific` etc timezones, which were dropped from the regular `tzdata`, see https://bugs-devel.debian.org/cgi-bin/bugreport.cgi?bug=1051973
+    tzdata-legacy \
     && rm -rf /var/lib/apt/lists/*
 
 # copy the dependencies


### PR DESCRIPTION
Apparently there are users still using `US/Pacific` or similar long deprecated timezones.

If the package is not installed, errors such as:
```
["Invalid timezone 'US/Pacific'"]
```

appear, when the `core_useraccount.timezone` is set to a legacy timezone.

See:
https://bugs-devel.debian.org/cgi-bin/bugreport.cgi?bug=1051973