### PR TITLE
Subscription cancellation: Use appropriate plan type

### DIFF
--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -912,10 +912,22 @@ class AbstractSubscription(models.Model):
 
         TODO Python 3.11 the actual return type is Self
         """
-        plan = Plan.objects.get(
-            user_type=account.user.type,
-            is_default=True,
+        most_recent_subscription = (
+            cls.objects.filter(account=account)
+            .exclude(active_until__isnull=True)
+            .order_by("active_until")
+            .last()
         )
+
+        # Use plan from the user's most recent subscription, if possible.
+        # Otherwise fall back to default plan for the given user type.
+        if most_recent_subscription:
+            plan = most_recent_subscription.plan
+        else:
+            plan = Plan.objects.get(
+                user_type=account.user.type,
+                is_default=True,
+            )
 
         if account.user.is_organization:
             # NOTE sometimes `account.user` is not an organization, e.g. when setting


### PR DESCRIPTION
When creating the inactive dummy subscription that follows a cancelled subscription, pick the plan type of the user's most recent subscription, if available.

This ensures that if they should want to re-activate their subscription, it will be of the appropriate plan type.