### PR TITLE
chore: bump `django-jazzmin` from `3.0.1` to `3.0.5`

### DIFF
--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -18,7 +18,7 @@ django-extensions==4.1
 django-fernet-encrypted-fields==0.4.0
 django-filter==25.2
 django-invitations==2.1.0
-django-jazzmin==3.0.1
+django-jazzmin==3.0.5
 django-log-request-id==2.1.2
 django-migrate-sql-3==3.0.2
 django-model-utils==5.0.0

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -109,7 +109,7 @@ django-filter==25.2
     # via -r /requirements/requirements.in
 django-invitations==2.1.0
     # via -r /requirements/requirements.in
-django-jazzmin==3.0.1
+django-jazzmin==3.0.5
     # via -r /requirements/requirements.in
 django-log-request-id==2.1.2
     # via -r /requirements/requirements.in


### PR DESCRIPTION
See changelog : https://github.com/farridav/django-jazzmin/releases/tag/v3.0.5

See diff : https://github.com/farridav/django-jazzmin/compare/v3.0.1...v3.0.5