### PR TITLE
Force linux/amd64 Docker images for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -457,6 +457,10 @@ COMPOSE_FILE=docker-compose.yml:docker-compose.override.local.yml:docker-compose
 # DEFAULT: :
 COMPOSE_PATH_SEPARATOR=:
 
+# Forces Docker to use the amd64 platform when building or pulling images.
+# Useful on Apple Silicon (arm64) Macs where some images are only available for amd64.
+# DEFAULT: linux/amd64
+DOCKER_DEFAULT_PLATFORM=linux/amd64
 
 ##################
 # Standalone settings - development only

--- a/docker-compose.override.standalone.yml
+++ b/docker-compose.override.standalone.yml
@@ -2,7 +2,6 @@ services:
 
   db:
     image: postgis/postgis:${POSTGIS_IMAGE_VERSION}
-    platform: linux/amd64
     restart: unless-stopped
     environment:
       POSTGRES_DB: ${POSTGRES_DB}
@@ -71,7 +70,6 @@ services:
 
   webdav:
     image: bytemark/webdav:2.4
-    platform: linux/amd64
     restart: unless-stopped
     ports:
       - ${WEBDAV_PUBLIC_PORT}:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,6 @@ services:
   # Automatically create self-signed certificates for local development and test deployments
   mkcert:
     image: vishnunair/docker-mkcert
-    platform: linux/amd64
     environment:
       domain: ${QFIELDCLOUD_HOST}
     volumes:

--- a/docker-qgis/Dockerfile
+++ b/docker-qgis/Dockerfile
@@ -1,5 +1,5 @@
 # NOTE if the ubuntu version is changed, also change it in `Suites:` in apt sources, and in `QGIS_VERSION`
-FROM --platform=linux/amd64 ubuntu:noble
+FROM  ubuntu:noble
 
 # Create the expected /io directory that is usually created via the `worker_wrapper`
 RUN mkdir -p /io

--- a/docker-qgis/Dockerfile
+++ b/docker-qgis/Dockerfile
@@ -1,5 +1,5 @@
 # NOTE if the ubuntu version is changed, also change it in `Suites:` in apt sources, and in `QGIS_VERSION`
-FROM  ubuntu:noble
+FROM ubuntu:noble
 
 # Create the expected /io directory that is usually created via the `worker_wrapper`
 RUN mkdir -p /io

--- a/scripts/check_envvars.py
+++ b/scripts/check_envvars.py
@@ -23,7 +23,11 @@ def get_env_varnames_from_envfile(filename: str) -> set[str]:
             variable_name = line.strip().split("=")[0]
 
             # not settings
-            if variable_name in ["COMPOSE_FILE", "COMPOSE_PATH_SEPARATOR"]:
+            if variable_name in [
+                "COMPOSE_FILE",
+                "COMPOSE_PATH_SEPARATOR",
+                "DOCKER_DEFAULT_PLATFORM",
+            ]:
                 continue
 
             result.add(variable_name)


### PR DESCRIPTION
When starting the development environment on an arm64 machine, Docker fails with a platform mismatch. The docker-createbuckets Dockerfile uses ubuntu:noble (pulled as linux/arm64 on Apple Silicon) but installs a hardcoded linux/amd64 binary for the rustfs, causing an architecture conflict.