### PR TITLE
open_qgis_file: Handle unexpected .qgs names inside .qgz

### DIFF
--- a/docker-app/qfieldcloud/core/tests/utils.py
+++ b/docker-app/qfieldcloud/core/tests/utils.py
@@ -1,8 +1,11 @@
 import io
 import os
 import tempfile
-from collections.abc import Iterable
+import zipfile
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from datetime import timedelta
+from pathlib import Path
 from time import sleep
 from typing import IO
 
@@ -107,6 +110,31 @@ def set_subscription(
     assert subscription is not None
 
     return subscription
+
+
+@contextmanager
+def qgz_from_qgs(qgs_path: str | Path, qgz_name: str | None = None) -> Iterator[Path]:
+    """Context manager that creates a temporary .qgz file from a .qgs file.
+
+    The .qgz file is placed in a temporary directory that is removed together
+    with all its contents when the context exits.
+
+    Args:
+        qgs_path: path to the source .qgs file.
+        qgz_name: name to use for the .qgz archive (optional).
+    """
+    qgs_path = Path(qgs_path)
+
+    # Unless a specific `qgz_name` was requested, default to basename of qgs file
+    if qgz_name is None:
+        qgz_name = qgs_path.with_suffix(".qgz").name
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        qgz_path = Path(tmpdir) / qgz_name
+        with zipfile.ZipFile(qgz_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.write(qgs_path, arcname=qgs_path.name)
+
+        yield qgz_path
 
 
 def get_random_file(mb: float) -> IO:

--- a/docker-app/qfieldcloud/filestorage/tests/test_utils.py
+++ b/docker-app/qfieldcloud/filestorage/tests/test_utils.py
@@ -1,13 +1,16 @@
 # from unittest import TestCase
 import logging
+from pathlib import Path
 
 from django.conf import settings
 from django.test import TestCase
 
+from qfieldcloud.core.tests.utils import qgz_from_qgs, testdata_path
 from qfieldcloud.filestorage.utils import (
     is_admin_restricted_file,
     is_qgis_project_file,
     is_valid_filename,
+    open_qgis_file,
 )
 
 logging.disable(logging.CRITICAL)
@@ -125,3 +128,22 @@ class QfcTestCase(TestCase):
 
     def test_calc_etag_on_large_files(self):
         pass
+
+    def test_open_qgis_file_with_qgs(self):
+        qgs_path = Path(testdata_path("delta/project.qgs"))
+
+        with open(qgs_path, "rb") as fh:
+            with open_qgis_file(qgs_path, fh) as text_fh:
+                self.assertIsNotNone(text_fh)
+                first_line = text_fh.readline()
+                self.assertIn("<qgis", first_line)
+
+    def test_open_qgis_file_with_qgz(self):
+        qgs_path = Path(testdata_path("delta/project.qgs"))
+
+        with qgz_from_qgs(qgs_path) as qgz_path:
+            with open(qgz_path, "rb") as fh:
+                with open_qgis_file(qgz_path, fh) as text_fh:
+                    self.assertIsNotNone(text_fh)
+                    first_line = text_fh.readline()
+                    self.assertIn("<qgis", first_line)

--- a/docker-app/qfieldcloud/filestorage/tests/test_utils.py
+++ b/docker-app/qfieldcloud/filestorage/tests/test_utils.py
@@ -147,3 +147,13 @@ class QfcTestCase(TestCase):
                     self.assertIsNotNone(text_fh)
                     first_line = text_fh.readline()
                     self.assertIn("<qgis", first_line)
+
+    def test_open_qgis_file_with_qgz_and_unexpected_qgs_name(self):
+        qgs_path = Path(testdata_path("delta/project.qgs"))
+
+        with qgz_from_qgs(qgs_path, "project.123.qgz") as qgz_path:
+            with open(qgz_path, "rb") as fh:
+                with open_qgis_file(qgz_path, fh) as text_fh:
+                    self.assertIsNotNone(text_fh)
+                    first_line = text_fh.readline()
+                    self.assertIn("<qgis", first_line)

--- a/docker-app/qfieldcloud/filestorage/utils.py
+++ b/docker-app/qfieldcloud/filestorage/utils.py
@@ -1,5 +1,6 @@
 import hashlib
 import io
+import logging
 import re
 import uuid
 import xml.etree.ElementTree as ET
@@ -18,6 +19,8 @@ from django.http import HttpRequest
 from django.utils.translation import gettext_lazy as _
 
 from qfieldcloud.core.exceptions import InvalidRangeError
+
+logger = logging.getLogger(__name__)
 
 filename_validator = RegexValidator(
     settings.STORAGES_FILENAME_VALIDATION_REGEX,
@@ -268,7 +271,32 @@ def open_qgis_file(
 
     if suffix == ".qgz":
         with zipfile.ZipFile(fh) as qgz:
-            with qgz.open(f"{path.stem}.qgs") as qgs:
+            expected_qgs_name = f"{path.stem}.qgs"
+            archive_names = qgz.namelist()
+
+            if expected_qgs_name in archive_names:
+                qgs_filename = expected_qgs_name
+
+            else:
+                qgs_filename = None
+                for archive_file in sorted(archive_names):
+                    if Path(archive_file).suffix == ".qgs":
+                        qgs_filename = archive_file
+                        break
+
+                if not qgs_filename:
+                    raise KeyError(
+                        f"No '.qgs' file found in the '.qgz' archive {filename}"
+                    )
+
+                logger.info(
+                    f"Expected '.qgs' file '{expected_qgs_name}' not found in '.qgz' archive '{filename}', "
+                    f"found and fallback to '{qgs_filename}' instead!"
+                )
+
+            assert qgs_filename
+
+            with qgz.open(qgs_filename) as qgs:
                 with io.TextIOWrapper(qgs, encoding="utf-8") as text_fh:
                     yield text_fh
 

--- a/docker-qgis/qfc_worker/utils.py
+++ b/docker-qgis/qfc_worker/utils.py
@@ -1092,7 +1092,32 @@ def open_qgis_file(filename: str | Path) -> Iterator[TextIO]:
     with open(filename, "rb") as fh:
         if suffix == ".qgz":
             with zipfile.ZipFile(fh) as qgz:
-                with qgz.open(f"{path.stem}.qgs") as qgs:
+                expected_qgs_name = f"{path.stem}.qgs"
+                archive_names = qgz.namelist()
+
+                if expected_qgs_name in archive_names:
+                    qgs_filename = expected_qgs_name
+
+                else:
+                    qgs_filename = None
+                    for archive_file in sorted(archive_names):
+                        if Path(archive_file).suffix == ".qgs":
+                            qgs_filename = archive_file
+                            break
+
+                    if not qgs_filename:
+                        raise KeyError(
+                            f"No '.qgs' file found in the '.qgz' archive {filename}"
+                        )
+
+                    logging.info(
+                        f"Expected '.qgs' file '{expected_qgs_name}' not found in '.qgz' archive '{filename}', "
+                        f"found and fallback to '{qgs_filename}' instead!"
+                    )
+
+                assert qgs_filename
+
+                with qgz.open(qgs_filename) as qgs:
                     with io.TextIOWrapper(qgs, encoding="utf-8") as text_fh:
                         yield text_fh
 


### PR DESCRIPTION
QGIS uses QFileInfo's `baseName()` to determine the stem of a `.qgs` file inside a `.qgz` file. This may lead to situations where the `.qgs` file doesn't have exactly the same stem as the `.qgz` that contains it, for example when the qgz filename contains more than one dot.

This change makes `open_qgis_file` more robust to deal with this fact, by:
  - Still trying the expected name first
  - But, when unsuccessful, falling back to the first `.qgs` file it finds and logging the expected and actual .qgs names
  
(Updated both `open_qgis_file` functions in app and worker)