### PR TITLE
Subscription cancellation: Fix plan type for org users

### DIFF
--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -919,9 +919,9 @@ class AbstractSubscription(models.Model):
             .last()
         )
 
-        # Use plan from the user's most recent subscription, if possible.
+        # For organization users, use plan from the user's most recent subscription.
         # Otherwise fall back to default plan for the given user type.
-        if most_recent_subscription:
+        if most_recent_subscription and account.user.is_organization:
             plan = most_recent_subscription.plan
         else:
             plan = Plan.objects.get(


### PR DESCRIPTION
With the recent change (#1667) that bases the dummy follow-up subscription after a cancellation on plan type of the user's most recent subscription, a bug was introduced:

Individual, non-organization users now would be put back on an inactive "Pro" plan instead of an active "Community" plan, which wasn't intended.

This change fixes that by only considering the most recent subscription to determine the plan for organization users.