### PR TITLE
fix: detect S3 Content-Type from original filename in versioned paths

### DIFF
--- a/docker-app/qfieldcloud/filestorage/backend.py
+++ b/docker-app/qfieldcloud/filestorage/backend.py
@@ -9,7 +9,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import ContentFile
 from django.core.files.storage import Storage
 from django.http import HttpResponse
-
 from storages.backends.s3 import S3Storage
 
 

--- a/docker-app/qfieldcloud/filestorage/backend.py
+++ b/docker-app/qfieldcloud/filestorage/backend.py
@@ -1,5 +1,7 @@
 import base64
+import mimetypes
 import os
+import re
 from abc import ABC
 
 import requests
@@ -7,7 +9,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import ContentFile
 from django.core.files.storage import Storage
 from django.http import HttpResponse
-import mimetypes
 
 from storages.backends.s3 import S3Storage
 
@@ -58,21 +59,30 @@ class QfcS3Boto3Storage(QfcBackendStorageMixin, S3Storage):
         """
         pass
 
-    def _get_write_parameters(self, name, content=None):
+    def _get_write_parameters(self, name: str, content=None) -> dict:
         params = super()._get_write_parameters(name, content)
 
-        # Detect Content-Type from the original filename embedded in the
-        # versioned S3 path.  Versioned paths look like:
-        #   projects/<uuid>/files/DCIM/photo.jpg/v20260610-a1b2c3d4
-        # The trailing version UUID has no file extension, so the parent
-        # class's mimetypes.guess_type(name) always returns None.
+        # Detect content type from the original filename embedded in the
+        # versioned S3 path, so it can be properly set in the object storage
+        # metadata and later returned as a `Content-Type` header when
+        # downloading the object.
+        # Versioned paths look like:
+        #   `projects/<uuid>/files/DCIM/photo.jpg/v20260317162354-512bd29b`
+        # Note the last part of the versioned name has the version timestamp
+        # and a random UUID fragment, which prevents `mimetypes.guess_type`
+        # from guessing a proper content type, as it uses the file extension
+        # to do so.  Without this fix, the parent class's
+        # `_get_write_parameters` would set `ContentType` to `None`.
         parts = name.rsplit("/", 1)
-        if len(parts) == 2 and parts[1].startswith("v2"):
-            original_name = parts[0].rsplit("/", 1)[-1]
-        else:
-            original_name = parts[-1]
+        base_name = parts[-1]
 
-        mime_type, encoding = mimetypes.guess_type(original_name)
+        if (
+            len(parts) == 2
+            and re.fullmatch(r"v20[0-9]{12}-[a-f0-9]{8}$", parts[-1])
+        ):
+            base_name = parts[0].rsplit("/", 1)[-1]
+
+        mime_type, encoding = mimetypes.guess_type(base_name)
         if mime_type:
             params["ContentType"] = mime_type
             if encoding:

--- a/docker-app/qfieldcloud/filestorage/backend.py
+++ b/docker-app/qfieldcloud/filestorage/backend.py
@@ -3,6 +3,7 @@ import mimetypes
 import os
 import re
 from abc import ABC
+from typing import Any
 
 import requests
 from django.core.exceptions import ImproperlyConfigured
@@ -58,7 +59,7 @@ class QfcS3Boto3Storage(QfcBackendStorageMixin, S3Storage):
         """
         pass
 
-    def _get_write_parameters(self, name: str, content: ContentFile | None = None) -> dict:
+    def _get_write_parameters(self, name: str, content: ContentFile | None = None) -> dict[str, Any]:
         params = super()._get_write_parameters(name, content)
 
         # Detect content type from the original filename embedded in the
@@ -70,7 +71,7 @@ class QfcS3Boto3Storage(QfcBackendStorageMixin, S3Storage):
         # Note the last part of the versioned name has the version timestamp
         # and a random UUID fragment, which prevents `mimetypes.guess_type`
         # from guessing a proper content type, as it uses the file extension
-        # to do so.  Without this fix, the parent class's
+        # to do so. Without this fix, the parent class's
         # `_get_write_parameters` would set `ContentType` to `None`.
         parts = name.rsplit("/", 1)
         base_name = parts[-1]

--- a/docker-app/qfieldcloud/filestorage/backend.py
+++ b/docker-app/qfieldcloud/filestorage/backend.py
@@ -7,6 +7,8 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import ContentFile
 from django.core.files.storage import Storage
 from django.http import HttpResponse
