### PR TITLE
Bump django-allauth to 65.18.0 to fix SSO issue.

### DIFF
--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -1,7 +1,7 @@
 boto3-stubs==1.35.90
 boto3==1.35.90
 deprecated==1.3.1
-django-allauth[socialaccount]==65.17.0
+django-allauth[socialaccount]==65.18.0
 django-auditlog==3.4.1
 django-axes==8.3.1
 django-bootstrap4==26.1

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -75,7 +75,7 @@ django==5.2.14
     #   djangorestframework
     #   drf-spectacular
     #   jsonfield
-django-allauth[socialaccount]==65.17.0
+django-allauth[socialaccount]==65.18.0
     # via -r /requirements/requirements.in
 django-auditlog==3.4.1
     # via -r /requirements/requirements.in


### PR DESCRIPTION
Bump `django-allauth` to `65.18.0` to fix SSO issue.

This bumps `django-allauth` to the version that contains the fix for a `KeyError` in `lookup_kid_jwk`:

```python
Traceback (most recent call last):
  File "/usr/local/lib/python3.14/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.14/site-packages/sentry_sdk/integrations/django/middleware.py", line 181, in __call__
    return f(*args, **kwargs)
  File "/usr/src/app/qfieldcloud/core/middleware/qgis_auth.py", line 101, in __call__
    social_login = oauth_adapter.complete_login(
        request, provider.app, token, response=token_response
    )
  File "/usr/local/lib/python3.14/site-packages/allauth/socialaccount/providers/openid_connect/views.py", line 61, in complete_login
    data["id_token"] = self._decode_id_token(app, id_token_str)
                       ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/allauth/socialaccount/providers/openid_connect/views.py", line 80, in _decode_id_token
    return jwtkit.verify_and_decode(
           ~~~~~~~~~~~~~~~~~~~~~~~~^
        credential=id_token,
        ^^^^^^^^^^^^^^^^^^^^
    ...<4 lines>...
        verify_signature=verify_signature,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/local/lib/python3.14/site-packages/allauth/socialaccount/internal/jwtkit.py", line 92, in verify_and_decode
    alg, key = fetch_key(credential, keys_url, lookup_kid)
               ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/allauth/socialaccount/internal/jwtkit.py", line 66, in fetch_key
    key = lookup(keys_data, kid)
  File "/usr/local/lib/python3.14/site-packages/allauth/socialaccount/internal/jwtkit.py", line 49, in lookup_kid_jwk
    alg = d["alg"]
          ~^^^^^^^
KeyError: 'alg'
```