### PR TITLE
chore: pin django-jazzmin to version `3.0.1` due to stability issues from version `3.0.2` onwards

### DIFF
--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -18,6 +18,7 @@ django-extensions==4.1
 django-fernet-encrypted-fields==0.4.0
 django-filter==25.2
 django-invitations==2.1.0
+# django-jazzmin 3.0.2 onwards breaks manifest static storages by passing a directory to {% static %}, see https://github.com/farridav/django-jazzmin/issues/684
 django-jazzmin==3.0.1
 django-log-request-id==2.1.2
 django-migrate-sql-3==3.0.2


### PR DESCRIPTION
pin django-jazzmin to version `3.0.1` due to stability issues from version `3.0.2` onwards, follow-up of https://github.com/opengisch/QFieldCloud/pull/1689. 