### PR TITLE
Fix GPG key download from qgis repos that prevents QGIS container build

### DIFF
--- a/docker-qgis/Dockerfile
+++ b/docker-qgis/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Add QGIS GPG key
-RUN wget -q -O /etc/apt/keyrings/qgis-archive-keyring.gpg https://download.qgis.org/downloads/qgis-archive-keyring.gpg
+RUN wget -q -O /etc/apt/keyrings/qgis-archive-keyring.gpg https://qgis.org/downloads/qgis-archive-keyring.gpg
 
 # Add QGIS repository
 RUN echo "Types: deb deb-src\n\


### PR DESCRIPTION
Because otherwise:

```
$ wget -q -S -O - https://download.qgis.org/downloads/qgis-archive-keyring.gpg
  HTTP/1.1 404 Not Found
  Server: nginx
  Date: Sat, 20 Jun 2026 21:32:09 GMT
  Content-Type: application/xml
  Transfer-Encoding: chunked
  Connection: keep-alive
  Vary: Accept-Encoding
  cache-control: no-cache
  Content-Disposition: attachment; filename=qgis-archive-keyring.gpg
```

and

```
$ curl https://download.qgis.org/downloads/qgis-archive-keyring.gpg
<?xml version="1.0" encoding="UTF-8"?>
<Error>
    <Code>NoSuchBucket</Code>
    <Message>The specified bucket does not exist.</Message>
    <RequestId>N/A</RequestId>
    <HostId>N/A</HostId>
</Error>%
```