### PR TITLE
Monkey patch dj.forms.formsets.DEFAULT_MAX_NUM to fix saving of large forms

### DIFF
--- a/docker-app/qfieldcloud/core/apps.py
+++ b/docker-app/qfieldcloud/core/apps.py
@@ -6,3 +6,11 @@ class CoreConfig(AppConfig):
 
     def ready(self):
         from qfieldcloud.core import signals  # noqa
+
+        # Monkey patch DEFAULT_MAX_NUM to a higher value to prevent saving
+        # of large formsets from erroring out. This monkey patch should be
+        # removed once this is configurable as a setting in Django.
+        # See QF-8530.
+        import django.forms.formsets
+
+        django.forms.formsets.DEFAULT_MAX_NUM = 5000


### PR DESCRIPTION
Monkey patch [`django.forms.formsets.DEFAULT_MAX_NUM`](https://github.com/django/django/blob/61a829d13aa5589cc12b10cc96194125f84f2e69/django/forms/formsets.py#L25) to a higher value to prevent saving of large formsets from erroring out. This monkey patch should be removed once this is configurable as a setting in Django.