### PR TITLE
Avoid the cost of closing and re-opening an edit session for every delta applied

### DIFF
--- a/docker-qgis/qfc_worker/commands/apply_deltas.py
+++ b/docker-qgis/qfc_worker/commands/apply_deltas.py
@@ -413,7 +413,6 @@ def apply_deltas_without_transaction(
     for idx, delta in enumerate(delta_file.deltas):
         delta_status = DeltaStatus.Applied
         layer_id: str = delta.get("sourceLayerId", "")
-        layer_ids_to_commit.append(layer_id)
         layer: QgsVectorLayer = project.mapLayer(layer_id)
         feature = QgsFeature()
 
@@ -429,6 +428,9 @@ def apply_deltas_without_transaction(
                     f'Cannot start editing layer "{layer_id}"',
                     provider_errors=layer.dataProvider().errors(),
                 )
+
+            if layer_id not in layer_ids_to_commit:
+                layer_ids_to_commit.append(layer_id)
 
             # check if a PostGIS layer's session_role override is requested.
             if layer.providerType() == "postgres" and QFC_PG_EFFECTIVE_USER:

--- a/docker-qgis/qfc_worker/commands/apply_deltas.py
+++ b/docker-qgis/qfc_worker/commands/apply_deltas.py
@@ -407,11 +407,13 @@ def apply_deltas_without_transaction(
     overwrite_conflicts: bool = False,
 ) -> bool:
     has_applied_all_deltas = True
+    layer_ids_to_commit = []
 
     # apply deltas on each individual layer
     for idx, delta in enumerate(delta_file.deltas):
         delta_status = DeltaStatus.Applied
         layer_id: str = delta.get("sourceLayerId", "")
+        layer_ids_to_commit.append(layer_id)
         layer: QgsVectorLayer = project.mapLayer(layer_id)
         feature = QgsFeature()
 
@@ -495,7 +497,7 @@ def apply_deltas_without_transaction(
                 # in QGIS the only way to get the real features that have been added after commit, if edit buffer is present, is to use this signal.
                 layer.committedFeaturesAdded.connect(committed_features_added_cb)
 
-            if not layer.commitChanges():
+            if not layer.commitChanges(False):
                 raise DeltaException(
                     "Failed to commit changes",
                     provider_errors=layer.dataProvider().errors(),
@@ -605,6 +607,10 @@ def apply_deltas_without_transaction(
             )
 
             raise err
+
+    for layer_id in layer_ids_to_commit:
+        layer = project.mapLayer(layer_id)
+        layer.commitChanges()
 
     return has_applied_all_deltas
 

--- a/docker-qgis/qfc_worker/commands/apply_deltas.py
+++ b/docker-qgis/qfc_worker/commands/apply_deltas.py
@@ -610,6 +610,7 @@ def apply_deltas_without_transaction(
 
             raise err
 
+    # Exits editing mode for modified layers, there is nothing to commit at this stage
     for layer_id in layer_ids_to_commit:
         layer = project.mapLayer(layer_id)
         layer.commitChanges()


### PR DESCRIPTION
This PR optimizes the apply_deltas function by avoiding the cost of opening/closing an edit session for every delta being applied within a delta file.

Using a delta file containing 217 create deltas, the time to apply goes from 20 seconds to 10 seconds. A different delta file containing 100 create deltas went from 11 seconds to 5.5 seconds. This _halves_ the time it takes to apply deltas on a single layer.

I'm sure there's more to optimize here, but this was the lowest of all low hanging fruits :)

@suricactus , as discussed over Google Chat.

