### PR TITLE
Use absolute imports across the codebase

### DIFF
--- a/docker-app/qfieldcloud/authentication/admin.py
+++ b/docker-app/qfieldcloud/authentication/admin.py
@@ -5,9 +5,8 @@ from django.db.models import Q, QuerySet
 from django.http import HttpRequest
 from django.utils import timezone
 
+from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core.admin import QFieldCloudModelAdmin, qfc_admin_site
-
-from .models import AuthToken
 
 if TYPE_CHECKING:
     from django_stubs_ext import StrOrPromise

--- a/docker-app/qfieldcloud/authentication/authentication.py
+++ b/docker-app/qfieldcloud/authentication/authentication.py
@@ -5,10 +5,9 @@ from rest_framework.authentication import (
     TokenAuthentication as DjangoRestFrameworkTokenAuthentication,
 )
 
+from qfieldcloud.authentication.models import AuthToken
+from qfieldcloud.core.exceptions import AuthenticationViaTokenFailedError
 from qfieldcloud.core.models import User
-
-from ..core.exceptions import AuthenticationViaTokenFailedError
-from .models import AuthToken
 
 
 def invalidate_all_tokens(user: User) -> int:

--- a/docker-app/qfieldcloud/authentication/serializers.py
+++ b/docker-app/qfieldcloud/authentication/serializers.py
@@ -4,7 +4,7 @@ from django.utils.translation import gettext as _
 from rest_framework import serializers
 from rest_framework.exceptions import AuthenticationFailed
 
-from .models import AuthToken
+from qfieldcloud.authentication.models import AuthToken
 
 User = get_user_model()
 

--- a/docker-app/qfieldcloud/authentication/views.py
+++ b/docker-app/qfieldcloud/authentication/views.py
@@ -14,11 +14,10 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from qfieldcloud.authentication.authentication import create_token
+from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.authentication.sso.auth_providers import get_auth_providers
-
-from .authentication import create_token
-from .models import AuthToken
-from .utils import load_module
+from qfieldcloud.authentication.utils import load_module
 
 LoginSerializer = load_module(settings.QFIELDCLOUD_LOGIN_SERIALIZER)
 TokenSerializer = load_module(settings.QFIELDCLOUD_TOKEN_SERIALIZER)

--- a/docker-app/qfieldcloud/core/tests/test_admin.py
+++ b/docker-app/qfieldcloud/core/tests/test_admin.py
@@ -5,10 +5,15 @@ from django.conf import settings
 from django.test.testcases import TransactionTestCase
 from django.urls.resolvers import URLPattern, URLResolver
 
+from qfieldcloud.core.models import (
+    Delta,
+    Organization,
+    Person,
+    ProcessProjectfileJob,
+    Team,
+)
+from qfieldcloud.core.tests.utils import setup_subscription_plans
 from qfieldcloud.project.models import Project
-
-from ..models import Delta, Organization, Person, ProcessProjectfileJob, Team
-from .utils import setup_subscription_plans
 
 logging.disable(logging.CRITICAL)
 

--- a/docker-app/qfieldcloud/core/tests/test_api.py
+++ b/docker-app/qfieldcloud/core/tests/test_api.py
@@ -5,9 +5,8 @@ from rest_framework.test import APITransactionTestCase
 
 from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core.models import Person
+from qfieldcloud.core.tests.utils import setup_subscription_plans
 from qfieldcloud.project.models import Project
-
-from .utils import setup_subscription_plans
 
 logging.disable(logging.CRITICAL)
 

--- a/docker-app/qfieldcloud/core/tests/test_collaborators.py
+++ b/docker-app/qfieldcloud/core/tests/test_collaborators.py
@@ -3,9 +3,8 @@ from rest_framework.test import APITransactionTestCase
 
 from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core.models import Person, ProjectCollaborator
+from qfieldcloud.core.tests.utils import setup_subscription_plans
 from qfieldcloud.project.models import Project
