### PR TITLE
Include team members in the collaborator count when displaying project collaborators in overview

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1825,26 +1825,33 @@ class Project(models.Model):
         )
 
     @property
-    def collaborators_count(self) -> int:
+    def total_collaborators(self) -> PersonQueryset:
         if self.owner.is_organization:
             exclude_pks = [self.owner.organization.organization_owner_id]
         else:
             exclude_pks = [self.owner_id]
 
-        team_collab_ids = (
+        team_collaborators_ids = (
             self.collaborators.skip_incognito()  # type: ignore[attr-defined]
             .filter(collaborator__type=User.Type.TEAM)
             .values_list("collaborator_id", flat=True)
         )
-        return (
-            self.direct_collaborators.values_list("collaborator_id", flat=True)
-            .union(
-                TeamMember.objects.filter(team_id__in=team_collab_ids)
-                .exclude(member_id__in=exclude_pks)
-                .values_list("member_id", flat=True)
-            )
-            .count()
+        direct_ids = self.direct_collaborators.values_list("collaborator_id", flat=True)
+        team_member_ids = (
+            TeamMember.objects.filter(team_id__in=team_collaborators_ids)
+            .exclude(member_id__in=exclude_pks)
+            .values_list("member_id", flat=True)
         )
+        return cast(
+            PersonQueryset,
+            Person.objects.filter(
+                Q(pk__in=direct_ids) | Q(pk__in=team_member_ids)
+            ).distinct(),
+        )
+
+    @property
+    def total_collaborators_count(self) -> int:
+        return self.total_collaborators.count()
 
     @property
     def owner_can_create_job(self):

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1825,6 +1825,28 @@ class Project(models.Model):
         )
 
     @property
+    def collaborators_count(self) -> int:
+        if self.owner.is_organization:
+            exclude_pks = [self.owner.organization.organization_owner_id]
+        else:
+            exclude_pks = [self.owner_id]
+
+        team_collab_ids = (
+            self.collaborators.skip_incognito()  # type: ignore[attr-defined]
+            .filter(collaborator__type=User.Type.TEAM)
+            .values_list("collaborator_id", flat=True)
+        )
+        return (
+            self.direct_collaborators.values_list("collaborator_id", flat=True)
+            .union(
+                TeamMember.objects.filter(team_id__in=team_collab_ids)
+                .exclude(member_id__in=exclude_pks)
+                .values_list("member_id", flat=True)
+            )
+            .count()
+        )
+
+    @property
     def owner_can_create_job(self):
         # NOTE consider including in status refactoring
 

--- a/docker-app/qfieldcloud/core/tests/test_project.py
+++ b/docker-app/qfieldcloud/core/tests/test_project.py
@@ -666,9 +666,9 @@ class QfcTestCase(APITransactionTestCase):
     def test_collaborators_count_no_collaborators(self):
         # baseline: owner-only project counts 0
         project = Project.objects.create(name="p", is_public=False, owner=self.user1)
-        self.assertEqual(project.collaborators_count, 0)
+        self.assertEqual(project.total_collaborators_count, 0)
 
-    def test_collaborators_count_team_members_only(self):
+    def test_total_collaborators_count_team_members_only(self):
         o1 = Organization.objects.create(username="o1", organization_owner=self.user1)
         t1 = Team.objects.create(username="@o1/t1", team_organization=o1)
         OrganizationMember.objects.create(organization=o1, member=self.user2)
@@ -679,9 +679,9 @@ class QfcTestCase(APITransactionTestCase):
         ProjectCollaborator.objects.create(
             project=project, collaborator=t1, role=ProjectCollaborator.Roles.REPORTER
         )
-        self.assertEqual(project.collaborators_count, 2)
+        self.assertEqual(project.total_collaborators_count, 2)
 
-    def test_collaborators_count_deduplicates_person_in_both(self):
+    def test_total_collaborators_count_deduplicates_person_in_both(self):
         # user2 is both a direct collaborator AND a team member
         o1 = Organization.objects.create(username="o1", organization_owner=self.user1)
         t1 = Team.objects.create(username="@o1/t1", team_organization=o1)
@@ -698,9 +698,9 @@ class QfcTestCase(APITransactionTestCase):
         ProjectCollaborator.objects.create(
             project=project, collaborator=t1, role=ProjectCollaborator.Roles.REPORTER
         )
-        self.assertEqual(project.collaborators_count, 2)  # user2, user3
+        self.assertEqual(project.total_collaborators_count, 2)  # user2, user3
 
-    def test_collaborators_count_excludes_org_owner_in_team(self):
+    def test_total_collaborators_count_excludes_org_owner_in_team(self):
         # org owner (user1) is a team member and must NOT be counted
         o1 = Organization.objects.create(username="o1", organization_owner=self.user1)
         t1 = Team.objects.create(username="@o1/t1", team_organization=o1)
@@ -711,7 +711,7 @@ class QfcTestCase(APITransactionTestCase):
         ProjectCollaborator.objects.create(
             project=project, collaborator=t1, role=ProjectCollaborator.Roles.REPORTER
         )
-        self.assertEqual(project.collaborators_count, 1)  # only user2, not user1
+        self.assertEqual(project.total_collaborators_count, 1)  # only user2, not user1
 
     def test_add_project_collaborator_and_being_org_member(self):
         u1 = Person.objects.create(username="u1")

--- a/docker-app/qfieldcloud/core/tests/test_project.py
+++ b/docker-app/qfieldcloud/core/tests/test_project.py
@@ -663,6 +663,56 @@ class QfcTestCase(APITransactionTestCase):
 
         self.assertEqual(len(p1.direct_collaborators), 0)
 
+    def test_collaborators_count_no_collaborators(self):
+        # baseline: owner-only project counts 0
+        project = Project.objects.create(name="p", is_public=False, owner=self.user1)
+        self.assertEqual(project.collaborators_count, 0)
+
+    def test_collaborators_count_team_members_only(self):
+        o1 = Organization.objects.create(username="o1", organization_owner=self.user1)
+        t1 = Team.objects.create(username="@o1/t1", team_organization=o1)
+        OrganizationMember.objects.create(organization=o1, member=self.user2)
+        OrganizationMember.objects.create(organization=o1, member=self.user3)
+        TeamMember.objects.create(team=t1, member=self.user2)
+        TeamMember.objects.create(team=t1, member=self.user3)
+        project = Project.objects.create(name="p", is_public=False, owner=o1)
+        ProjectCollaborator.objects.create(
+            project=project, collaborator=t1, role=ProjectCollaborator.Roles.REPORTER
+        )
+        self.assertEqual(project.collaborators_count, 2)
+
+    def test_collaborators_count_deduplicates_person_in_both(self):
+        # user2 is both a direct collaborator AND a team member
+        o1 = Organization.objects.create(username="o1", organization_owner=self.user1)
+        t1 = Team.objects.create(username="@o1/t1", team_organization=o1)
+        OrganizationMember.objects.create(organization=o1, member=self.user2)
+        OrganizationMember.objects.create(organization=o1, member=self.user3)
+        TeamMember.objects.create(team=t1, member=self.user2)
+        TeamMember.objects.create(team=t1, member=self.user3)
+        project = Project.objects.create(name="p", is_public=False, owner=o1)
+        ProjectCollaborator.objects.create(
+            project=project,
+            collaborator=self.user2,
+            role=ProjectCollaborator.Roles.MANAGER,
+        )
+        ProjectCollaborator.objects.create(
+            project=project, collaborator=t1, role=ProjectCollaborator.Roles.REPORTER
+        )
+        self.assertEqual(project.collaborators_count, 2)  # user2, user3
+
+    def test_collaborators_count_excludes_org_owner_in_team(self):
+        # org owner (user1) is a team member and must NOT be counted
+        o1 = Organization.objects.create(username="o1", organization_owner=self.user1)
+        t1 = Team.objects.create(username="@o1/t1", team_organization=o1)
+        TeamMember.objects.create(team=t1, member=self.user1)
+        OrganizationMember.objects.create(organization=o1, member=self.user2)
+        TeamMember.objects.create(team=t1, member=self.user2)
+        project = Project.objects.create(name="p", is_public=False, owner=o1)
+        ProjectCollaborator.objects.create(
+            project=project, collaborator=t1, role=ProjectCollaborator.Roles.REPORTER
+        )
+        self.assertEqual(project.collaborators_count, 1)  # only user2, not user1
+
     def test_add_project_collaborator_and_being_org_member(self):
         u1 = Person.objects.create(username="u1")
         u2 = Person.objects.create(username="u2")


### PR DESCRIPTION
Number of people involved in a project counted only direct collaborators. 

Now it counts both team members and direct collaborators, deduplicated.