### PR TITLE
feat: clear Jobs outputs after retention period

### DIFF
--- a/docker-app/qfieldcloud/core/cron.py
+++ b/docker-app/qfieldcloud/core/cron.py
@@ -107,3 +107,18 @@ class DeleteObsoleteProjectPackagesJob(CronJobBase):
         )
 
         packages.delete_obsolete_packages(projects)
+
+
+class ClearJobOutputsAfterRetentionPeriodJob(CronJobBase):
+    # runs every night at 02:00
+    schedule = Schedule(run_every_mins=1440, run_at_times=["02:00"])
+    code = "qfieldcloud.clear_jobs_outputs_after_retention_period"
+
+    def do(self):
+        jobs = Job.objects.filter(
+            created_at__lt=timezone.now()
+            - timedelta(days=config.JOB_OUTPUT_RETENTION_DAYS),
+            output__isnull=False,
+        )
+
+        jobs.update(output=None)


### PR DESCRIPTION
Follow-up of #1688: add a cron job that nightly sets the Jobs outputs to null, after the `JOBS_LOGS_RETENTION_PERIOD_DAYS` retention period.