-
-from .utils import setup_subscription_plans
 
 
 class QfcTestCase(APITransactionTestCase):

--- a/docker-app/qfieldcloud/core/tests/test_delta.py
+++ b/docker-app/qfieldcloud/core/tests/test_delta.py
@@ -24,10 +24,13 @@ from qfieldcloud.core.models import (
     Person,
     ProjectCollaborator,
 )
+from qfieldcloud.core.tests.utils import (
+    get_filename,
+    setup_subscription_plans,
+    testdata_path,
+)
 from qfieldcloud.project.models import Project
 from qfieldcloud.subscription.models import Subscription
-
-from .utils import get_filename, setup_subscription_plans, testdata_path
 
 logging.disable(logging.CRITICAL)
 

--- a/docker-app/qfieldcloud/core/tests/test_organization.py
+++ b/docker-app/qfieldcloud/core/tests/test_organization.py
@@ -16,9 +16,8 @@ from qfieldcloud.core.models import (
     Person,
     ProjectCollaborator,
 )
+from qfieldcloud.core.tests.utils import set_subscription, setup_subscription_plans
 from qfieldcloud.project.models import Project
-
-from .utils import set_subscription, setup_subscription_plans
 
 logging.disable(logging.CRITICAL)
 

--- a/docker-app/qfieldcloud/core/tests/test_permission.py
+++ b/docker-app/qfieldcloud/core/tests/test_permission.py
@@ -13,9 +13,12 @@ from qfieldcloud.core.models import (
     Team,
     User,
 )
+from qfieldcloud.core.tests.utils import (
+    set_subscription,
+    setup_subscription_plans,
+    testdata_path,
+)
 from qfieldcloud.project.models import Project
-
-from .utils import set_subscription, setup_subscription_plans, testdata_path
 
 logging.disable(logging.CRITICAL)
 

--- a/docker-app/qfieldcloud/core/tests/test_qgis_file.py
+++ b/docker-app/qfieldcloud/core/tests/test_qgis_file.py
@@ -10,14 +10,13 @@ from rest_framework.test import APITransactionTestCase
 
 from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core.models import Job, Person, ProcessProjectfileJob
