### PR TITLE
feat: Prepare for adding captcha on the signup page

### DIFF
--- a/docker-app/qfieldcloud/core/templates/account/signup.html
+++ b/docker-app/qfieldcloud/core/templates/account/signup.html
@@ -33,6 +33,9 @@
   </div>
 </div>
 
+{% endblock content %}
+
+
 {% block additional_js %}
 <script type="application/javascript">
   try {
@@ -42,7 +45,27 @@
   } catch(err) {
     console.error("Failed to automatically select timezone: ", err);
   }
+
+  (() => {
+    const elCaptchaImage = document.querySelector('.qfc-captcha-image');
+    const elCaptchaBtn = document.querySelector('.qfc-captcha-btn');
+    const elCaptchaHidden = document.querySelector('input[name="captcha_0"]');
+
+    if (elCaptchaImage && elCaptchaBtn && elCaptchaHidden) {
+      elCaptchaBtn.addEventListener('click', () => {
+        fetch("/captcha/refresh/", { headers: { "X-Requested-With": "XMLHttpRequest" } })
+          .then(response => response.json())
+          .then(result => {
+            elCaptchaHidden.value = result['key'];
+            elCaptchaImage.src = result['image_url'];
+          })
+          .catch(err => {
+            console.error("Failed to refresh CAPTCHA: ", err);
+          });
+      });
+    } else {
+      console.error("Captcha elements not found in the DOM. Automatic refresh will not work.");
+    }
+  })();
 </script>
 {% endblock additional_js %}
-
-{% endblock content %}

--- a/docker-app/qfieldcloud/core/templates/captcha/widgets/captcha.html
+++ b/docker-app/qfieldcloud/core/templates/captcha/widgets/captcha.html
@@ -1,0 +1,17 @@
+{% load i18n %}
+{% spaceless %}
+<div class="form-group">
+  <div class="mb-3">
+    {% if audio %}
+        <a title="{% trans "Play CAPTCHA as audio file" %}" href="{{ audio }}">
+    {% endif %}
+    <img src="{{ image }}" alt="captcha" class="qfc-captcha-image" />
+    <button type="button" class="btn btn-outline-secondary qfc-captcha-btn ml-3" title="{% trans "Refresh CAPTCHA" %}">
+      <i class="fa fa-refresh"></i>
+    </button>
+  </div>
+
+  {% include "django/forms/widgets/multiwidget.html" %}
+
+</div>
+{% endspaceless %}

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -143,6 +143,7 @@ INSTALLED_APPS = [
     "bootstrap4",
     "sri",
     "corsheaders",
+    "captcha",
     # To ensure that exceptions inside other apps' signal handlers do not affect the integrity of file deletions within transactions, `django_cleanup` should be placed last in `INSTALLED_APPS`. See https://github.com/un1t/django-cleanup#configuration
     "django_cleanup.apps.CleanupConfig",
 ]
@@ -1011,6 +1012,41 @@ CORS_URLS_REGEX = r"^/(api/.*|swagger(.yaml|/))$"
 # Whether to include credentials (cookies, authorization headers) in
 # cross-origin requests. Required when clients send auth tokens.
 CORS_ALLOW_CREDENTIALS = parse_string_to_bool(os.environ["CORS_ALLOW_CREDENTIALS"])
