### PR TITLE
Simplify captcha by less rotation, down from 6 to 4 chars and less noise

### DIFF
--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -1035,7 +1035,7 @@ CAPTCHA_IMAGE_SIZE = (200, 50)
 
 # A random rotation in this interval is applied to each letter in the challenge text.
 # See https://django-simple-captcha.readthedocs.io/en/latest/advanced.html#captcha-letter-rotation
-CAPTCHA_LETTER_ROTATION = (-45, 45)
+CAPTCHA_LETTER_ROTATION = (-35, 35)
 
 # Background-color of the captcha. Can be expressed as html-style #rrggbb, rgb(red, green, blue), or common html names (e.g. “red”).
 # See https://django-simple-captcha.readthedocs.io/en/latest/advanced.html#captcha-background-color
@@ -1051,12 +1051,17 @@ CAPTCHA_TIMEOUT = 5
 
 # Sets the length, in chars, of the generated captcha. (for the 'captcha.helpers.random_char_challenge' challenge)
 # See https://django-simple-captcha.readthedocs.io/en/latest/advanced.html#captcha-length
-CAPTCHA_LENGTH = 6
+CAPTCHA_LENGTH = 4
 
 # When set to True, the string “PASSED” (any case) will be accepted as a valid response to any CAPTCHA. Use this for testing purposes.
 # See https://django-simple-captcha.readthedocs.io/en/latest/advanced.html#captcha-test-mode
 CAPTCHA_TEST_MODE = DEBUG or ENVIRONMENT == "test"
 
+# List of strings of python callables that take a Pillow DrawImage object and an Image image as input, modify the DrawImage, then return it.
+# See https://django-simple-captcha.readthedocs.io/en/latest/advanced.html#captcha-noise-functions
+CAPTCHA_NOISE_FUNCTIONS = [
+    "captcha.helpers.noise_dots",
+]
 
 # Optional volume name where custom CA files are mounted
 QFIELDCLOUD_CUSTOM_CA_VOLUME_NAME = (


### PR DESCRIPTION
Before it was shared it is too hard to read. Let's try to simplify it.

| before | after |
|-|-|
| <img width="470" height="150" alt="image" src="https://github.com/user-attachments/assets/930d439c-c9ad-434c-8f77-0807aa6e2003" /> | <img width="470" height="150" alt="image" src="https://github.com/user-attachments/assets/398fb871-9d9f-448e-afec-941013ba5421" /> |