+import mimetypes
+
 from storages.backends.s3 import S3Storage
 
 
@@ -55,6 +57,28 @@ class QfcS3Boto3Storage(QfcBackendStorageMixin, S3Storage):
             response: HTTP redirect response to patch.
         """
         pass
+
+    def _get_write_parameters(self, name, content=None):
+        params = super()._get_write_parameters(name, content)
+
+        # Detect Content-Type from the original filename embedded in the
+        # versioned S3 path.  Versioned paths look like:
+        #   projects/<uuid>/files/DCIM/photo.jpg/v20260610-a1b2c3d4
+        # The trailing version UUID has no file extension, so the parent
+        # class's mimetypes.guess_type(name) always returns None.
+        parts = name.rsplit("/", 1)
+        if len(parts) == 2 and parts[1].startswith("v2"):
+            original_name = parts[0].rsplit("/", 1)[-1]
+        else:
+            original_name = parts[-1]
+
+        mime_type, encoding = mimetypes.guess_type(original_name)
+        if mime_type:
+            params["ContentType"] = mime_type
+            if encoding:
+                params["ContentEncoding"] = encoding
+
+        return params
 
 
 class QfcWebDavStorage(QfcBackendStorageMixin, Storage):

--- a/docker-app/qfieldcloud/filestorage/backend.py
+++ b/docker-app/qfieldcloud/filestorage/backend.py
@@ -59,7 +59,9 @@ class QfcS3Boto3Storage(QfcBackendStorageMixin, S3Storage):
         """
         pass
 
-    def _get_write_parameters(self, name: str, content: ContentFile | None = None) -> dict[str, Any]:
+    def _get_write_parameters(
+        self, name: str, content: ContentFile | None = None
+    ) -> dict[str, Any]:
         params = super()._get_write_parameters(name, content)
 
         # Detect content type from the original filename embedded in the
@@ -76,10 +78,7 @@ class QfcS3Boto3Storage(QfcBackendStorageMixin, S3Storage):
         parts = name.rsplit("/", 1)
         base_name = parts[-1]
 
-        if (
-            len(parts) == 2
-            and re.fullmatch(r"v20[0-9]{12}-[a-f0-9]{8}$", parts[-1])
-        ):
+        if len(parts) == 2 and re.fullmatch(r"v20[0-9]{12}-[a-f0-9]{8}$", parts[-1]):
             base_name = parts[0].rsplit("/", 1)[-1]
 
         mime_type, encoding = mimetypes.guess_type(base_name)

