### PR TITLE
Show correct toast error when submitting empty collaborator input

### DIFF
--- a/docker-app/qfieldcloud/core/utils2/projects.py
+++ b/docker-app/qfieldcloud/core/utils2/projects.py
@@ -75,15 +75,17 @@ def create_collaborator_by_username_or_email(
         success, message - whether the collaborator creation was success and explanation message of the outcome
     """
     success, message = False, ""
+
+    if not username.strip():
+        return False, _("Please enter a username or email address.")
+
     users = list(
         Person.objects.filter(Q(username=username) | Q(email=username))
     ) + list(Team.objects.filter(username=username, team_organization=project.owner))
 
     if len(users) == 0:
         # No user found, if string is an email address, we try to send a link
-        if not username:
-            message = _("Please enter a username or email address.")
-        elif invitation.is_valid_email(username):
+        if invitation.is_valid_email(username):
             success, message = invitation.invite_user_by_email(username, created_by)
         else:
             message = _('User "{}" does not exist.').format(username)


### PR DESCRIPTION
Follows up on #1651

In the referred PR, passing an empty input could silently skip the validation message. Django's AbstractUser.email is an `EmailField(blank=True)`, so accounts created without an email (e.g. via createsuperuser) store `email=""` rather than `NULL`. The DB query `Q(email=username)` with `username=""` would therefore match all such accounts, producing a non-zero user count and routing to the wrong error branch. The early return now ensures the correct validation message is always shown and avoids the unnecessary database lookup.

Before: `Adding multiple collaborators at once is not supported.`
After: `Please enter a username or email address.`