+
+
+###########################
+# Captcha settings
+# Managed via `django-simple-captcha`, see https://django-simple-captcha.readthedocs.io/en/latest/advanced.html for all available options and defaults.
+###########################
+
+# Image size in pixels of generated captcha, specified as a tuple (width, height)
+# See https://django-simple-captcha.readthedocs.io/en/latest/advanced.html#captcha-image-size
+CAPTCHA_IMAGE_SIZE = (200, 50)
+
+# A random rotation in this interval is applied to each letter in the challenge text.
+# See https://django-simple-captcha.readthedocs.io/en/latest/advanced.html#captcha-letter-rotation
+CAPTCHA_LETTER_ROTATION = (-45, 45)
+
+# Background-color of the captcha. Can be expressed as html-style #rrggbb, rgb(red, green, blue), or common html names (e.g. “red”).
+# See https://django-simple-captcha.readthedocs.io/en/latest/advanced.html#captcha-background-color
+CAPTCHA_BACKGROUND_COLOR = "transparent"
+
+# A string representing a Python callable (i.e., a function) to determine the color of each letter in the CAPTCHA.
+# See https://django-simple-captcha.readthedocs.io/en/latest/advanced.html#captcha-letter-color-funct
+CAPTCHA_LETTER_COLOR_FUNCT = "captcha.helpers.random_letter_color_challenge"
+
+# Integer. Lifespan, in minutes, of the generated captcha.
+# See https://django-simple-captcha.readthedocs.io/en/latest/advanced.html#captcha-timeout
+CAPTCHA_TIMEOUT = 5
+
+# Sets the length, in chars, of the generated captcha. (for the 'captcha.helpers.random_char_challenge' challenge)
+# See https://django-simple-captcha.readthedocs.io/en/latest/advanced.html#captcha-length
+CAPTCHA_LENGTH = 6
+
+# When set to True, the string “PASSED” (any case) will be accepted as a valid response to any CAPTCHA. Use this for testing purposes.
+# See https://django-simple-captcha.readthedocs.io/en/latest/advanced.html#captcha-test-mode
+CAPTCHA_TEST_MODE = DEBUG or ENVIRONMENT == "test"
+
 
 # Optional volume name where custom CA files are mounted
 QFIELDCLOUD_CUSTOM_CA_VOLUME_NAME = (

--- a/docker-app/qfieldcloud/urls.py
+++ b/docker-app/qfieldcloud/urls.py
@@ -104,5 +104,6 @@ urlpatterns = [
     path("accounts/", include("allauth.urls")),
     path("invitations/", include("invitations.urls", namespace="invitations")),
     path("__debug__/", include("debug_toolbar.urls")),
+    path("captcha/", include("captcha.urls")),
     path("a/<str:username>/<str:project_name>/", redirect_to_admin_project_view),
 ]

--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -26,6 +26,7 @@ django-nonrelated-inlines==0.2
 # Unfortunately the version is not released yet on pypi, so we need to install it from the git repository, currently # 1.9.0
 django-notifications-hq @ git+https://github.com/django-notifications/django-notifications.git@4c44bcea2504d9a3fcd26366b232a13732a08f2a
 django-phonenumber-field==8.4.0
+django-simple-captcha==0.6.3
 django-sri==0.8.0
 django-storages==1.14.6
 django-tables2==3.0.0

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -64,6 +64,8 @@ django==5.2.14
     #   django-nonrelated-inlines
     #   django-notifications-hq
     #   django-phonenumber-field
+    #   django-ranged-response
+    #   django-simple-captcha
     #   django-sri
     #   django-storages
     #   django-stubs
@@ -123,6 +125,10 @@ django-notifications-hq @ git+https://github.com/django-notifications/django-not
     # via -r /requirements/requirements.in
 django-phonenumber-field==8.4.0
     # via -r /requirements/requirements.in
+django-ranged-response==0.2.0
+    # via django-simple-captcha
+django-simple-captcha==0.6.3
+    # via -r /requirements/requirements.in
 django-sri==0.8.0
     # via -r /requirements/requirements.in
 django-storages==1.14.6
@@ -172,7 +178,9 @@ packaging==26.0
 phonenumbers==9.0.27
     # via -r /requirements/requirements.in
 pillow==12.2.0
-    # via -r /requirements/requirements.in
+    # via
+    #   -r /requirements/requirements.in
+    #   django-simple-captcha
 psycopg2==2.9.12
     # via -r /requirements/requirements.in
 pycparser==2.22


### PR DESCRIPTION
Currently we were very liberal on people registering on the QFC service.

While `django-simple-captcha` is not the most advanced captcha, it is a good start to filter out the majority of the bots abusing our service.

This PR/commit also fixed a bug that the JS block on the signup page was loading twice, as the `block additional_js` was wrongly nested within the `block content`, which made it rendered twice. Once the `block additional_js` was moved outside, it will only be replaced in the root `base.html` template.

Finally, this PR does not add the captcha on the signup page, we need to setup a custom the `SignUpForm` to do so, which is out of scope.