### PR TITLE
Replace the usage of fiona with geopandas in tests

### DIFF
--- a/docker-app/Dockerfile
+++ b/docker-app/Dockerfile
@@ -18,10 +18,6 @@ RUN apt-get update \
     libpq-dev \
     python3-dev \
     gcc \
-    # fiona dependencies
-    g++ \
-    libgdal-dev \
-    gdal-bin \
     # ability to install modules from git repositories (e.g. `django-cron`)
     git \
     && rm -rf /var/lib/apt/lists/*
@@ -115,22 +111,11 @@ USER app
 # WEBSERVER TEST         #
 ##########################
 
-# a separate builder stage for webserver test environment to compile `fiona` only
-FROM build AS build_webserver_test
-COPY ./requirements/requirements_test.txt requirements/requirements_test.txt
-RUN echo "GDAL_VERSION=$(gdalinfo --version | cut -d, -f1 | cut -d' ' -f2)"
-RUN export GDAL_VERSION=$(gdalinfo --version | cut -d, -f1 | cut -d' ' -f2); echo "GDAL_VERSION=$GDAL_VERSION" && pip3 install $(grep ^fiona requirements/requirements_test.txt)
-
 # a separate stage for webserver test environment
 FROM base AS webserver_test
 ENV LOGGER_SOURCE=app
-
-# Copy fiona only
-COPY --from=build_webserver_test /usr/local/lib/python3.14/site-packages/fiona /usr/local/lib/python3.14/site-packages/fiona/
-COPY --from=build_webserver_test /usr/local/lib/python3.14/site-packages/fiona-1.10.1.dist-info /usr/local/lib/python3.14/site-packages/fiona-1.10.1.dist-info
-
 COPY ./requirements/requirements_test.txt requirements/requirements_test.txt
-RUN export GDAL_VERSION=$(gdalinfo --version | cut -d, -f1 | cut -d' ' -f2); echo "GDAL_VERSION=$GDAL_VERSION" && pip3 install -r requirements/requirements_test.txt
+RUN pip3 install -r requirements/requirements_test.txt
 EXPOSE 8000
 
 COPY . .

--- a/docker-app/qfieldcloud/core/tests/test_delta.py
+++ b/docker-app/qfieldcloud/core/tests/test_delta.py
@@ -1,18 +1,18 @@
 import io
 import json
 import logging
+import tempfile
 import time
 from datetime import datetime
 from typing import NoReturn
 from unittest import mock, skip
 from uuid import UUID
 
-import fiona
+import geopandas as gpd
 import rest_framework
 from django.http.response import FileResponse
 from rest_framework import response, status
 from rest_framework.test import APITransactionTestCase
-from shapely.geometry import shape
 
 from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core.models import (
@@ -187,10 +187,9 @@ class QfcTestCase(APITransactionTestCase):
             ],
         )
 
-        gpkg = io.BytesIO(self.get_file_contents(project, "testdata.gpkg"))
-        with fiona.open(gpkg, layer="points_xy") as layer:
-            features = list(layer)
-            self.assertEqual(666, features[0]["properties"]["int"])
+        gdf = self.read_gpkg_layer(project, "testdata.gpkg", "points_xy")
+
+        self.assertEqual(666, gdf.iloc[0]["int"])
 
     def test_push_apply_delta_file_empty_source_layer_id(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
@@ -209,10 +208,9 @@ class QfcTestCase(APITransactionTestCase):
             ],
         )
 
-        gpkg = io.BytesIO(self.get_file_contents(project, "testdata.gpkg"))
-        with fiona.open(gpkg, layer="points_xy") as layer:
-            features = list(layer)
-            self.assertEqual(666, features[0]["properties"]["int"])
+        gdf = self.read_gpkg_layer(project, "testdata.gpkg", "points_xy")
+
+        self.assertEqual(666, gdf.iloc[0]["int"])
 
     def test_push_apply_delta_file_with_null_char(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
@@ -231,10 +229,9 @@ class QfcTestCase(APITransactionTestCase):
             ],
         )
 
-        gpkg = io.BytesIO(self.get_file_contents(project, "testdata.gpkg"))
-        with fiona.open(gpkg, layer="points_xy") as layer:
-            features = list(layer)
-            self.assertEqual("", features[0]["properties"]["str"])
+        gdf = self.read_gpkg_layer(project, "testdata.gpkg", "points_xy")
+
+        self.assertEqual("", gdf.iloc[0]["str"])
 
     def test_push_apply_delta_file_with_error(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
@@ -343,10 +340,9 @@ class QfcTestCase(APITransactionTestCase):
             ],
         )
 
-        gpkg = io.BytesIO(self.get_file_contents(project, "testdata.gpkg"))
-        with fiona.open(gpkg, layer="points_xy") as layer:
-            features = list(layer)
-            self.assertEqual(666, features[0]["properties"]["int"])
+        gdf = self.read_gpkg_layer(project, "testdata.gpkg", "points_xy")
+
+        self.assertEqual(666, gdf.iloc[0]["int"])
 
         self.upload_and_check_deltas(
             project=project,
@@ -945,15 +941,13 @@ class QfcTestCase(APITransactionTestCase):
             ],
         )
 
-        gpkg = io.BytesIO(self.get_file_contents(project, "testdata.gpkg"))
-        with fiona.open(gpkg, "r", layer="points_xy") as layer:
-            features = list(layer)
+        gdf = self.read_gpkg_layer(project, "testdata.gpkg", "points_xy")
 
-            self.assertEqual(len(features), 4)
-            self.assertEqual(features[0]["properties"]["int"], 1)
-            self.assertEqual(features[1]["properties"]["int"], 2)
-            self.assertEqual(features[2]["properties"]["int"], 3)
-            self.assertEqual(features[3]["properties"]["int"], 1000)
+        self.assertEqual(len(gdf), 4)
+        self.assertEqual(gdf.iloc[0]["int"], 1)
+        self.assertEqual(gdf.iloc[1]["int"], 2)
+        self.assertEqual(gdf.iloc[2]["int"], 3)
+        self.assertEqual(gdf.iloc[3]["int"], 1000)
 
         # 2) client 2 creates a feature
         self.upload_and_check_deltas(
@@ -969,16 +963,14 @@ class QfcTestCase(APITransactionTestCase):
             ],
         )
 
-        gpkg = io.BytesIO(self.get_file_contents(project, "testdata.gpkg"))
-        with fiona.open(gpkg, "r", layer="points_xy") as layer:
-            features = list(layer)
+        gdf = self.read_gpkg_layer(project, "testdata.gpkg", "points_xy")
 
-            self.assertEqual(len(features), 5)
-            self.assertEqual(features[0]["properties"]["int"], 1)
-            self.assertEqual(features[1]["properties"]["int"], 2)
-            self.assertEqual(features[2]["properties"]["int"], 3)
-            self.assertEqual(features[3]["properties"]["int"], 1000)
-            self.assertEqual(features[4]["properties"]["int"], 2000)
+        self.assertEqual(len(gdf), 5)
+        self.assertEqual(gdf.iloc[0]["int"], 1)
+        self.assertEqual(gdf.iloc[1]["int"], 2)
+        self.assertEqual(gdf.iloc[2]["int"], 3)
+        self.assertEqual(gdf.iloc[3]["int"], 1000)
+        self.assertEqual(gdf.iloc[4]["int"], 2000)
 
         # 3) client 1 updates their created feature
         self.upload_and_check_deltas(
@@ -994,16 +986,14 @@ class QfcTestCase(APITransactionTestCase):
             ],
         )
 
-        gpkg = io.BytesIO(self.get_file_contents(project, "testdata.gpkg"))
-        with fiona.open(gpkg, "r", layer="points_xy") as layer:
-            features = list(layer)
+        gdf = self.read_gpkg_layer(project, "testdata.gpkg", "points_xy")
 
-            self.assertEqual(len(features), 5)
-            self.assertEqual(features[0]["properties"]["int"], 1)
-            self.assertEqual(features[1]["properties"]["int"], 2)
-            self.assertEqual(features[2]["properties"]["int"], 3)
-            self.assertEqual(features[3]["properties"]["int"], 1001)
-            self.assertEqual(features[4]["properties"]["int"], 2000)
+        self.assertEqual(len(gdf), 5)
+        self.assertEqual(gdf.iloc[0]["int"], 1)
+        self.assertEqual(gdf.iloc[1]["int"], 2)
+        self.assertEqual(gdf.iloc[2]["int"], 3)
+        self.assertEqual(gdf.iloc[3]["int"], 1001)
+        self.assertEqual(gdf.iloc[4]["int"], 2000)
 
         # 4) client 2 updates their created feature
         self.upload_and_check_deltas(
@@ -1019,16 +1009,14 @@ class QfcTestCase(APITransactionTestCase):
             ],
         )
 
-        gpkg = io.BytesIO(self.get_file_contents(project, "testdata.gpkg"))
-        with fiona.open(gpkg, "r", layer="points_xy") as layer:
-            features = list(layer)
+        gdf = self.read_gpkg_layer(project, "testdata.gpkg", "points_xy")
 
-            self.assertEqual(len(features), 5)
-            self.assertEqual(features[0]["properties"]["int"], 1)
-            self.assertEqual(features[1]["properties"]["int"], 2)
-            self.assertEqual(features[2]["properties"]["int"], 3)
-            self.assertEqual(features[3]["properties"]["int"], 1001)
-            self.assertEqual(features[4]["properties"]["int"], 2002)
+        self.assertEqual(len(gdf), 5)
+        self.assertEqual(gdf.iloc[0]["int"], 1)
+        self.assertEqual(gdf.iloc[1]["int"], 2)
+        self.assertEqual(gdf.iloc[2]["int"], 3)
+        self.assertEqual(gdf.iloc[3]["int"], 1001)
+        self.assertEqual(gdf.iloc[4]["int"], 2002)
 
         # 5) client 1 deletes their created feature
         self.upload_and_check_deltas(
@@ -1044,15 +1032,13 @@ class QfcTestCase(APITransactionTestCase):
             ],
         )
 
-        gpkg = io.BytesIO(self.get_file_contents(project, "testdata.gpkg"))
-        with fiona.open(gpkg, "r", layer="points_xy") as layer:
-            features = list(layer)
+        gdf = self.read_gpkg_layer(project, "testdata.gpkg", "points_xy")
 
-            self.assertEqual(len(features), 4)
-            self.assertEqual(features[0]["properties"]["int"], 1)
-            self.assertEqual(features[1]["properties"]["int"], 2)
-            self.assertEqual(features[2]["properties"]["int"], 3)
-            self.assertEqual(features[3]["properties"]["int"], 2002)
+        self.assertEqual(len(gdf), 4)
+        self.assertEqual(gdf.iloc[0]["int"], 1)
+        self.assertEqual(gdf.iloc[1]["int"], 2)
+        self.assertEqual(gdf.iloc[2]["int"], 3)
+        self.assertEqual(gdf.iloc[3]["int"], 2002)
 
         # 6) client 2 deletes their created feature
         self.upload_and_check_deltas(
@@ -1068,14 +1054,12 @@ class QfcTestCase(APITransactionTestCase):
             ],
         )
 
-        gpkg = io.BytesIO(self.get_file_contents(project, "testdata.gpkg"))
-        with fiona.open(gpkg, "r", layer="points_xy") as layer:
-            features = list(layer)
+        gdf = self.read_gpkg_layer(project, "testdata.gpkg", "points_xy")
 
-            self.assertEqual(len(features), 3)
-            self.assertEqual(features[0]["properties"]["int"], 1)
-            self.assertEqual(features[1]["properties"]["int"], 2)
-            self.assertEqual(features[2]["properties"]["int"], 3)
+        self.assertEqual(len(gdf), 3)
+        self.assertEqual(gdf.iloc[0]["int"], 1)
+        self.assertEqual(gdf.iloc[1]["int"], 2)
+        self.assertEqual(gdf.iloc[2]["int"], 3)
 
     def test_push_list_multilayer_multidelta(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
@@ -1358,14 +1342,14 @@ class QfcTestCase(APITransactionTestCase):
                     if layer_name is None:
                         continue
 
-                    layer = fiona.open(
-                        io.BytesIO(self.get_file_contents(project, "testdata.gpkg")),
-                        layer=layer_name,
-                    )
-
                     if delta.content["method"] in ("create", "patch"):
                         fid = delta.last_modified_pk
-                        matched_features = list(filter(lambda f: f.id == fid, layer))
+                        with tempfile.NamedTemporaryFile(suffix=".gpkg") as tmp:
+                            tmp.write(self.get_file_contents(project, "testdata.gpkg"))
+                            tmp.flush()
+                            matched_features = gpd.read_file(
+                                tmp.name, layer=layer_name, fids=[int(fid)]
+                            )
 
                         if len(matched_features) == 0:
                             self.fail(
@@ -1376,17 +1360,23 @@ class QfcTestCase(APITransactionTestCase):
                                 f"More than one feature found in the resulting gpkg: {fid=} {layer_name=} {layer_id=} "
                             )
 
-                        f = matched_features[0]
+                        f = matched_features.iloc[0]
                         new = delta.content["new"]
 
                         if "geometry" in new:
                             new_geometry_wkt = new["geometry"].replace("nan", "0")
                             # shapely's WKT is `POINT Z` instead of QGIS "POINTZ"
-                            shapely_wkt = shape(f.geometry).wkt.replace(
-                                "POINT Z", "POINTZ"
-                            )
+                            shapely_wkt = f.geometry.wkt.replace("POINT Z", "POINTZ")
                             self.assertEqual(shapely_wkt, new_geometry_wkt)
 
                 return
 
         self.fail("Worker didn't finish", job=job)
+
+    def read_gpkg_layer(
+        self, project: Project, filename: str, layer: str
+    ) -> gpd.GeoDataFrame:
+        with tempfile.NamedTemporaryFile(suffix=".gpkg") as tmp:
+            tmp.write(self.get_file_contents(project, filename))
+            tmp.flush()
+            return gpd.read_file(tmp.name, layer=layer)

--- a/docker-app/qfieldcloud/core/tests/test_delta.py
+++ b/docker-app/qfieldcloud/core/tests/test_delta.py
@@ -1278,7 +1278,7 @@ class QfcTestCase(APITransactionTestCase):
         ).latest("updated_at")
 
         for _ in range(10):
-            time.sleep(2)
+            time.sleep(3)
             response = self.client.get(uri)
 
             self.assertHttpOk(response)

--- a/docker-app/qfieldcloud/core/tests/test_delta.py
+++ b/docker-app/qfieldcloud/core/tests/test_delta.py
@@ -616,7 +616,7 @@ class QfcTestCase(APITransactionTestCase):
             ],
         )
 
-    @skip("Enable when Fiona and Shapely support Z and M dimensions")
+    @skip("Enable when pyogrio supports Measured (M) geometry types")
     def test_delta_with_xy_for_xyzm_layer(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
         project = self.upload_project_files(self.project1)
@@ -639,7 +639,7 @@ class QfcTestCase(APITransactionTestCase):
             ],
         )
 
-    @skip("Enable when Fiona and Shapely support Z and M dimensions")
+    @skip("Enable when pyogrio supports Measured (M) geometry types")
     def test_delta_with_xyz_for_xyzm_layer(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
         project = self.upload_project_files(self.project1)
@@ -662,7 +662,7 @@ class QfcTestCase(APITransactionTestCase):
             ],
         )
 
-    @skip("Enable when Fiona and Shapely support Z and M dimensions")
+    @skip("Enable when pyogrio supports Measured (M) geometry types")
     def test_delta_with_xyz_nan_for_xyzm_layer(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
         project = self.upload_project_files(self.project1)
@@ -685,7 +685,7 @@ class QfcTestCase(APITransactionTestCase):
             ],
         )
 
-    @skip("Enable when Fiona and Shapely support Z and M dimensions")
+    @skip("Enable when pyogrio supports Measured (M) geometry types")
     def test_delta_with_xyzm_for_xyzm_layer(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
         project = self.upload_project_files(self.project1)
@@ -708,7 +708,7 @@ class QfcTestCase(APITransactionTestCase):
             ],
         )
 
-    @skip("Enable when Fiona and Shapely support Z and M dimensions")
+    @skip("Enable when pyogrio supports Measured (M) geometry types")
     def test_delta_with_xyzm_nan_for_xyzm_layer(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
         project = self.upload_project_files(self.project1)
@@ -731,7 +731,7 @@ class QfcTestCase(APITransactionTestCase):
             ],
         )
 
-    @skip("Enable when Fiona and Shapely support Z and M dimensions")
+    @skip("Enable when Shapely supports M dimension in WKT output")
     def test_delta_with_xyzm_nannan_for_xyzm_layer(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
         project = self.upload_project_files(self.project1)

--- a/docker-app/requirements/requirements_test.in
+++ b/docker-app/requirements/requirements_test.in
@@ -1,6 +1,5 @@
-fiona==1.*
 imageio==2.*
 requests-mock==1.*
 selenium==4.*
-shapely==2.*
 coverage==7.11.0
+geopandas==1.*

--- a/docker-app/requirements/requirements_test.txt
+++ b/docker-app/requirements/requirements_test.txt
@@ -6,28 +6,19 @@
 #
 attrs==26.1.0
     # via
-    #   fiona
     #   outcome
     #   trio
 certifi==2026.4.22
     # via
-    #   fiona
+    #   pyogrio
+    #   pyproj
     #   requests
     #   selenium
 charset-normalizer==3.4.7
     # via requests
-click==8.3.3
-    # via
-    #   click-plugins
-    #   cligj
-    #   fiona
-click-plugins==1.1.1.2
-    # via fiona
-cligj==0.7.2
-    # via fiona
 coverage==7.11.0
     # via -r /requirements/requirements_test.in
-fiona==1.10.1
+geopandas==1.1.3
     # via -r /requirements/requirements_test.in
 h11==0.16.0
     # via wsproto
@@ -39,16 +30,31 @@ imageio==2.37.3
     # via -r /requirements/requirements_test.in
 numpy==2.4.4
     # via
+    #   geopandas
     #   imageio
+    #   pandas
+    #   pyogrio
     #   shapely
 outcome==1.3.0.post0
     # via
     #   trio
     #   trio-websocket
+packaging==26.2
+    # via
+    #   geopandas
+    #   pyogrio
+pandas==3.0.3
+    # via geopandas
 pillow==12.2.0
     # via imageio
+pyogrio==0.12.1
+    # via geopandas
+pyproj==3.7.2
+    # via geopandas
 pysocks==1.7.1
     # via urllib3
+python-dateutil==2.9.0.post0
+    # via pandas
 requests==2.34.0
     # via requests-mock
 requests-mock==1.12.1
@@ -56,7 +62,9 @@ requests-mock==1.12.1
 selenium==4.44.0
     # via -r /requirements/requirements_test.in
 shapely==2.1.2
-    # via -r /requirements/requirements_test.in
+    # via geopandas
+six==1.17.0
+    # via python-dateutil
 sniffio==1.3.1
     # via trio
 sortedcontainers==2.4.0


### PR DESCRIPTION
Fiona is abandoned. Remove the fiona dependency, add geopandas as tests dependency.

**Details:**
When GPKG files were read from an in-memory io.BytesIO buffer, pyogrio mapped them to a /vsimem/ path with no .gpkg extension and no write access, producing two RuntimeWarnings on every read:
* "File has GPKG application_id, but non conformant file extension"
* "WAL-enabled database … retrying with IMMUTABLE=YES"

Fixed by writing the bytes to a `tempfile.NamedTemporaryFile(suffix=".gpkg")` before reading, giving **pyogrio** a real file path with the correct extension and a writable filesystem for WAL handling. 
The repeated pattern was extracted into a `read_gpkg_layer` helper method.

**Flaky tests due to tight polling timeout**
`check_deltas_by_file_id` polled for delta status with a fixed 20-second window (10 × 2s). `test_push_list_deltas` uploads two delta files sequentially, triggering two jobs (~18s total). On slower runs the worker exceeded the window, causing an intermittent failure unrelated to correctness. 
Increased the timeout to 30s (10 × 3s).

**Updated skip message for XYZM tests**
The skipped XYZM tests referenced "Fiona and Shapely" as the blocker. Fiona is no longer used (replaced by pyogrio). Currently geopandas and shapely support Z and M dimensions. The actual blocker is pyogrio itself, which silently drops M coordinates:
* UserWarning: Measured (M) geometry types are not supported. Original type 'Measured 3D Point' is converted to 'Point Z'