### PR TITLE
Rename the label of `Project.is_featured` from "Is sticky" to "Is featured"

### DIFF
--- a/docker-app/qfieldcloud/core/migrations/0083_project_is_sticky.py
+++ b/docker-app/qfieldcloud/core/migrations/0083_project_is_sticky.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
             field=models.BooleanField(
                 default=False,
                 help_text="If set to true, the project will always appear on top of the project list, no matter the sorting. If multiple projects are featured, they will be sorted by the user defined sorting.",
-                verbose_name="Is sticky",
+                verbose_name="Is featured",
             ),
         ),
         migrations.AlterModelOptions(

--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -1297,7 +1297,7 @@ class Project(models.Model):
     )
 
     is_featured = models.BooleanField(
-        _("Is sticky"),
+        _("Is featured"),
         help_text=_(
             "If set to true, the project will always appear on top of the project list, no matter the sorting. If multiple projects are featured, they will be sorted by the user defined sorting."
         ),


### PR DESCRIPTION


The original name was "is_sticky" and we forgot to update the label.

The migration is directly edited, as the value does not have any effect on the database and it is safe to do.