### PR TITLE
fix: When selecting files, ensure they are of project file type, not package files

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1455,9 +1455,11 @@ class Project(models.Model):
             # Return all layers if the project is missing
             return self.localized_layers
 
-        available_filenames = File.objects.filter(
-            project=self.shared_datasets_project
-        ).values_list("name", flat=True)
+        available_filenames = (
+            File.objects.with_type_project()
+            .filter(project=self.shared_datasets_project)
+            .values_list("name", flat=True)
+        )
 
         missing_localized_layers = []
         for layer in self.localized_layers:

--- a/docker-app/qfieldcloud/filestorage/view_helpers.py
+++ b/docker-app/qfieldcloud/filestorage/view_helpers.py
@@ -408,10 +408,12 @@ def delete_project_file_version(
 
         if (
             is_qgis_project_file(filename)
-            and not File.objects.filter(
+            and not File.objects.with_type_project()
+            .filter(
                 name=filename,
                 project_id=project_id,
-            ).exists()
+            )
+            .exists()
         ):
             project.the_qgis_file_name = None
             update_fields.append("the_qgis_file_name")


### PR DESCRIPTION
This is quite error prone, we sometimes do checks on files that are no meant to be checked, e.g. package types.

For example, on deletion we check if a file with given name exists. This should not check for all files with given name, but only those that are project files.

As for the localized layers, this is less likely to be a problem, as we never package localized projects.