### PR TITLE
Add ratelimit for password resets

### DIFF
--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -489,7 +489,9 @@ ACCOUNT_EMAIL_SUBJECT_PREFIX = ""
 ACCOUNT_EMAIL_VERIFICATION = os.environ["ACCOUNT_EMAIL_VERIFICATION"]
 
 # https://docs.allauth.org/en/latest/account/rate_limits.html
-ACCOUNT_RATE_LIMITS = False
+ACCOUNT_RATE_LIMITS = {
+    "reset_password": "5/m/ip,5/m/key",
+}
 
 # https://docs.allauth.org/en/latest/account/configuration.html#user-model
 # NOTE when casing is preserved, potentially expensive `__iexact`` lookups are performed when filter on username.

--- a/docker-nginx/pages/429.html
+++ b/docker-nginx/pages/429.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="/pages/favicon.ico" type="image/x-icon">
+  <title>Error 429 - Too Many Requests</title>
+</head>
+
+<body>
+  <div class="container text-center">
+    <img src="/pages/sad_nyuki.svg" alt="Sad Nyuki" class="mt-5 mb-4">
+    <h1 class="display-4">429</h1>
+    <p class="lead">Too Many Requests</p>
+    <p>You have made too many requests in a short period of time. Please wait a moment and try again.</p>
+    <a href="/" class="btn btn-primary mt-3">Go back to Home</a>
+  </div>
+  <style>
+    /* exported from 'https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css' */
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+      font-size: 1rem;
+      font-weight: 400;
+      line-height: 1.5;
+      color: #212529;
+      text-align: left;
+    }
+
+    .lead {
+      font-size: 1.25rem;
+      font-weight: 300;
+    }
+
+    p {
+      margin-top: 0;
+      margin-bottom: 1rem;
+    }
+
+    .btn {
+      display: inline-block;
+      font-weight: 400;
+      color: #212529;
+      text-align: center;
+      vertical-align: middle;
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+      background-color: transparent;
+      border: 1px solid transparent;
+      border-top-color: transparent;
+      border-right-color: transparent;
+      border-bottom-color: transparent;
+      border-left-color: transparent;
+      padding: .375rem .75rem;
+      font-size: 1rem;
+      line-height: 1.5;
+      border-radius: .25rem;
+      transition: color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out;
+    }
+
+    .btn:not(:disabled):not(.disabled) {
+      cursor: pointer;
+    }
+
+    .mt-3,
+    .my-3 {
+      margin-top: 1rem !important;
+    }
+
+
+    .mt-5,
+    .my-5 {
+      margin-top: 3rem !important;
+    }
+
+    .mb-4,
+    .my-4 {
+      margin-bottom: 1.5rem !important;
+    }
+
+    img {
+      vertical-align: middle;
+      border-style: none;
+    }
+
+    *,
+    ::after,
+    ::before {
+      box-sizing: border-box;
+    }
+
+    .display-4 {
+      font-size: 3.5rem;
+      font-weight: 300;
+      line-height: 1.2;
+    }
+
+    .h1,
+    .h2,
+    .h3,
+    .h4,
+    .h5,
+    .h6,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      margin-bottom: .5rem;
+      font-weight: 500;
+      line-height: 1.2;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      margin-top: 0;
+      margin-bottom: .5rem;
+    }
+
+    *,
+    ::after,
+    ::before {
+      box-sizing: border-box;
+    }
+
+    .text-center {
+      text-align: center !important;
+    }
+
+    @media (min-width: 992px) {
+
+      .container,
+      .container-lg,
+      .container-md,
+      .container-sm {
+        max-width: 960px;
+      }
+    }
+
+    @media (min-width: 768px) {
+
+      .container,
+      .container-md,
+      .container-sm {
+        max-width: 720px;
+      }
+    }
+
+    @media (min-width: 576px) {
+
+      .container,
+      .container-sm {
+        max-width: 540px;
+      }
+    }
+
+    .container,
+    .container-fluid,
+    .container-lg,
+    .container-md,
+    .container-sm,
+    .container-xl {
+      width: 100%;
+      padding-right: 15px;
+      padding-left: 15px;
+      margin-right: auto;
+      margin-left: auto;
+    }
+
+    /* added qfc style */
+    a {
+      color: #4a6fae;
+      text-decoration: none;
+    }
+
+    a :hover {
+      color: #3f5e93;
+    }
+
+    .btn-primary {
+      color: #fff;
+      background-color: #4a6fae;
+      border-color: #4a6fae;
+    }
+
+    .btn-primary:hover {
+      color: #fff;
+      background-color: #3f5e93;
+      border-color: #3b588a;
+    }
+  </style>
+
+</body>
+
+</html>

--- a/docker-nginx/templates/includes/qfieldcloud.conf.template
+++ b/docker-nginx/templates/includes/qfieldcloud.conf.template
@@ -31,6 +31,9 @@ location @proxy_to_app {
     error_page 403 =403 /pages/403.html;
     error_page 404 =404 /pages/404.html;
 
+    # Rate limit exceeded, shown when app returns 429 (e.g. too many password reset attempts)
+    error_page 429 =429 /pages/429.html;
+
     # Initial loading page for upstream issues (502, 503, 504 for timeouts)
     error_page 502 503 504 =503 /pages/loading.html;
 


### PR DESCRIPTION
Default rate limiting for password reset in django-allauth is 20/m/ip, 5/m/key (20 attempts per minute per IP, 5 per minute per key). Lowered the IP limit to 5/m/ip, 5/m/key.

Also added a custom page for 429 (Too Many Requests) errors