### PR TITLE
chore: bump `boto3` and related dependencies

### DIFF
--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -1,5 +1,5 @@
-boto3-stubs==1.35.90
-boto3==1.35.90
+boto3-stubs==1.43.38
+boto3==1.43.38
 deprecated==1.3.1
 django-allauth[socialaccount]==65.18.0
 django-auditlog==3.4.1
@@ -38,7 +38,7 @@ djangorestframework==3.17.1
 djangorestframework-stubs==3.16.9
 drf-spectacular==0.29.0
 json-log-formatter==1.2.1
-mypy-boto3-s3==1.35.81
+mypy-boto3-s3==1.43.31
 phonenumbers==9.0.27
 Pillow==12.2.0
 psycopg2==2.9.12

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -17,11 +17,11 @@ attrs==25.3.0
     #   referencing
 beautifulsoup4==4.13.5
     # via django-bootstrap4
-boto3==1.35.90
+boto3==1.43.38
     # via -r /requirements/requirements.in
-boto3-stubs==1.35.90
+boto3-stubs==1.43.38
     # via -r /requirements/requirements.in
-botocore==1.35.99
+botocore==1.43.38
     # via
     #   boto3
     #   s3transfer
@@ -169,7 +169,7 @@ jsonschema==4.25.1
     # via drf-spectacular
 jsonschema-specifications==2025.4.1
     # via jsonschema
-mypy-boto3-s3==1.35.81
+mypy-boto3-s3==1.43.31
     # via -r /requirements/requirements.in
 oauthlib==3.3.1
     # via django-allauth
@@ -207,7 +207,7 @@ rpds-py==0.27.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.10.4
+s3transfer==0.19.0
     # via boto3
 sentry-sdk==2.62.0
     # via -r /requirements/requirements.in


### PR DESCRIPTION
Since some Object Storage providers were not always compatible with recent versions of boto3 (e.g. >= `1.37`),

See individual commit messages for changelogs, diffs and version changes.

The `boto3-stubs` and `mypy-boto3-s3` are built from [this repository](https://github.com/youtype/mypy_boto3_builder), could not really find a changelog for those,

Needs to be tested on several providers before getting merged.