### PR TITLE
chore: Mypy should ignore libqfieldsync within docker-qgis

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -2,6 +2,11 @@
 no_implicit_optional = True
 disable_error_code = var-annotated
 
+exclude = (?x)(
+    # Ignore the `libqfieldsync` symlink in `docker-qgis` used for local development
+    ^docker-qgis/libqfieldsync/.*
+  )
+
 # Turn off mypy for all django migration packages via naming convention.
 [mypy-*.migrations.*]
 ignore_errors: True


### PR DESCRIPTION
This is a local development environment to codevelop QFC and libqfieldsync. Unfortunately the qfc mypy configuration is not exactly happy with the libqfieldsynnc mypy configuration.