### PR TITLE
Bump `django` from `5.2.14` to `5.2.16`

### DIFF
--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -31,7 +31,7 @@ django-sri==0.8.0
 django-storages==1.14.6
 django-tables2==3.0.0
 django-timezone-field==7.2.1
-django==5.2.14
+django==5.2.16
 django-stubs==5.2.9
 django-stubs-ext==5.2.9
 djangorestframework==3.17.1

--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -41,7 +41,7 @@ cryptography==49.0.0
     #   pyjwt
 deprecated==1.3.1
     # via -r /requirements/requirements.in
-django==5.2.14
+django==5.2.16
     # via
     #   -r /requirements/requirements.in
     #   django-allauth


### PR DESCRIPTION
Mostly small security fixes:

- Django 5.2.15 fixes five security issues with severity “low” in 5.2.14.
- Django 5.2.16 fixes three security issues with severity “low” in 5.2.15.

Changelog: https://docs.djangoproject.com/en/dev/releases/5.2.15/ and https://docs.djangoproject.com/en/dev/releases/5.2.16/ Changes: https://github.com/django/django/compare/5.2.14...5.2.16

Closes https://github.com/opengisch/QFieldCloud/pull/1707