### PR TITLE
chore: bump dependencies

### DIFF
--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -42,5 +42,5 @@ phonenumbers==9.0.27
 Pillow==12.2.0
 psycopg2==2.9.11
 pymemcache==4.0.0
-sentry-sdk==2.60.0
+sentry-sdk==2.62.0
 stripe==4.2.0

--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -36,7 +36,7 @@ django-stubs-ext==5.2.9
 djangorestframework==3.17.1
 djangorestframework-stubs==3.16.9
 drf-spectacular==0.29.0
-json-log-formatter==1.1.1
+json-log-formatter==1.2.1
 mypy-boto3-s3==1.35.81
 phonenumbers==9.0.27
 Pillow==12.2.0

--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -10,7 +10,7 @@ django-cleanup==9.0.0
 django-cors-headers==4.9.0
 django-common-helpers==0.9.2
 django-constance==4.3.5
-django-countries==8.2.0
+django-countries==9.0.0
 django-cron-django5==0.6.2
 django-currentuser==0.10.0
 django-debug-toolbar==6.3.0

--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -40,7 +40,7 @@ json-log-formatter==1.2.1
 mypy-boto3-s3==1.35.81
 phonenumbers==9.0.27
 Pillow==12.2.0
-psycopg2==2.9.11
+psycopg2==2.9.12
 pymemcache==4.0.0
 sentry-sdk==2.62.0
 stripe==4.2.0

--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -28,7 +28,7 @@ django-notifications-hq @ git+https://github.com/django-notifications/django-not
 django-phonenumber-field==8.4.0
 django-sri==0.8.0
 django-storages==1.14.6
-django-tables2==2.9.0
+django-tables2==3.0.0
 django-timezone-field==7.2.1
 django==5.2.14
 django-stubs==5.2.9

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -177,7 +177,7 @@ psycopg2==2.9.11
     # via -r /requirements/requirements.in
 pycparser==2.22
     # via cffi
-pyjwt[crypto]==2.12.1
+pyjwt[crypto]==2.13.0
     # via django-allauth
 pymemcache==4.0.0
     # via -r /requirements/requirements.in

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -155,7 +155,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-json-log-formatter==1.1.1
+json-log-formatter==1.2.1
     # via -r /requirements/requirements.in
 jsonfield==3.2.0
     # via django-notifications-hq

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -91,7 +91,7 @@ django-constance==4.3.5
     # via -r /requirements/requirements.in
 django-cors-headers==4.9.0
     # via -r /requirements/requirements.in
-django-countries==8.2.0
+django-countries==9.0.0
     # via -r /requirements/requirements.in
 django-cron-django5==0.6.2
     # via -r /requirements/requirements.in

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -135,7 +135,7 @@ django-stubs-ext==5.2.9
     # via
     #   -r /requirements/requirements.in
     #   django-stubs
-django-tables2==2.9.0
+django-tables2==3.0.0
     # via -r /requirements/requirements.in
 django-timezone-field==7.2.1
     # via -r /requirements/requirements.in

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -201,7 +201,7 @@ rpds-py==0.27.0
     #   referencing
 s3transfer==0.10.4
     # via boto3
-sentry-sdk==2.60.0
+sentry-sdk==2.62.0
     # via -r /requirements/requirements.in
 six==1.17.0
     # via python-dateutil

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -173,7 +173,7 @@ phonenumbers==9.0.27
     # via -r /requirements/requirements.in
 pillow==12.2.0
     # via -r /requirements/requirements.in
-psycopg2==2.9.11
+psycopg2==2.9.12
     # via -r /requirements/requirements.in
 pycparser==2.22
     # via cffi

--- a/docker-app/requirements/requirements_runtime.in
+++ b/docker-app/requirements/requirements_runtime.in
@@ -1,1 +1,1 @@
-gunicorn==25.1.0
+gunicorn==26.0.0

--- a/docker-app/requirements/requirements_runtime.txt
+++ b/docker-app/requirements/requirements_runtime.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --no-strip-extras --output-file=/requirements/requirements_runtime.txt /requirements/requirements_runtime.in
 #
-gunicorn==25.1.0
+gunicorn==26.0.0
     # via -r /requirements/requirements_runtime.in
 packaging==25.0
     # via gunicorn

--- a/docker-app/requirements/requirements_test.in
+++ b/docker-app/requirements/requirements_test.in
@@ -1,5 +1,5 @@
 imageio==2.*
 requests-mock==1.*
 selenium==4.*
-coverage==7.11.0
+coverage==7.14.1
 geopandas==1.*

--- a/docker-app/requirements/requirements_test.txt
+++ b/docker-app/requirements/requirements_test.txt
@@ -16,7 +16,7 @@ certifi==2026.4.22
     #   selenium
 charset-normalizer==3.4.7
     # via requests
-coverage==7.11.0
+coverage==7.14.1
     # via -r /requirements/requirements_test.in
 geopandas==1.1.3
     # via -r /requirements/requirements_test.in

--- a/docker-qgis/requirements.in
+++ b/docker-qgis/requirements.in
@@ -2,4 +2,4 @@ jsonschema==4.26.0
 typing-extensions==4.15.0
 tabulate==v0.10.0
 requests==2.33.1
-qfieldcloud-sdk==0.15.0
+qfieldcloud-sdk==0.16.0

--- a/docker-qgis/requirements.txt
+++ b/docker-qgis/requirements.txt
@@ -9,26 +9,20 @@ attrs==24.2.0
     #   jsonschema
     #   referencing
 certifi==2024.8.30
-    # via
-    #   qfieldcloud-sdk
-    #   requests
+    # via requests
 charset-normalizer==3.3.2
-    # via
-    #   qfieldcloud-sdk
-    #   requests
+    # via requests
 click==8.1.7
     # via qfieldcloud-sdk
 idna==3.16
-    # via
-    #   qfieldcloud-sdk
-    #   requests
+    # via requests
 jsonschema==4.26.0
     # via -r requirements.in
 jsonschema-specifications==2023.12.1
     # via jsonschema
 pathvalidate==3.3.1
     # via qfieldcloud-sdk
-qfieldcloud-sdk==0.15.0
+qfieldcloud-sdk==0.16.0
     # via -r requirements.in
 referencing==0.35.1
     # via


### PR DESCRIPTION
Bumping dependencies to latest versions here and there,  
See individual commits for changelogs and diffs.

One _major_ change spotted for `django-tables2`, see https://github.com/opengisch/QFieldCloud/commit/31f734330062b7d97ee49d069ebb6d1f05ae2335  
Though it seems that QFieldCloud is not impacted.

Closes #1662 