### PR TITLE
feat: increase max number of GET/POST parameters

### DIFF
--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -1020,3 +1020,6 @@ QFIELDCLOUD_CUSTOM_CA_VOLUME_NAME = (
 # Filename where optional custom CA certificate are stored.
 QFIELDCLOUD_CUSTOM_CA_DIR = "/etc/ssl/custom_certs"
 QFIELDCLOUD_CUSTOM_CA_FILENAME = f"{QFIELDCLOUD_CUSTOM_CA_DIR}/custom_ca.crt"
+
+# Maximum number of GET/POST parameters, avoids `TooManyFieldsSent` error.
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 5000


### PR DESCRIPTION
Follow-up of #1654 : increases the max number of GET/POST parameters via a setting configuration, from the 1000 default to 5000.

Reason behind this is that in Django Admin, editing Models with a lot of related objects (e.g. Organizations with many Projects / many Members) may send a lot of GET/POST parameters, sometimes more than the 1000 default.