### PR TITLE
 feat: allow authenticate by unverified email if verification not mandatory

### DIFF
--- a/docker-app/qfieldcloud/authentication/tests/test_social_login.py
+++ b/docker-app/qfieldcloud/authentication/tests/test_social_login.py
@@ -1,6 +1,7 @@
 import logging
 from unittest.mock import MagicMock
 
+from allauth.account import app_settings
 from allauth.account.models import EmailAddress
 from allauth.socialaccount.models import SocialLogin
 from allauth.socialaccount.providers.dummy.provider import DummyProvider
@@ -39,9 +40,12 @@ class QfcTestCase(TestCase):
         self.assertIsNone(match_result)
 
     @override_settings(
-        SOCIALACCOUNT_PROVIDERS={"dummy": {"EMAIL_AUTHENTICATION": True}}
+        ACCOUNT_EMAIL_VERIFICATION=app_settings.EmailVerificationMethod.MANDATORY,
+        SOCIALACCOUNT_PROVIDERS={"dummy": {"EMAIL_AUTHENTICATION": True}},
     )
-    def test_3rd_party_auth_does_not_link_to_unverified_email(self):
+    def test_3rd_party_auth_does_not_link_to_unverified_email_when_verification_mandatory(
+        self,
+    ):
         Person.objects.create(
             username="the_person",
             email="the_email@qfield.cloud",
@@ -58,7 +62,36 @@ class QfcTestCase(TestCase):
         self.assertIsNone(match_result)
 
     @override_settings(
-        SOCIALACCOUNT_PROVIDERS={"dummy": {"EMAIL_AUTHENTICATION": True}}
+        ACCOUNT_EMAIL_VERIFICATION=app_settings.EmailVerificationMethod.OPTIONAL,
+        SOCIALACCOUNT_PROVIDERS={"dummy": {"EMAIL_AUTHENTICATION": True}},
+    )
+    def test_3rd_party_auth_links_to_user_with_unverified_email_when_verification_optional(
+        self,
+    ):
+        person = Person.objects.create(
+            username="the_person",
+            email="the_email@qfield.cloud",
+        )
+
+        email_address = EmailAddress(email="the_email@qfield.cloud")
+        sociallogin = SocialLogin(
+            provider=self.dummy_provider, email_addresses=[email_address]
+        )
+
+        adapter = SocialAccountAdapter()
+        match_result = adapter.authenticate_by_email(sociallogin)
+
+        self.assertIsNotNone(match_result)
+
+        matched_user, matched_email = match_result
+
+        self.assertEqual(matched_user.pk, person.pk)
+        self.assertEqual(matched_email, "the_email@qfield.cloud")
+        self.assertEqual(matched_user.email, "the_email@qfield.cloud")
+
+    @override_settings(
+        ACCOUNT_EMAIL_VERIFICATION=app_settings.EmailVerificationMethod.MANDATORY,
+        SOCIALACCOUNT_PROVIDERS={"dummy": {"EMAIL_AUTHENTICATION": True}},
     )
     def test_3rd_party_auth_links_to_user_and_not_organization(self):
         # an organization and a person user share the same email address.
@@ -127,6 +160,10 @@ class QfcTestCase(TestCase):
 
         self.assertIsNone(match_result)
 
+    @override_settings(
+        ACCOUNT_EMAIL_VERIFICATION=app_settings.EmailVerificationMethod.MANDATORY,
+        SOCIALACCOUNT_PROVIDERS={"dummy": {"EMAIL_AUTHENTICATION": True}},
+    )
     def test_3rd_party_auth_links_mail_case_insensitive(self):
         person = Person.objects.create(
             username="the_person",

--- a/docker-app/qfieldcloud/core/adapters.py
+++ b/docker-app/qfieldcloud/core/adapters.py
@@ -11,6 +11,7 @@ from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.models import SocialLogin
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 from constance import config
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import AbstractUser
 from django.core.exceptions import ValidationError
@@ -301,18 +302,25 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
         for email_address in emails:
             email = email_address.email
 
-            verified_users_ids = EmailAddress.objects.filter(
-                email__iexact=email,
-                primary=True,
-                verified=True,
-            ).values_list("user_id", flat=True)
-
             users = User.objects.filter(
                 type=User.Type.PERSON,
                 email__iexact=email,
                 is_active=True,
-                pk__in=verified_users_ids,
             )
+
+            # here we check if the email address is verified, but only if the email verification is mandatory,
+            # otherwise we allow unverified emails to authenticate as well.
+            if (
+                settings.ACCOUNT_EMAIL_VERIFICATION
+                == app_settings.EmailVerificationMethod.MANDATORY
+            ):
+                verified_users_ids = EmailAddress.objects.filter(
+                    email__iexact=email,
+                    primary=True,
+                    verified=True,
+                ).values_list("user_id", flat=True)
+
+                users = users.filter(pk__in=verified_users_ids)
 
             matching_users.extend(users.all())
 


### PR DESCRIPTION
When logging in with a 3rd party IDP, social account linking currently checks and looks for verified email addresses.  
Though, if the QFieldCloud instance is configured with `ACCOUNT_EMAIL_VERIFICATION=optional`, the `authenticate_by_email` hook of the social account adapter shall not look for verified email addresses - this is the change brought by this PR.

Tests are also updated to match this new behavior, based on the app's settings.

Follow-up of #1623 