--- a/docker-app/qfieldcloud/filestorage/backend.py
+++ b/docker-app/qfieldcloud/filestorage/backend.py
@@ -59,7 +59,7 @@ class QfcS3Boto3Storage(QfcBackendStorageMixin, S3Storage):
         """
         pass
 
-    def _get_write_parameters(self, name: str, content=None) -> dict:
+    def _get_write_parameters(self, name: str, content: ContentFile | None = None) -> dict:
         params = super()._get_write_parameters(name, content)
 
         # Detect content type from the original filename embedded in the

--- a/docker-app/qfieldcloud/filestorage/tests/test_backend.py
+++ b/docker-app/qfieldcloud/filestorage/tests/test_backend.py
@@ -1,0 +1,166 @@
+import logging
+import re
+import uuid
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from qfieldcloud.filestorage.backend import QfcS3Boto3Storage
+
+logging.disable(logging.CRITICAL)
+
+# -- Regex extracted to module level so the contract tests below
+#    can reference it.  This must stay in sync with the inline
+#    pattern inside QfcS3Boto3Storage._get_write_parameters.
+_VERSION_RE = re.compile(r"v20[0-9]{12}-[a-f0-9]{8}$")
+
+
+class QfcS3Boto3StorageTestCase(TestCase):
+    """Tests for _get_write_parameters Content-Type detection.
+
+    The version-detection regex mirrors the S3 key format produced by
+    FileVersion.display and get_file_version_upload_to in models.py.
+    The contract tests below verify that the regex matches keys built
+    from those same format strings — if someone changes either the
+    display format or the UUID fragment length in models.py, these
+    tests will fail, forcing the regex in backend.py to be updated.
+    """
+
+    def setUp(self):
+        with patch(
+            "storages.backends.s3.S3Storage.__init__",
+            lambda self, **kwargs: None,
+        ):
+            self.storage = QfcS3Boto3Storage()
+
+    def _call(self, name, parent_params=None):
+        if parent_params is None:
+            parent_params = {}
+        with patch(
+            "storages.backends.s3.S3Storage._get_write_parameters",
+            return_value=parent_params,
+        ):
+            return self.storage._get_write_parameters(name)
+
+    # ==================================================================
+    # CONTRACT TESTS — regex must match the key format from models.py
+    # ==================================================================
+    #
+    # models.py line 344:  display = uploaded_at.strftime("v%Y%m%d%H%M%S")
+    # models.py line 265:  key   = projects/{id}/files/{name}/{display}-{id[:8]}
+    #
+    # If either format changes these tests MUST break.
+
+    def test_regex_matches_display_format_from_models(self):
+        """FileVersion.display produces ``vYYYYMMDDHHMMSS`` — the regex
+        must accept any valid datetime in that format."""
+        now = timezone.now()
+        display = now.strftime("v%Y%m%d%H%M%S")
+
+        # display alone is 15 chars (v + 14 digits), but the full
+        # suffix is {display}-{uuid_fragment}.
+        self.assertEqual(len(display), 15)
+        self.assertTrue(
+            display.startswith("v20"),
+            f"Expected display to start with v20, got {display}",
+        )
+
+    def test_regex_matches_full_version_suffix(self):
+        """The complete version suffix is {display}-{id[:8]}.
+        This is what _get_write_parameters sees as the last path
+        component after versioning."""
+        now = timezone.now()
+        display = now.strftime("v%Y%m%d%H%M%S")
+        version_id = uuid.uuid4()
+        uuid_fragment = str(version_id)[:8]
+
+        suffix = f"{display}-{uuid_fragment}"
+
+        self.assertRegex(suffix, _VERSION_RE)
+        self.assertEqual(len(uuid_fragment), 8)
+        self.assertTrue(
+            all(c in "0123456789abcdef" for c in uuid_fragment),
+            f"UUID fragment contains non-hex chars: {uuid_fragment}",
+        )
+
+    def test_full_s3_key_constructed_like_get_file_version_upload_to(self):
+        """End-to-end: build an S3 key the same way
+        get_file_version_upload_to does and verify Content-Type
+        is correctly detected."""
+        project_id = uuid.uuid4()
+        filename = "DCIM/survey.jpg"
+        now = timezone.now()
+        display = now.strftime("v%Y%m%d%H%M%S")
+        version_id = uuid.uuid4()
+
+        s3_key = (
+            f"projects/{project_id}/files/{filename}/"
+            f"{display}-{str(version_id)[:8]}"
+        )
+
+        params = self._call(s3_key)
+        self.assertEqual(params["ContentType"], "image/jpeg")
+
+    # ==================================================================
+    # HAPPY PATH — versioned paths for common file types
+    # ==================================================================
+
+    def test_versioned_jpg(self):
+        params = self._call(
+            "projects/abc123/files/DCIM/photo.jpg/v20260317162354-512bd29b"
+        )
+        self.assertEqual(params["ContentType"], "image/jpeg")
+
+    def test_versioned_png(self):
+        params = self._call(
+            "projects/abc123/files/maps/topo.png/v20260610152033-a1b2c3d4"
+        )
+        self.assertEqual(params["ContentType"], "image/png")
+
+    def test_versioned_pdf(self):
+        params = self._call(
+            "projects/abc123/files/report.pdf/v20261231235959-abcdef01"
+        )
+        self.assertEqual(params["ContentType"], "application/pdf")
+
+    # ==================================================================
+    # REGRESSION — non-versioned paths must still work
+    # ==================================================================
+
+    def test_non_versioned_jpg(self):
+        params = self._call("projects/abc123/files/DCIM/photo.jpg")
+        self.assertEqual(params["ContentType"], "image/jpeg")
+
+    def test_non_versioned_txt(self):
+        params = self._call("projects/abc123/files/notes.txt")
+        self.assertEqual(params["ContentType"], "text/plain")
+
+    # ==================================================================
+    # EDGE CASES
+    # ==================================================================
+
+    def test_no_extension_versioned(self):
+        """Versioned path where the original filename has no extension
+        — no Content-Type should be set."""
+        params = self._call(
+            "projects/abc123/files/README/v20260317162354-512bd29b"
+        )
+        self.assertNotIn("ContentType", params)
+
+    def test_preserves_existing_parent_params(self):
+        """Params set by the parent S3Storage call (e.g. ACL) survive."""
+        params = self._call(
+            "projects/abc123/files/photo.jpg/v20260317162354-512bd29b",
+            parent_params={"ACL": "public-read"},
+        )
+        self.assertEqual(params["ACL"], "public-read")
+        self.assertEqual(params["ContentType"], "image/jpeg")
+
+    def test_old_year_format_not_matched(self):
+        """v1999… does not match the regex — falls through safely
+        to guess_type on the last path component (no extension)."""
+        params = self._call(
+            "projects/abc123/files/photo.jpg/v19991231235959-abcdef01"
+        )
+        self.assertNotIn("ContentType", params)

--- a/docker-app/qfieldcloud/filestorage/tests/test_backend.py
+++ b/docker-app/qfieldcloud/filestorage/tests/test_backend.py
@@ -37,6 +37,7 @@ class QfcS3Boto3StorageTestCase(TestCase):
     def _call(self, name, parent_params=None):
         if parent_params is None:
             parent_params = {}
+
         with patch(
             "storages.backends.s3.S3Storage._get_write_parameters",
             return_value=parent_params,
@@ -95,8 +96,7 @@ class QfcS3Boto3StorageTestCase(TestCase):
         version_id = uuid.uuid4()
 
         s3_key = (
-            f"projects/{project_id}/files/{filename}/"
-            f"{display}-{str(version_id)[:8]}"
+            f"projects/{project_id}/files/{filename}/{display}-{str(version_id)[:8]}"
         )
 
         params = self._call(s3_key)
@@ -119,9 +119,7 @@ class QfcS3Boto3StorageTestCase(TestCase):
         self.assertEqual(params["ContentType"], "image/png")
 
     def test_versioned_pdf(self):
-        params = self._call(
-            "projects/abc123/files/report.pdf/v20261231235959-abcdef01"
-        )
+        params = self._call("projects/abc123/files/report.pdf/v20261231235959-abcdef01")
         self.assertEqual(params["ContentType"], "application/pdf")
 
     # ==================================================================
@@ -143,9 +141,7 @@ class QfcS3Boto3StorageTestCase(TestCase):
     def test_no_extension_versioned(self):
         """Versioned path where the original filename has no extension
         — no Content-Type should be set."""
-        params = self._call(
-            "projects/abc123/files/README/v20260317162354-512bd29b"
-        )
+        params = self._call("projects/abc123/files/README/v20260317162354-512bd29b")
         self.assertNotIn("ContentType", params)
 
     def test_preserves_existing_parent_params(self):
@@ -160,7 +156,5 @@ class QfcS3Boto3StorageTestCase(TestCase):
     def test_old_year_format_not_matched(self):
         """v1999… does not match the regex — falls through safely
         to guess_type on the last path component (no extension)."""
-        params = self._call(
-            "projects/abc123/files/photo.jpg/v19991231235959-abcdef01"
-        )
+        params = self._call("projects/abc123/files/photo.jpg/v19991231235959-abcdef01")
         self.assertNotIn("ContentType", params)


### PR DESCRIPTION
## Summary

Fixes incorrect S3 Content-Type metadata on all uploaded files.

### The Bug

QFieldCloud stores project files with versioned S3 keys:

    projects/<uuid>/files/DCIM/photo.jpg/v20260610-a1b2c3d4

django-storages calls mimetypes.guess_type() on the full key — the
trailing version UUID has no extension, so it always returns None.
The fallback then uses content.content_type from the HTTP request
(typically application/json), causing **every uploaded file** to be
stored as Content-Type: application/json.

This breaks S3 web UIs (AWS Console, MinIO Console, rustfs) — images
do not preview, downloads get wrong MIME types.

### The Fix

Override _get_write_parameters() in QfcS3Boto3Storage to extract
the original filename from the versioned path and use it for MIME
detection. Example:

    photo.jpg/v20260610-a1b2c3d4  →  photo.jpg  →  image/jpeg
    notes.gpkg/v20260610-a1b2c3d4 →  notes.gpkg →  application/geopackage+sqlite3

Non-versioned paths (thumbnails, etc.) are unaffected — they fall
through to the original behaviour.

### Changes

- docker-app/qfieldcloud/filestorage/backend.py — +24 lines
- Adds import mimetypes (stdlib)
- Adds _get_write_parameters() override to QfcS3Boto3Storage

### Testing

- [x] Deployed on a live QFieldCloud instance with rustfs S3 backend
- [x] Uploaded JPEG, PNG, GeoPackage, QGIS project — all now get correct Content-Type
- [x] Storage health check passes ({"storage":"ok"})
- [x] Backward compatible — existing objects unaffected