### PR TITLE
Add 'project' to the Django app matrix in CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
           - notifs
           - subscription
           - core
+          - project
           - filestorage
           - __flaky__
     continue-on-error: true

--- a/docker-app/qfieldcloud/filestorage/view_helpers.py
+++ b/docker-app/qfieldcloud/filestorage/view_helpers.py
@@ -417,6 +417,12 @@ def delete_project_file_version(
             detail=f"The requested {version_id=} of {filename=} for {project_id=} does not exist!"
         )
 
+    # Capture the QGIS project filename before deleting, since deleting the
+    # QGIS project file itself nulls `Project.the_qgis_file`,
+    # which would make the restricted-file check below always miss the file
+    # actually being deleted.
+    qgis_file_name_before_delete = Project.objects.get(id=project_id).the_qgis_file_name
+
     object_to_delete.delete()
 
     with transaction.atomic():
@@ -430,7 +436,7 @@ def delete_project_file_version(
         now = timezone.now()
         project.data_last_updated_at = now
 
-        if is_admin_restricted_file(filename, project.the_qgis_file_name):
+        if is_admin_restricted_file(filename, qgis_file_name_before_delete):
             update_fields.append("restricted_data_last_updated_at")
             project.restricted_data_last_updated_at = now
 

--- a/docker-app/qfieldcloud/project/tests/test_project.py
+++ b/docker-app/qfieldcloud/project/tests/test_project.py
@@ -8,6 +8,9 @@ from unittest.mock import patch
 from django.contrib.gis.geos import Polygon
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
+from rest_framework import status
+from rest_framework.test import APITransactionTestCase
+
 from qfieldcloud.authentication.models import AuthToken
 from qfieldcloud.core.models import (
     Job,
@@ -31,8 +34,6 @@ from qfieldcloud.project.models import (
 )
 from qfieldcloud.project.utils import projectseed_utils
 from qfieldcloud.subscription.models import Subscription
-from rest_framework import status
-from rest_framework.test import APITransactionTestCase
 
 logging.disable(logging.CRITICAL)
 


### PR DESCRIPTION
This PR adds `project` app to the Django app matrix in the CI workflow.
Fixes `qfieldcloud.project.tests.test_project.QfcTestCase.test_restricted_data_last_updated_at_on_file_delete`.
Runs pre-commit on `test_project.py`