-from qfieldcloud.project.models import Project
-
-from .utils import (
+from qfieldcloud.core.tests.utils import (
     get_filename,
     set_subscription,
     setup_subscription_plans,
     testdata_path,
 )
+from qfieldcloud.project.models import Project
 
 logging.disable(logging.CRITICAL)
 

--- a/docker-app/qfieldcloud/core/tests/test_queryset.py
+++ b/docker-app/qfieldcloud/core/tests/test_queryset.py
@@ -13,10 +13,9 @@ from qfieldcloud.core.models import (
     TeamMember,
     User,
 )
+from qfieldcloud.core.tests.utils import set_subscription, setup_subscription_plans
 from qfieldcloud.project.enums import ProjectRoleOrigins
 from qfieldcloud.project.models import Project
-
-from .utils import set_subscription, setup_subscription_plans
 
 logging.disable(logging.CRITICAL)
 

--- a/docker-app/qfieldcloud/core/tests/test_sentry.py
+++ b/docker-app/qfieldcloud/core/tests/test_sentry.py
@@ -4,7 +4,7 @@ from unittest import skipIf
 from django.conf import settings
 from django.test import Client, TestCase
 
-from ..utils2.sentry import report_serialization_diff_to_sentry
+from qfieldcloud.core.utils2.sentry import report_serialization_diff_to_sentry
 
 
 class QfcTestCase(TestCase):

--- a/docker-app/qfieldcloud/core/tests/test_team.py
+++ b/docker-app/qfieldcloud/core/tests/test_team.py
@@ -11,8 +11,7 @@ from qfieldcloud.core.models import (
     Team,
     TeamMember,
 )
-
-from .utils import setup_subscription_plans
+from qfieldcloud.core.tests.utils import setup_subscription_plans
 
 logging.disable(logging.CRITICAL)
 

--- a/docker-app/qfieldcloud/core/tests/test_user.py
+++ b/docker-app/qfieldcloud/core/tests/test_user.py
@@ -13,9 +13,8 @@ from qfieldcloud.core.models import (
     User,
     UserAccount,
 )
+from qfieldcloud.core.tests.utils import set_subscription, setup_subscription_plans
 from qfieldcloud.project.models import Project
-
-from .utils import set_subscription, setup_subscription_plans
 
 logging.disable(logging.CRITICAL)
 

--- a/docker-app/qfieldcloud/filestorage/helpers.py
+++ b/docker-app/qfieldcloud/filestorage/helpers.py
@@ -2,9 +2,8 @@ import logging
 
 from django.db import transaction
 
+from qfieldcloud.filestorage.models import FileVersion
 from qfieldcloud.project.models import Project
-
-from .models import FileVersion
 
 logger = logging.getLogger(__name__)
 

--- a/docker-app/qfieldcloud/filestorage/signals.py
+++ b/docker-app/qfieldcloud/filestorage/signals.py
@@ -1,7 +1,7 @@
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 
-from .models import File, FileVersion
+from qfieldcloud.filestorage.models import File, FileVersion
 
 
 @receiver(pre_delete, sender=FileVersion)

--- a/docker-app/qfieldcloud/filestorage/urls.py
+++ b/docker-app/qfieldcloud/filestorage/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import (
+from qfieldcloud.filestorage.views import (
     AvatarFileReadView,
     FileCrudView,
     FileListView,

--- a/docker-app/qfieldcloud/filestorage/view_helpers.py
+++ b/docker-app/qfieldcloud/filestorage/view_helpers.py
@@ -29,6 +29,7 @@ from qfieldcloud.core.models import (
 from qfieldcloud.core.utils2.storage import (
     get_attachment_dir_prefix,
 )
+from qfieldcloud.filestorage.helpers import purge_old_file_versions
 from qfieldcloud.filestorage.models import (
     File,
     FileVersion,
@@ -41,8 +42,6 @@ from qfieldcloud.filestorage.utils import (
     validate_filename,
 )
 from qfieldcloud.project.models import Project
-
-from .helpers import purge_old_file_versions
 
 logger = logging.getLogger(__name__)
 

--- a/docker-app/qfieldcloud/filestorage/views.py
+++ b/docker-app/qfieldcloud/filestorage/views.py
@@ -27,15 +27,14 @@ from qfieldcloud.core.models import (
 from qfieldcloud.filestorage.models import (
     File,
 )
-from qfieldcloud.project.models import Project
-
-from .serializers import FileWithVersionsSerializer
-from .view_helpers import (
+from qfieldcloud.filestorage.serializers import FileWithVersionsSerializer
+from qfieldcloud.filestorage.view_helpers import (
     delete_project_file_version,
     download_field_file,
     download_project_file_version,
     upload_project_file_version,
 )
+from qfieldcloud.project.models import Project
 
 logger = logging.getLogger(__name__)
 

--- a/docker-app/qfieldcloud/notifs/signals.py
+++ b/docker-app/qfieldcloud/notifs/signals.py
@@ -7,10 +7,7 @@ from django.dispatch import receiver
 from django_currentuser.middleware import get_current_authenticated_user
 from notifications.signals import notify
 
-from qfieldcloud.project.enums import ProjectRoleOrigins
-from qfieldcloud.project.models import Project
-
-from ..core.models import (
+from qfieldcloud.core.models import (
     Organization,
     OrganizationMember,
     Person,
@@ -19,6 +16,8 @@ from ..core.models import (
     TeamMember,
     User,
 )
+from qfieldcloud.project.enums import ProjectRoleOrigins
+from qfieldcloud.project.models import Project
 
 
 def _send_notif(verb, action_object, recipient, target=None):

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -16,7 +16,7 @@ from datetime import datetime, timedelta
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
-from .settings_utils import (
+from qfieldcloud.settings_utils import (
     ConfigValidationError,
     get_socialaccount_providers_config,
     get_storages_config,

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -18,8 +18,7 @@ from django.utils.translation import gettext as _
 from model_utils.managers import InheritanceManagerMixin
 
 from qfieldcloud.core.models import Organization, Person, User, UserAccount
-
-from .exceptions import NotPremiumPlanException
+from qfieldcloud.subscription.exceptions import NotPremiumPlanException
 
 logger = logging.getLogger(__name__)
 

--- a/docker-app/qfieldcloud/subscription/tests/test_external_db.py
+++ b/docker-app/qfieldcloud/subscription/tests/test_external_db.py
@@ -13,8 +13,7 @@ from qfieldcloud.core.tests.utils import (
     setup_subscription_plans,
 )
 from qfieldcloud.project.models import Project
-
-from ..models import Plan
+from qfieldcloud.subscription.models import Plan
 
 DATA_FOLDER = Path(__file__).parent / "data"
 

--- a/docker-app/qfieldcloud/subscription/tests/test_package.py
+++ b/docker-app/qfieldcloud/subscription/tests/test_package.py
@@ -11,9 +11,8 @@ from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core.models import Person
 from qfieldcloud.core.tests.utils import get_random_file, setup_subscription_plans
 from qfieldcloud.project.models import Project
-
-from ..exceptions import NotPremiumPlanException
-from ..models import Package, PackageType, Plan
+from qfieldcloud.subscription.exceptions import NotPremiumPlanException
+from qfieldcloud.subscription.models import Package, PackageType, Plan
 
 logging.disable(logging.CRITICAL)
 

--- a/docker-app/qfieldcloud/subscription/tests/test_plans.py
+++ b/docker-app/qfieldcloud/subscription/tests/test_plans.py
@@ -2,8 +2,7 @@ from django.core.exceptions import ValidationError
 from rest_framework.test import APITransactionTestCase
 
 from qfieldcloud.core.tests.utils import setup_subscription_plans
-
-from ..models import Plan
+from qfieldcloud.subscription.models import Plan
 
 
 class QfcTestCase(APITransactionTestCase):

--- a/docker-app/qfieldcloud/subscription/tests/test_subscription.py
+++ b/docker-app/qfieldcloud/subscription/tests/test_subscription.py
@@ -9,9 +9,13 @@ from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core.models import Organization, Person
 from qfieldcloud.core.tests.utils import set_subscription, setup_subscription_plans
 from qfieldcloud.project.models import Project
-
-from ..exceptions import NotPremiumPlanException
-from ..models import Package, PackageType, Plan, get_subscription_model
+from qfieldcloud.subscription.exceptions import NotPremiumPlanException
+from qfieldcloud.subscription.models import (
+    Package,
+    PackageType,
+    Plan,
+    get_subscription_model,
+)
 
 logging.disable(logging.CRITICAL)
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -25,8 +25,12 @@ extend-select = [
     "B006",     # Mutable argument default
     "BLE001",   # Checks for except clauses that catch all exceptions, see https://docs.astral.sh/ruff/rules/blind-except/
     "UP035",    # Checks for uses of deprecated imports based on the minimum supported Python version, see https://docs.astral.sh/ruff/rules/deprecated-import/
+    "TID252",   # Bans relative imports, requires absolute imports, see https://docs.astral.sh/ruff/rules/relative-imports/
 ]
 ignore = []
+
+[lint.flake8-tidy-imports]
+ban-relative-imports = "all"
 
 [lint.mccabe]
 max-complexity = 30


### PR DESCRIPTION
The codebase currently has a mix of absolute and relative imports. This PR harmonizes everything to use absolute imports.
Checked with:
```shell
ruff check --select TID252 --output-format=concise .
```