### PR TITLE
feat: configure max number of parameters via constance

### DIFF
--- a/docker-app/qfieldcloud/core/middleware/fields_limit.py
+++ b/docker-app/qfieldcloud/core/middleware/fields_limit.py
@@ -1,0 +1,17 @@
+from collections.abc import Callable
+
+from constance import config
+from django.http import HttpRequest, HttpResponse
+from django.test.utils import override_settings
+
+
+class DynamicMaxNumberFieldsLimitMiddleware:
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]):
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        """Dynamically set the DATA_UPLOAD_MAX_NUMBER_FIELDS setting limit based on the Constance value."""
+        with override_settings(
+            DATA_UPLOAD_MAX_NUMBER_FIELDS=config.WEB_DATA_UPLOAD_MAX_NUMBER_FIELDS
+        ):
+            return self.get_response(request)

--- a/docker-app/qfieldcloud/core/tests/test_fields_number.py
+++ b/docker-app/qfieldcloud/core/tests/test_fields_number.py
@@ -1,0 +1,38 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+
+class QfcTestCase(TestCase):
+    def _create_request_data(self, n: int) -> dict:
+        """Helper method to create a dummy dictionary with n fields."""
+        result = {}
+
+        for i in range(n):
+            result[f"field_{i}"] = f"value_{i}"
+
+        return result
+
+    def test_too_many_parameters_fail(self):
+        with patch("qfieldcloud.core.middleware.fields_limit.config") as mock_config:
+            mock_config.WEB_DATA_UPLOAD_MAX_NUMBER_FIELDS = 1000
+
+            response = self.client.get(
+                "/api/v1/status/", query_params=self._create_request_data(1001)
+            )
+
+            # Django throws a `django.core.exceptions.TooManyFieldsSent` exception, with message :
+            # `The number of GET/POST parameters exceeded settings.DATA_UPLOAD_MAX_NUMBER_FIELDS.`
+            # somehow, the test does not catch with a `self.assertRaises(TooManyFieldsSent)`
+            self.assertNotEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 400)
+
+    def test_many_parameters_ok_when_constance_limit_set_bigger(self):
+        with patch("qfieldcloud.core.middleware.fields_limit.config") as mock_config:
+            mock_config.WEB_DATA_UPLOAD_MAX_NUMBER_FIELDS = 1010
+
+            response = self.client.get(
+                "/api/v1/status/", query_params=self._create_request_data(1001)
+            )
+
+            self.assertEqual(response.status_code, 200)

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -156,6 +156,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "qfieldcloud.core.middleware.fields_limit.DynamicMaxNumberFieldsLimitMiddleware",
     "qfieldcloud.core.middleware.requests.attach_keys",  # QF-2540: Inspecting request after Django middlewares
     "log_request_id.middleware.RequestIDMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
@@ -782,6 +783,11 @@ CONSTANCE_CONFIG = {
         "User inactivity threshold in days. Set to 0 to disable the inactivity threshold.",
         int,
     ),
+    "WEB_DATA_UPLOAD_MAX_NUMBER_FIELDS": (
+        1000,
+        "Max number of GET/POST parameters, dynamically overrides the DATA_UPLOAD_MAX_NUMBER_FIELDS setting.",
+        int,
+    ),
 }
 CONSTANCE_ADDITIONAL_FIELDS = {
     "textarea": [
@@ -813,6 +819,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
     "Web": (
         "STATUS_PAGE_URL",
         "WEB_USER_INACTIVITY_THRESHOLD_DAYS",
+        "WEB_DATA_UPLOAD_MAX_NUMBER_FIELDS",
     ),
 }
 


### PR DESCRIPTION
This PR intends to add the ability to dynamically configure the `DATA_UPLOAD_MAX_NUMBER_FIELDS` Django setting, via a new Constance config.

This value is set via a middleware that overrides this setting for each request.

Reason behind this is that in Django Admin, editing Models with a lot of related objects (e.g. Organizations with many Projects / many Members) may send a lot of GET/POST parameters, thus reaching the Django `DATA_UPLOAD_MAX_NUMBER_FIELDS` setting limit (1000 is the default).