### PR TITLE
Disable Gunicorn control socket to fix `Permission denied` error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       gunicorn
         qfieldcloud.wsgi:application
         --bind 0.0.0.0:8000
+        --no-control-socket
         --timeout ${GUNICORN_TIMEOUT_S}
         --max-requests ${GUNICORN_MAX_REQUESTS}
         --workers ${GUNICORN_WORKERS}


### PR DESCRIPTION
This fixes the following (non-fatal) error we started seeing in our `app` container logs:

```
  [ERROR] Control server error: [Errno 13] Permission denied: '/nonexistent'
```

Gunicorn recently introduced a change that [starts a control socket server](https://gunicorn.org/reference/settings/#control) by default, creating a socket at `$HOME/.gunicorn/gunicorn.ctl`. The `app` system user has `HOME=/nonexistent` (Debian's default for `adduser --system`), a mode-000 directory, causing a Permission denied error on every startup.

The `--no-control-socket` flag disables this socket, since we don't need it.