### PR TITLE
chore: bump `pillow` from `12.2.0` to `12.3.0` in `requirements.in`

### DIFF
--- a/docker-app/requirements/requirements.in
+++ b/docker-app/requirements/requirements.in
@@ -41,7 +41,7 @@ drf-spectacular==0.29.0
 json-log-formatter==1.2.1
 mypy-boto3-s3==1.43.31
 phonenumbers==9.0.27
-Pillow==12.2.0
+Pillow==12.3.0
 psycopg2==2.9.12
 pymemcache==4.0.0
 sentry-sdk==2.62.0


### PR DESCRIPTION
Changelog: https://github.com/python-pillow/Pillow/releases
Diff: https://github.com/python-pillow/Pillow/compare/12.2.0...12.3.0

Follow-up of #1721 which was only bumping the `pillow` version in `requirements.txt`,  
Closes #1724 