### PR TITLE
chore: bump `pillow` from `12.2.0` to `12.3.0`

### DIFF
--- a/docker-app/requirements/requirements.txt
+++ b/docker-app/requirements/requirements.txt
@@ -177,7 +177,7 @@ packaging==26.0
     # via django-notifications-hq
 phonenumbers==9.0.27
     # via -r /requirements/requirements.in
-pillow==12.2.0
+pillow==12.3.0
     # via
     #   -r /requirements/requirements.in
     #   django-simple-captcha

--- a/docker-app/requirements/requirements_test.txt
+++ b/docker-app/requirements/requirements_test.txt
@@ -45,7 +45,7 @@ packaging==26.2
     #   pyogrio
 pandas==3.0.3
     # via geopandas
-pillow==12.2.0
+pillow==12.3.0
     # via imageio
 pyogrio==0.12.1
     # via geopandas


### PR DESCRIPTION
Changelog: https://github.com/python-pillow/Pillow/releases
Diff: https://github.com/python-pillow/Pillow/compare/12.2.0...12.3.0
Closes #1718