### PR TITLE
fix: preserve package files for non-member users on public projects

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1388,6 +1388,13 @@ class Project(models.Model):
         Returns:
             QuerySet of all the last package jobs.
         """
+        if self.is_public:
+            return (
+                PackageJob.objects.filter(project_id=self.id)
+                .order_by("triggered_by", "-created_at")
+                .distinct("triggered_by")
+            )
+
         if self.owner.is_organization:
             # all the users including the organization owner
             triggered_by_qs = Person.objects.for_organization(self.owner)

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1388,12 +1388,16 @@ class Project(models.Model):
         Returns:
             QuerySet of all the last package jobs.
         """
-        if self.is_public:
-            return (
-                PackageJob.objects.filter(project_id=self.id)
-                .order_by("triggered_by", "-created_at")
-                .distinct("triggered_by")
+        jobs_qs = (
+            PackageJob.objects.filter(
+                project_id=self.id,
             )
+            .order_by("triggered_by", "-created_at")
+            .distinct("triggered_by")
+        )
+
+        if self.is_public:
+            return jobs_qs
 
         if self.owner.is_organization:
             # all the users including the organization owner
@@ -1406,14 +1410,7 @@ class Project(models.Model):
         )
         triggered_by_ids_qs = triggered_by_qs.distinct().values_list("id", flat=True)
 
-        jobs_qs = (
-            PackageJob.objects.filter(
-                project_id=self.id,
-                triggered_by__in=triggered_by_ids_qs,
-            )
-            .order_by("triggered_by", "-created_at")
-            .distinct("triggered_by")
-        )
+        jobs_qs = jobs_qs.filter(triggered_by__in=triggered_by_ids_qs)
 
         return jobs_qs
 

--- a/docker-app/qfieldcloud/core/tests/test_packages.py
+++ b/docker-app/qfieldcloud/core/tests/test_packages.py
@@ -998,3 +998,34 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
         self.assertIn(package_job_owner, latest_package_jobs_qs)
         self.assertIn(package_job_admin, latest_package_jobs_qs)
         self.assertIn(package_job_member, latest_package_jobs_qs)
+
+    def test_public_project_non_member_latest_package_jobs(self):
+        """Non-members who trigger package jobs on public projects must be
+        included in latest_package_jobs so their files are not deleted by cleanup."""
+
+        owner = Person.objects.create_user(username="project_owner")
+
+        project = Project.objects.create(
+            name="public_project",
+            owner=owner,
+            is_public=True,
+        )
+
+        non_member = Person.objects.create_user(username="non_member")
+
+        owner_package_job = PackageJob.objects.create(
+            project=project,
+            created_by=owner,
+            triggered_by=owner,
+        )
+
+        non_member_package_job = PackageJob.objects.create(
+            project=project,
+            created_by=non_member,
+            triggered_by=non_member,
+        )
+
+        latest_package_jobs_qs = project.latest_package_jobs()
+
+        self.assertIn(owner_package_job, latest_package_jobs_qs)
+        self.assertIn(non_member_package_job, latest_package_jobs_qs)


### PR DESCRIPTION
`latest_package_jobs()` was filtering the cleanup (`delete_obsolete_packages`) protection set to only include the project owner and direct collaborators Package jobs triggered by public users were excluded, causing their files to be deleted immediately after the next cleanup run and resulting in a 400 `invalid_job` error

Added a conditional check for public projects to bypass the collaborator-only filter so the latest job per distinct `triggered_by` user is preserved regardless of membership status