### PR TITLE
Ensure that produced version suffix are always matching a regex

### DIFF
--- a/docker-app/qfieldcloud/filestorage/backend.py
+++ b/docker-app/qfieldcloud/filestorage/backend.py
@@ -1,7 +1,6 @@
 import base64
 import mimetypes
 import os
-import re
 from abc import ABC
 from typing import Any
 
@@ -11,6 +10,8 @@ from django.core.files.base import ContentFile
 from django.core.files.storage import Storage
 from django.http import HttpResponse
 from storages.backends.s3 import S3Storage
+
+from qfieldcloud.filestorage.constants import VERSION_SUFFIX_REGEX
 
 
 class QfcBackendStorageMixin(ABC):
@@ -78,7 +79,7 @@ class QfcS3Boto3Storage(QfcBackendStorageMixin, S3Storage):
         parts = name.rsplit("/", 1)
         base_name = parts[-1]
 
-        if len(parts) == 2 and re.fullmatch(r"v20[0-9]{12}-[a-f0-9]{8}$", parts[-1]):
+        if len(parts) == 2 and VERSION_SUFFIX_REGEX.fullmatch(parts[-1]):
             base_name = parts[0].rsplit("/", 1)[-1]
 
         mime_type, encoding = mimetypes.guess_type(base_name)

--- a/docker-app/qfieldcloud/filestorage/constants.py
+++ b/docker-app/qfieldcloud/filestorage/constants.py
@@ -1,0 +1,4 @@
+import re
+
+VERSION_SUFFIX_REGEX = re.compile(r"v20[0-9]{12}-[a-f0-9]{8}$")
+"""A regex to ensure the format of the version suffix is correct."""

--- a/docker-app/qfieldcloud/filestorage/models.py
+++ b/docker-app/qfieldcloud/filestorage/models.py
@@ -26,6 +26,7 @@ from qfieldcloud.core.models import (
 )
 from qfieldcloud.core.utils2 import storage
 from qfieldcloud.core.validators import MaxBytesLengthValidator
+from qfieldcloud.filestorage.constants import VERSION_SUFFIX_REGEX
 from qfieldcloud.filestorage.utils import calc_etag, filename_validator
 
 
@@ -262,7 +263,14 @@ def get_file_version_upload_to(instance: "FileVersion", _filename: str) -> str:
         ):
             return f"projects/{instance.file.project.id}/files/{instance.file.name}"
 
-        return f"projects/{instance.file.project.id}/files/{instance.file.name}/{instance.display}-{str(instance.id)[0:8]}"
+        version_suffix = f"{instance.display}-{str(instance.id)[0:8]}"
+
+        if not VERSION_SUFFIX_REGEX.match(version_suffix):
+            raise AssertionError(
+                f"Version suffix {version_suffix} does not match the expected format!"
+            )
+
+        return f"projects/{instance.file.project.id}/files/{instance.file.name}/{version_suffix}"
 
     elif instance.file.file_type == File.FileType.PACKAGE_FILE:
         # TODO decide whether we need to add the version id in there?

--- a/docker-app/qfieldcloud/filestorage/tests/test_backend.py
+++ b/docker-app/qfieldcloud/filestorage/tests/test_backend.py
@@ -1,19 +1,11 @@
 import logging
-import re
-import uuid
 from unittest.mock import patch
 
 from django.test import TestCase
-from django.utils import timezone
 
 from qfieldcloud.filestorage.backend import QfcS3Boto3Storage
 
 logging.disable(logging.CRITICAL)
-
-# -- Regex extracted to module level so the contract tests below
-#    can reference it.  This must stay in sync with the inline
-#    pattern inside QfcS3Boto3Storage._get_write_parameters.
-_VERSION_RE = re.compile(r"v20[0-9]{12}-[a-f0-9]{8}$")
 
 
 class QfcS3Boto3StorageTestCase(TestCase):
@@ -43,64 +35,6 @@ class QfcS3Boto3StorageTestCase(TestCase):
             return_value=parent_params,
         ):
             return self.storage._get_write_parameters(name)
-
-    # ==================================================================
-    # CONTRACT TESTS — regex must match the key format from models.py
-    # ==================================================================
-    #
-    # models.py line 344:  display = uploaded_at.strftime("v%Y%m%d%H%M%S")
-    # models.py line 265:  key   = projects/{id}/files/{name}/{display}-{id[:8]}
-    #
-    # If either format changes these tests MUST break.
-
-    def test_regex_matches_display_format_from_models(self):
-        """FileVersion.display produces ``vYYYYMMDDHHMMSS`` — the regex
-        must accept any valid datetime in that format."""
-        now = timezone.now()
-        display = now.strftime("v%Y%m%d%H%M%S")
-
-        # display alone is 15 chars (v + 14 digits), but the full
-        # suffix is {display}-{uuid_fragment}.
-        self.assertEqual(len(display), 15)
-        self.assertTrue(
-            display.startswith("v20"),
-            f"Expected display to start with v20, got {display}",
-        )
-
-    def test_regex_matches_full_version_suffix(self):
-        """The complete version suffix is {display}-{id[:8]}.
-        This is what _get_write_parameters sees as the last path
-        component after versioning."""
-        now = timezone.now()
-        display = now.strftime("v%Y%m%d%H%M%S")
-        version_id = uuid.uuid4()
-        uuid_fragment = str(version_id)[:8]
-
-        suffix = f"{display}-{uuid_fragment}"
-
-        self.assertRegex(suffix, _VERSION_RE)
-        self.assertEqual(len(uuid_fragment), 8)
-        self.assertTrue(
-            all(c in "0123456789abcdef" for c in uuid_fragment),
-            f"UUID fragment contains non-hex chars: {uuid_fragment}",
-        )
-
-    def test_full_s3_key_constructed_like_get_file_version_upload_to(self):
-        """End-to-end: build an S3 key the same way
-        get_file_version_upload_to does and verify Content-Type
-        is correctly detected."""
-        project_id = uuid.uuid4()
-        filename = "DCIM/survey.jpg"
-        now = timezone.now()
-        display = now.strftime("v%Y%m%d%H%M%S")
-        version_id = uuid.uuid4()
-
-        s3_key = (
-            f"projects/{project_id}/files/{filename}/{display}-{str(version_id)[:8]}"
-        )
-
-        params = self._call(s3_key)
-        self.assertEqual(params["ContentType"], "image/jpeg")
 
     # ==================================================================
     # HAPPY PATH — versioned paths for common file types


### PR DESCRIPTION
Before we had a bit too much freedom with how the version suffix was generated. However since `150b65dc4fb2f6d9c6dafff3071895bc19c2f093`, the `QfcS3Boto3Storage` expects the file key to be of given format.

Centralizing the management of the matching regex and validating against it as soon as a new file is generated make me feel more confident we do not accidentally break something.

Took the opportunity to remove a few less useful tests with it.

Continuation of https://github.com/opengisch/QFieldCloud/pull/1658