### PR TITLE
chore: bump `soupsieve` from `2.7` to `2.8.4`

### DIFF
--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -213,7 +213,7 @@ sentry-sdk==2.62.0
     # via -r /requirements/requirements.in
 six==1.17.0
     # via python-dateutil
-soupsieve==2.7
+soupsieve==2.8.4
     # via beautifulsoup4
 sqlparse==0.5.5
     # via


### PR DESCRIPTION
Bump transitive `soupsieve` dependency from `2.7` to `2.8.4`.

Changelog: https://github.com/facelessuser/soupsieve/releases
Diff: https://github.com/facelessuser/soupsieve/compare/2.7...2.8.4

Supersedes and closes #1704