### PR TITLE
Fetch a lighter `Project` when we're just checking permissions

### DIFF
--- a/docker-app/qfieldcloud/core/permissions_utils.py
+++ b/docker-app/qfieldcloud/core/permissions_utils.py
@@ -58,7 +58,8 @@ def user_eq(user1: QfcUser, user2: QfcUser) -> bool:
 
 def _project_for_owner(user: QfcUser, project: Project, skip_invalid: bool):
     return (
-        Project.objects.for_user(user, skip_invalid)
+        Project.objects.slim()
+        .for_user(user, skip_invalid)
         .select_related(None)
         .filter(pk=project.pk)
     )

--- a/docker-app/qfieldcloud/core/views/collaborators_views.py
+++ b/docker-app/qfieldcloud/core/views/collaborators_views.py
@@ -1,10 +1,9 @@
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ObjectDoesNotExist
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from qfieldcloud.core import pagination, permissions_utils
 from qfieldcloud.core.models import ProjectCollaborator
 from qfieldcloud.core.serializers import ProjectCollaboratorSerializer
-from qfieldcloud.project.models import Project
+from qfieldcloud.project.models import Project, get_slim_project_or_raise
 from rest_framework import generics, permissions, status
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
@@ -16,10 +15,7 @@ class ListCreateCollaboratorsViewPermissions(permissions.BasePermission):
     def has_permission(self, request, view):
         user = request.user
         projectid = permissions_utils.get_param_from_request(request, "projectid")
-        try:
-            project = Project.objects.get(id=projectid)
-        except ObjectDoesNotExist:
-            return False
+        project = get_slim_project_or_raise(projectid)
 
         if request.method == "GET":
             return permissions_utils.can_read_collaborators(user, project)
@@ -76,10 +72,7 @@ class GetUpdateDestroyCollaboratorViewPermissions(permissions.BasePermission):
         user = request.user
         projectid = permissions_utils.get_param_from_request(request, "projectid")
 
-        try:
-            project = Project.objects.get(id=projectid)
-        except ObjectDoesNotExist:
-            return False
+        project = get_slim_project_or_raise(projectid)
 
         if request.method == "GET":
             return permissions_utils.can_read_collaborators(user, project)

--- a/docker-app/qfieldcloud/core/views/deltas_views.py
+++ b/docker-app/qfieldcloud/core/views/deltas_views.py
@@ -18,7 +18,7 @@ from qfieldcloud.core import exceptions, pagination, permissions_utils, utils
 from qfieldcloud.core.models import Delta, FaultyDeltaFile
 from qfieldcloud.core.serializers import DeltaSerializer
 from qfieldcloud.core.utils2 import jobs
-from qfieldcloud.project.models import Project
+from qfieldcloud.project.models import Project, get_slim_project_or_raise
 from rest_framework import generics, permissions, views
 from rest_framework.response import Response
 
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 class DeltaFilePermissions(permissions.BasePermission):
     def has_permission(self, request, view):
         projectid = permissions_utils.get_param_from_request(request, "projectid")
-        project = Project.objects.get(id=projectid)
+        project = get_slim_project_or_raise(projectid)
         user = request.user
 
         if request.method == "GET":

--- a/docker-app/qfieldcloud/core/views/jobs_views.py
+++ b/docker-app/qfieldcloud/core/views/jobs_views.py
@@ -7,7 +7,7 @@ from drf_spectacular.utils import (
 )
 from qfieldcloud.core import pagination, permissions_utils, serializers
 from qfieldcloud.core.models import Job
-from qfieldcloud.project.models import Project
+from qfieldcloud.project.models import Project, get_slim_project_or_raise
 from rest_framework import generics, permissions, viewsets
 from rest_framework.response import Response
 from rest_framework.status import HTTP_201_CREATED
@@ -28,10 +28,7 @@ class JobPermissions(permissions.BasePermission):
             job_type = request.data.get("type")
 
         if should_expect_project_id:
-            try:
-                project = Project.objects.get(id=project_id)
-            except ObjectDoesNotExist:
-                return False
+            project = get_slim_project_or_raise(project_id)
         else:
             job_id = permissions_utils.get_param_from_request(request, "job_id")
 

--- a/docker-app/qfieldcloud/core/views/package_views.py
+++ b/docker-app/qfieldcloud/core/views/package_views.py
@@ -1,7 +1,6 @@
 import logging
 from uuid import UUID
 
-from django.core.exceptions import ObjectDoesNotExist
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from drf_spectacular.utils import (
@@ -24,7 +23,7 @@ from qfieldcloud.filestorage.view_helpers import (
     download_project_file_version,
     upload_project_file_version,
 )
-from qfieldcloud.project.models import Project
+from qfieldcloud.project.models import Project, get_slim_project_or_raise
 from rest_framework import permissions, status, views
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -34,12 +33,9 @@ logger = logging.getLogger(__name__)
 
 class PackageViewPermissions(permissions.BasePermission):
     def has_permission(self, request, view):
-        try:
-            project_id = request.parser_context["kwargs"].get("project_id")
-            project = Project.objects.get(pk=project_id)
-            return perms.can_access_project(request.user, project)
-        except ObjectDoesNotExist:
-            return False
+        project_id = request.parser_context["kwargs"].get("project_id")
+        project = get_slim_project_or_raise(project_id)
+        return perms.can_access_project(request.user, project)
 
 
 class PackageUploadViewPermissions(permissions.BasePermission):
@@ -50,25 +46,20 @@ class PackageUploadViewPermissions(permissions.BasePermission):
         if request.auth.client_type != AuthToken.ClientType.WORKER:
             return False
 
-        try:
-            project_id = request.parser_context["kwargs"].get("project_id")
-            job_id = request.parser_context["kwargs"].get("job_id")
-            project = Project.objects.get(pk=project_id)
+        project_id = request.parser_context["kwargs"].get("project_id")
+        job_id = request.parser_context["kwargs"].get("job_id")
+        project = get_slim_project_or_raise(project_id)
 
-            if not perms.can_retrieve_project(request.user, project):
-                return False
-
-            # Check if the package job exists and it is already started, but not finished yet.
-            # This is extra check that the request is coming from a currently active job.
-            PackageJob.objects.get(
-                id=job_id,
-                status=PackageJob.Status.STARTED,
-                project=project,
-            )
-
-            return True
-        except ObjectDoesNotExist:
+        if not perms.can_retrieve_project(request.user, project):
             return False
+
+        # Check if the package job exists and it is already started, but not finished yet.
+        # This is extra check that the request is coming from a currently active job.
+        return PackageJob.objects.filter(
+            id=job_id,
+            status=PackageJob.Status.STARTED,
+            project=project,
+        ).exists()
 
 
 @extend_schema_view(

--- a/docker-app/qfieldcloud/filestorage/views.py
+++ b/docker-app/qfieldcloud/filestorage/views.py
@@ -34,7 +34,7 @@ from qfieldcloud.filestorage.view_helpers import (
     download_project_file_version,
     upload_project_file_version,
 )
-from qfieldcloud.project.models import Project
+from qfieldcloud.project.models import Project, get_slim_project_or_raise
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +45,7 @@ class FileListViewPermissions(permissions.BasePermission):
             return False
 
         project_id = request.parser_context["kwargs"]["project_id"]
-        project = get_object_or_404(Project, id=project_id)
+        project = get_slim_project_or_raise(project_id)
 
         return permissions_utils.can_read_files(request.user, project)
 
@@ -56,7 +56,7 @@ class FileCrudViewPermissions(permissions.BasePermission):
             return False
 
         project_id = request.parser_context["kwargs"]["project_id"]
-        project = get_object_or_404(Project, id=project_id)
+        project = get_slim_project_or_raise(project_id)
         user = request.user
 
         if request.method == "GET":

--- a/docker-app/qfieldcloud/project/models.py
+++ b/docker-app/qfieldcloud/project/models.py
@@ -20,6 +20,7 @@ from django.core.validators import (
 from django.db.models import Case, Exists, F, OuterRef, Q, When
 from django.db.models import Value as V
 from django.db.models.aggregates import Count, Sum
+from django.shortcuts import get_object_or_404
 from django.urls import reverse_lazy
 from django.utils.translation import gettext as _
 from django_stubs_ext import StrOrPromise
@@ -117,6 +118,26 @@ class ProjectQueryset(models.QuerySet):
             qs = qs.filter(user_role_is_valid=True)
 
         return qs
+
+    def slim(self) -> "ProjectQueryset":
+        """A light-weight fetch for permission checks, which run on every
+        request and only need a project's id, owner, and public flag.
+        """
+        return self.only("id", "name", "is_public", "owner_id")
+
+
+def get_slim_project_or_raise(project_id: uuid.UUID | str | None) -> "Project":
+    """Fetch a project for a permission check, or raise `Http404` if it doesn't exist.
+
+    Only use this where the caller needs `pk`/`owner`/`is_public` and nothing
+    else — the returned project has every other field deferred (see `slim()`
+    in `ProjectQueryset`). Fetching more fields off the result triggers extra queries,
+    so for anything that needs the full project, use `get_object_or_404(Project, ...)`.
+    """
+
+    # NOTE raises `Http404`, not `Project.DoesNotExist`: DRF treats both the same, see `core.rest_utils.exception_handler`.
+    # TODO @suricactus: add `qs.fetch_mode(models.RAISE)` once on Django 6.1, see https://app.clickup.com/t/2192114/QF-8624
+    return get_object_or_404(Project.objects.slim(), pk=project_id)  # type: ignore[attr-defined]
 
 
 def get_project_file_storage_default() -> str:

--- a/docker-app/qfieldcloud/project/tests/test_project.py
+++ b/docker-app/qfieldcloud/project/tests/test_project.py
@@ -1463,7 +1463,7 @@ class QfcTestCase(APITransactionTestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-        # Cloning a non-existent project returns 403
+        # Cloning a non-existent project returns 404
         response = self.client.post(
             "/api/v1/projects/",
             {
@@ -1473,7 +1473,7 @@ class QfcTestCase(APITransactionTestCase):
             },
             format="json",
         )
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_project_type_defaults_to_regular(self):
         """Test that a normally named project gets a project type of REGULAR"""

--- a/docker-app/qfieldcloud/project/views.py
+++ b/docker-app/qfieldcloud/project/views.py
@@ -21,11 +21,10 @@ from rest_framework.response import Response
 
 from qfieldcloud.core import pagination, permissions_utils
 from qfieldcloud.core.drf_utils import QfcOrderingFilter
-from qfieldcloud.core.exceptions import ObjectNotFoundError
 from qfieldcloud.core.models import Job
 from qfieldcloud.project.enums import ProjectRoleOrigins
 from qfieldcloud.project.filters import ProjectFilterSet
-from qfieldcloud.project.models import Project, ProjectSeed
+from qfieldcloud.project.models import Project, ProjectSeed, get_slim_project_or_raise
 from qfieldcloud.project.serializers import (
     ProjectSeedSerializer,
     ProjectSerializer,
@@ -64,10 +63,7 @@ class ProjectViewSetPermissions(permissions.BasePermission):
 
             clone_from_project_id = request.data.get("clone_from_project")
             if clone_from_project_id:
-                try:
-                    clone_from_project = Project.objects.get(id=clone_from_project_id)
-                except Project.DoesNotExist:
-                    return False
+                clone_from_project = get_slim_project_or_raise(clone_from_project_id)
 
                 if not permissions_utils.can_access_project(user, clone_from_project):
                     return False
@@ -75,11 +71,7 @@ class ProjectViewSetPermissions(permissions.BasePermission):
             return True
 
         projectid = permissions_utils.get_param_from_request(request, "projectid")
-
-        try:
-            project = Project.objects.get(id=projectid)
-        except Project.DoesNotExist:
-            raise ObjectNotFoundError(detail="Project not found.")
+        project = get_slim_project_or_raise(projectid)
 
         if view.action == "retrieve":
             return permissions_utils.can_retrieve_project(user, project)


### PR DESCRIPTION
> Variant 1 for solving the problem is https://github.com/opengisch/QFieldCloud/pull/1730
> Edit: After discussions, this PR's solution was picked for implementing.

This PR is a proof of concept for reducing memory and processing overhead when doing permissions check for `Project` model.

Permission checks run on every request, but they only ever look at a project's `id`, `owner`, and `is_public`, never the heavier stuff like JSON blobs or file references. So instead of loading the full project every time, add `ProjectQueryset.slim()` to skip those fields, and `get_slim_project_or_404()` as a shared helper for the common "fetch this project for a permission check, or 404" pattern.

Switched the permission classes in `collaborators`, `deltas`, `jobs`, `packages`, and `filestorage` views.

**TL;DR**: `.slim()` (plain `.only()` queryset method) uses ~3% less memory with no CPU cost. The separate slim-model approach uses more memory *and* CPU than doing nothing.

<details>
<summary>Benchmark raw output (memray + cProfile/timeit)</summary>

```
# Current (Master)
============================================================
MEMORY (memray, 100 calls) -> /tmp/bench_endpoint_mem.bin
============================================================
📏 Total allocations:
	55224

📦 Total memory allocated:
	43.767MB

📈 Peak memory usage:
	1.238MB

📊 Histogram of allocation size:
	min: 1.000B
	--------------------------------------------
	< 4.000B   :  8760 ▇▇▇▇▇▇▇▇▇▇
	< 15.000B  :    10 ▇
	< 63.000B  :  2709 ▇▇▇▇
	< 255.000B :  5622 ▇▇▇▇▇▇▇
	< 1.024kB  : 22502 ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇
	< 4.095kB  : 15243 ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇
	< 16.383kB :   263 ▇
	< 65.535kB :   107 ▇
	< 262.143kB:     7 ▇
	<=1.049MB  :     1 ▇
	--------------------------------------------
	max: 1.049MB

📂 Allocator type distribution:
	 MALLOC: 48004
	 REALLOC: 6919
	 CALLOC: 300
	 MMAP: 1

🥇 Top 5 largest allocating locations (by size):
	- _execute:/usr/local/lib/python3.14/site-packages/django/db/backends/utils.py:105 -> 9.947MB
	- _add_q:/usr/local/lib/python3.14/site-packages/django/db/models/sql/query.py:1680 -> 3.329MB
	- __init__:/usr/local/lib/python3.14/site-packages/django/utils/datastructures.py:268 -> 3.226MB
	- unsign_object:/usr/local/lib/python3.14/site-packages/django/core/signing.py:274 -> 2.358MB
	- check_alias:/usr/local/lib/python3.14/site-packages/django/db/models/sql/query.py:1211 -> 2.300MB

🥇 Top 5 largest allocating locations (by number of allocations):
	- _execute:/usr/local/lib/python3.14/site-packages/django/db/backends/utils.py:105 -> 7006
	- _add_q:/usr/local/lib/python3.14/site-packages/django/db/models/sql/query.py:1680 -> 6401
	- get_select:/usr/local/lib/python3.14/site-packages/django/db/models/sql/compiler.py:262 -> 6100
	- check_alias:/usr/local/lib/python3.14/site-packages/django/db/models/sql/query.py:1211 -> 4200
	- __init__:/usr/local/lib/python3.14/site-packages/django/utils/datastructures.py:268 -> 4200

============================================================
CPU — timeit (200 calls)
============================================================
total: 7645.5 ms
avg per call: 38227.4 µs

============================================================
CPU — cProfile (50 calls, top 10 by cumulative time)
============================================================
         2539401 function calls (2401901 primitive calls) in 4.146 seconds

   Ordered by: cumulative time
   List reduced from 1284 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       50    0.000    0.000    4.146    0.083 <ipython-input-1-a90542ff87c7>:50(hit_endpoint)
       50    0.000    0.000    4.146    0.083 /usr/local/lib/python3.14/site-packages/django/test/client.py:1113(get)
       50    0.000    0.000    4.146    0.083 /usr/local/lib/python3.14/site-packages/django/test/client.py:467(get)
       50    0.001    0.000    4.145    0.083 /usr/local/lib/python3.14/site-packages/django/test/client.py:633(generic)
       50    0.002    0.000    4.143    0.083 /usr/local/lib/python3.14/site-packages/django/test/client.py:1066(request)
       50    0.001    0.000    4.122    0.082 /usr/local/lib/python3.14/site-packages/django/test/client.py:169(__call__)
       50    0.000    0.000    4.100    0.082 /usr/local/lib/python3.14/site-packages/django/core/handlers/base.py:136(get_response)
   950/50    0.002    0.000    4.098    0.082 /usr/local/lib/python3.14/site-packages/django/core/handlers/exception.py:52(inner)
       50    0.000    0.000    4.098    0.082 /usr/local/lib/python3.14/site-packages/corsheaders/middleware.py:46(__call__)
   400/50    0.002    0.000    4.095    0.082 /usr/local/lib/python3.14/site-packages/django/utils/deprecation.py:113(__call__)

============================================================
Summary
============================================================
endpoint: /api/v1/projects/61b64551-eb7e-4412-9a8e-695b11a709de/
CPU:      38227.4 µs/call
memory: 43.767MB


# Slim method approach (https://github.com/opengisch/QFieldCloud/pull/1731)
============================================================
MEMORY (memray, 100 calls) -> /tmp/bench_endpoint_mem.bin
============================================================
📏 Total allocations:
	54124

📦 Total memory allocated:
	42.471MB

📈 Peak memory usage:
	1.223MB

📊 Histogram of allocation size:
	min: 1.000B
	--------------------------------------------
	< 4.000B   :  8960 ▇▇▇▇▇▇▇▇▇▇▇
	< 15.000B  :    10 ▇
	< 63.000B  :  2709 ▇▇▇▇
	< 255.000B :  5522 ▇▇▇▇▇▇▇
	< 1.024kB  : 22202 ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇
	< 4.095kB  : 14343 ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇
	< 16.383kB :   263 ▇
	< 65.535kB :   107 ▇
	< 262.143kB:     7 ▇
	<=1.049MB  :     1 ▇
	--------------------------------------------
	max: 1.049MB

📂 Allocator type distribution:
	 MALLOC: 47304
	 REALLOC: 6519
	 CALLOC: 300
	 MMAP: 1

🥇 Top 5 largest allocating locations (by size):
	- _execute:/usr/local/lib/python3.14/site-packages/django/db/backends/utils.py:105 -> 9.263MB
	- _add_q:/usr/local/lib/python3.14/site-packages/django/db/models/sql/query.py:1680 -> 3.329MB
	- __init__:/usr/local/lib/python3.14/site-packages/django/utils/datastructures.py:268 -> 3.226MB
	- unsign_object:/usr/local/lib/python3.14/site-packages/django/core/signing.py:274 -> 2.358MB
	- check_alias:/usr/local/lib/python3.14/site-packages/django/db/models/sql/query.py:1211 -> 2.300MB

🥇 Top 5 largest allocating locations (by number of allocations):
	- _execute:/usr/local/lib/python3.14/site-packages/django/db/backends/utils.py:105 -> 6606
	- _add_q:/usr/local/lib/python3.14/site-packages/django/db/models/sql/query.py:1680 -> 6401
	- get_select:/usr/local/lib/python3.14/site-packages/django/db/models/sql/compiler.py:262 -> 5800
	- check_alias:/usr/local/lib/python3.14/site-packages/django/db/models/sql/query.py:1211 -> 4200
	- __init__:/usr/local/lib/python3.14/site-packages/django/utils/datastructures.py:268 -> 4200

============================================================
CPU — timeit (200 calls)
============================================================
total: 7736.1 ms
avg per call: 38680.7 µs

============================================================
CPU — cProfile (50 calls, top 10 by cumulative time)
============================================================
         2481551 function calls (2344551 primitive calls) in 3.935 seconds

   Ordered by: cumulative time
   List reduced from 1289 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       50    0.000    0.000    3.935    0.079 <ipython-input-1-a90542ff87c7>:50(hit_endpoint)
       50    0.000    0.000    3.935    0.079 /usr/local/lib/python3.14/site-packages/django/test/client.py:1113(get)
       50    0.000    0.000    3.935    0.079 /usr/local/lib/python3.14/site-packages/django/test/client.py:467(get)
       50    0.001    0.000    3.934    0.079 /usr/local/lib/python3.14/site-packages/django/test/client.py:633(generic)
       50    0.001    0.000    3.932    0.079 /usr/local/lib/python3.14/site-packages/django/test/client.py:1066(request)
       50    0.001    0.000    3.912    0.078 /usr/local/lib/python3.14/site-packages/django/test/client.py:169(__call__)
       50    0.000    0.000    3.891    0.078 /usr/local/lib/python3.14/site-packages/django/core/handlers/base.py:136(get_response)
   950/50    0.002    0.000    3.890    0.078 /usr/local/lib/python3.14/site-packages/django/core/handlers/exception.py:52(inner)
       50    0.000    0.000    3.890    0.078 /usr/local/lib/python3.14/site-packages/corsheaders/middleware.py:46(__call__)
   400/50    0.002    0.000    3.887    0.078 /usr/local/lib/python3.14/site-packages/django/utils/deprecation.py:113(__call__)

============================================================
Summary
============================================================
endpoint: /api/v1/projects/61b64551-eb7e-4412-9a8e-695b11a709de/
CPU:      38680.7 µs/call
memory: 42.471MB


# Slim model approach (https://github.com/opengisch/QFieldCloud/pull/1730)

============================================================
MEMORY (memray, 100 calls) -> /tmp/bench_endpoint_mem.bin
============================================================
📏 Total allocations:
	64922

📦 Total memory allocated:
	50.120MB

📈 Peak memory usage:
	1.232MB

📊 Histogram of allocation size:
	min: 1.000B
	--------------------------------------------
	< 4.000B   : 10560 ▇▇▇▇▇▇▇▇▇▇
	< 15.000B  :    10 ▇
	< 63.000B  :  3109 ▇▇▇
	< 255.000B :  5622 ▇▇▇▇▇
	< 1.024kB  : 28600 ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇
	< 4.095kB  : 16643 ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇
	< 16.383kB :   263 ▇
	< 65.535kB :   107 ▇
	< 262.143kB:     7 ▇
	<=1.049MB  :     1 ▇
	--------------------------------------------
	max: 1.049MB

📂 Allocator type distribution:
	 MALLOC: 56802
	 REALLOC: 7819
	 CALLOC: 300
	 MMAP: 1

🥇 Top 5 largest allocating locations (by size):
	- _execute:/usr/local/lib/python3.14/site-packages/django/db/backends/utils.py:105 -> 10.011MB
	- clone:/usr/local/lib/python3.14/site-packages/django/db/models/sql/query.py:386 -> 4.608MB
	- check_alias:/usr/local/lib/python3.14/site-packages/django/db/models/sql/query.py:1211 -> 3.833MB
	- _add_q:/usr/local/lib/python3.14/site-packages/django/db/models/sql/query.py:1680 -> 3.641MB
	- __init__:/usr/local/lib/python3.14/site-packages/django/utils/datastructures.py:268 -> 2.611MB

🥇 Top 5 largest allocating locations (by number of allocations):
	- _execute:/usr/local/lib/python3.14/site-packages/django/db/backends/utils.py:105 -> 7006
	- _add_q:/usr/local/lib/python3.14/site-packages/django/db/models/sql/query.py:1680 -> 7001
	- check_alias:/usr/local/lib/python3.14/site-packages/django/db/models/sql/query.py:1211 -> 7000
	- get_select:/usr/local/lib/python3.14/site-packages/django/db/models/sql/compiler.py:262 -> 6900
	- clone:/usr/local/lib/python3.14/site-packages/django/db/models/sql/query.py:386 -> 6000

============================================================
CPU — timeit (200 calls)
============================================================
total: 9489.6 ms
avg per call: 47448.2 µs

============================================================
CPU — cProfile (50 calls, top 10 by cumulative time)
============================================================
         2608601 function calls (2452651 primitive calls) in 4.247 seconds

   Ordered by: cumulative time
   List reduced from 1276 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       50    0.000    0.000    4.247    0.085 <ipython-input-1-a90542ff87c7>:50(hit_endpoint)
       50    0.000    0.000    4.247    0.085 /usr/local/lib/python3.14/site-packages/django/test/client.py:1113(get)
       50    0.000    0.000    4.247    0.085 /usr/local/lib/python3.14/site-packages/django/test/client.py:467(get)
       50    0.001    0.000    4.246    0.085 /usr/local/lib/python3.14/site-packages/django/test/client.py:633(generic)
       50    0.002    0.000    4.244    0.085 /usr/local/lib/python3.14/site-packages/django/test/client.py:1066(request)
       50    0.001    0.000    4.224    0.084 /usr/local/lib/python3.14/site-packages/django/test/client.py:169(__call__)
       50    0.000    0.000    4.202    0.084 /usr/local/lib/python3.14/site-packages/django/core/handlers/base.py:136(get_response)
   950/50    0.002    0.000    4.201    0.084 /usr/local/lib/python3.14/site-packages/django/core/handlers/exception.py:52(inner)
       50    0.000    0.000    4.201    0.084 /usr/local/lib/python3.14/site-packages/corsheaders/middleware.py:46(__call__)
   400/50    0.002    0.000    4.198    0.084 /usr/local/lib/python3.14/site-packages/django/utils/deprecation.py:113(__call__)

============================================================
Summary
============================================================
endpoint: /api/v1/projects/61b64551-eb7e-4412-9a8e-695b11a709de/
CPU:      47448.2 µs/call
memory: 50.120MB
```

</details>

**TL;DR Second testing with heavier project**: Same two endpoints (`GET /api/v1/projects/<id>/` and `GET /api/v1/jobs/<id>/`), benchmarked once on master and once on the slim method, with layer fields turned on in both runs. Slim is faster and lighter on the project endpoint (~29% less memory, ~21% less CPU). On the job endpoint it's basically the same memory, just a bit faster.

<details>
<summary>Benchmark output of second test</summary>

```
# Current master
############################################################
Benchmarking project: GET /api/v1/projects/d3c594b6-97cf-467b-a736-b6d150122562/
############################################################

============================================================
MEMORY (memray, 100 calls) -> /tmp/bench_endpoint_mem_project.bin
============================================================
📏 Total allocations:
	65766

📦 Total memory allocated:
	104.697MB

📈 Peak memory usage:
	11.464MB

📊 Histogram of allocation size:
	min: 1.000B
	--------------------------------------------
	< 4.000B   :  9569 ▇▇▇▇▇▇▇▇▇
	< 15.000B  :    10 ▇
	< 63.000B  :  3011 ▇▇▇
	< 255.000B :  5923 ▇▇▇▇▇
	< 1.024kB  : 29862 ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇
	< 4.095kB  : 16576 ▇▇▇▇▇▇▇▇▇▇▇▇▇▇
	< 16.383kB :   289 ▇
	< 65.535kB :   108 ▇
	< 262.143kB:   408 ▇
	<=1.049MB  :    10 ▇
	--------------------------------------------
	max: 1.049MB

📂 Allocator type distribution:
	 MALLOC: 57746
	 REALLOC: 7643
	 CALLOC: 367
	 MMAP: 10

🥇 Top 5 largest allocating locations (by size):
	- _execute:/usr/local/lib/python3.14/site-packages/django/db/backends/utils.py:105 -> 32.576MB
	- inner:/usr/local/lib/python3.14/site-packages/django/db/utils.py:98 -> 21.851MB
	- raw_decode:/usr/local/lib/python3.14/json/decoder.py:361 -> 12.598MB
	- _add_q:/usr/local/lib/python3.14/site-packages/django/db/models/sql/query.py:1680 -> 3.641MB
	- __init__:/usr/local/lib/python3.14/site-packages/django/utils/datastructures.py:268 -> 3.379MB

🥇 Top 5 largest allocating locations (by number of allocations):
	- _execute:/usr/local/lib/python3.14/site-packages/django/db/backends/utils.py:105 -> 8206
	- _add_q:/usr/local/lib/python3.14/site-packages/django/db/models/sql/query.py:1680 -> 7001
	- get_select:/usr/local/lib/python3.14/site-packages/django/db/models/sql/compiler.py:262 -> 6800
	- raw_decode:/usr/local/lib/python3.14/json/decoder.py:361 -> 6007
	- check_alias:/usr/local/lib/python3.14/site-packages/django/db/models/sql/query.py:1211 -> 4400

============================================================
CPU — timeit (200 calls)
============================================================
total: 12062.8 ms
avg per call: 60313.9 µs

============================================================
CPU — cProfile (50 calls, top 10 by cumulative time)
============================================================
         2683101 function calls (2535601 primitive calls) in 6.787 seconds

   Ordered by: cumulative time
   List reduced from 1312 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       50    0.000    0.000    6.787    0.136 <ipython-input-1-05431b862058>:128(<lambda>)
       50    0.000    0.000    6.787    0.136 <ipython-input-1-05431b862058>:67(hit_endpoint)
       50    0.001    0.000    6.786    0.136 /usr/local/lib/python3.14/site-packages/django/test/client.py:1113(get)
       50    0.001    0.000    6.785    0.136 /usr/local/lib/python3.14/site-packages/django/test/client.py:467(get)
       50    0.001    0.000    6.784    0.136 /usr/local/lib/python3.14/site-packages/django/test/client.py:633(generic)
       50    0.005    0.000    6.779    0.136 /usr/local/lib/python3.14/site-packages/django/test/client.py:1066(request)
       50    0.001    0.000    6.739    0.135 /usr/local/lib/python3.14/site-packages/django/test/client.py:169(__call__)
       50    0.000    0.000    6.705    0.134 /usr/local/lib/python3.14/site-packages/django/core/handlers/base.py:136(get_response)
   950/50    0.004    0.000    6.703    0.134 /usr/local/lib/python3.14/site-packages/django/core/handlers/exception.py:52(inner)
       50    0.000    0.000    6.703    0.134 /usr/local/lib/python3.14/site-packages/corsheaders/middleware.py:46(__call__)




############################################################
Benchmarking job: GET /api/v1/jobs/fa0cdd31-7bef-40b2-954c-fe5749e2897f/
############################################################

============================================================
MEMORY (memray, 100 calls) -> /tmp/bench_endpoint_mem_job.bin
============================================================
📏 Total allocations:
	55105

📦 Total memory allocated:
	474.025MB

📈 Peak memory usage:
	7.304MB

📊 Histogram of allocation size:
	min: 1.000B
	--------------------------------------------
	< 3.000B   :  5400 ▇▇▇▇▇▇
	< 14.000B  :     0 
	< 56.000B  :   500 ▇
	< 216.000B :  5000 ▇▇▇▇▇
	< 830.000B : 25804 ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇
	< 3.185kB  : 14500 ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇
	< 12.221kB :  1000 ▇
	< 46.879kB :   900 ▇
	< 179.827kB:  1100 ▇▇
	<=689.808kB:   901 ▇
	--------------------------------------------
	max: 689.808kB

📂 Allocator type distribution:
	 MALLOC: 50204
	 REALLOC: 4901

🥇 Top 5 largest allocating locations (by size):
	- iterencode:/usr/local/lib/python3.14/json/encoder.py:263 -> 222.744MB
	- render:/usr/local/lib/python3.14/site-packages/rest_framework/renderers.py:107 -> 91.980MB
	- inner:/usr/local/lib/python3.14/site-packages/django/db/utils.py:98 -> 65.109MB
	- _execute:/usr/local/lib/python3.14/site-packages/django/db/backends/utils.py:105 -> 64.817MB
	- raw_decode:/usr/local/lib/python3.14/json/decoder.py:361 -> 12.034MB

🥇 Top 5 largest allocating locations (by number of allocations):
	- raw_decode:/usr/local/lib/python3.14/json/decoder.py:361 -> 14400
	- iterencode:/usr/local/lib/python3.14/json/encoder.py:263 -> 9000
	- _execute:/usr/local/lib/python3.14/site-packages/django/db/backends/utils.py:105 -> 4301
	- match:/usr/local/lib/python3.14/site-packages/django/urls/resolvers.py:325 -> 3200
	- __init__:/usr/local/lib/python3.14/site-packages/django/utils/datastructures.py:268 -> 2800

============================================================
CPU — timeit (200 calls)
============================================================
total: 8981.1 ms
avg per call: 44905.4 µs

============================================================
CPU — cProfile (50 calls, top 10 by cumulative time)
============================================================
         1075201 function calls (1024251 primitive calls) in 3.315 seconds

   Ordered by: cumulative time
   List reduced from 1104 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       50    0.000    0.000    3.315    0.066 <ipython-input-1-05431b862058>:128(<lambda>)
       50    0.000    0.000    3.315    0.066 <ipython-input-1-05431b862058>:67(hit_endpoint)
       50    0.000    0.000    3.314    0.066 /usr/local/lib/python3.14/site-packages/django/test/client.py:1113(get)
       50    0.000    0.000    3.314    0.066 /usr/local/lib/python3.14/site-packages/django/test/client.py:467(get)
       50    0.001    0.000    3.314    0.066 /usr/local/lib/python3.14/site-packages/django/test/client.py:633(generic)
       50    0.002    0.000    3.311    0.066 /usr/local/lib/python3.14/site-packages/django/test/client.py:1066(request)
       50    0.001    0.000    3.287    0.066 /usr/local/lib/python3.14/site-packages/django/test/client.py:169(__call__)
       50    0.000    0.000    3.262    0.065 /usr/local/lib/python3.14/site-packages/django/core/handlers/base.py:136(get_response)
   950/50    0.003    0.000    3.261    0.065 /usr/local/lib/python3.14/site-packages/django/core/handlers/exception.py:52(inner)
       50    0.000    0.000    3.260    0.065 /usr/local/lib/python3.14/site-packages/corsheaders/middleware.py:46(__call__)



=== Summary ===
[project] endpoint: /api/v1/projects/d3c594b6-97cf-467b-a736-b6d150122562/
  CPU:    60313.9 µs/call
  memory: 104.697MB
[job] endpoint: /api/v1/jobs/fa0cdd31-7bef-40b2-954c-fe5749e2897f/
  CPU:    44905.4 µs/call
  memory: 474.025MB

# With Slim method
############################################################
Benchmarking project: GET /api/v1/projects/d3c594b6-97cf-467b-a736-b6d150122562/
############################################################

============================================================
MEMORY (memray, 100 calls) -> /tmp/bench_endpoint_mem_project.bin
============================================================
📏 Total allocations:
	60862

📦 Total memory allocated:
	74.565MB

📈 Peak memory usage:
	6.993MB

📊 Histogram of allocation size:
	min: 1.000B
	--------------------------------------------
	< 4.000B   :  9369 ▇▇▇▇▇▇▇▇▇
	< 15.000B  :    10 ▇
	< 63.000B  :  3011 ▇▇▇
	< 255.000B :  5823 ▇▇▇▇▇▇
	< 1.024kB  : 26762 ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇
	< 4.095kB  : 15276 ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇
	< 16.383kB :   289 ▇
	< 65.535kB :   108 ▇
	< 262.143kB:   208 ▇
	<=1.049MB  :     6 ▇
	--------------------------------------------
	max: 1.049MB

📂 Allocator type distribution:
	 MALLOC: 53246
	 REALLOC: 7243
	 CALLOC: 367
	 MMAP: 6

🥇 Top 5 largest allocating locations (by size):
	- _execute:/usr/local/lib/python3.14/site-packages/django/db/backends/utils.py:105 -> 20.997MB
	- inner:/usr/local/lib/python3.14/site-packages/django/db/utils.py:98 -> 10.953MB
	- raw_decode:/usr/local/lib/python3.14/json/decoder.py:361 -> 5.775MB
	- _add_q:/usr/local/lib/python3.14/site-packages/django/db/models/sql/query.py:1680 -> 3.641MB
	- __init__:/usr/local/lib/python3.14/site-packages/django/utils/datastructures.py:268 -> 3.379MB

🥇 Top 5 largest allocating locations (by number of allocations):
	- _execute:/usr/local/lib/python3.14/site-packages/django/db/backends/utils.py:105 -> 7706
	- _add_q:/usr/local/lib/python3.14/site-packages/django/db/models/sql/query.py:1680 -> 7001
	- get_select:/usr/local/lib/python3.14/site-packages/django/db/models/sql/compiler.py:262 -> 6500
	- check_alias:/usr/local/lib/python3.14/site-packages/django/db/models/sql/query.py:1211 -> 4400
	- __init__:/usr/local/lib/python3.14/site-packages/django/utils/datastructures.py:268 -> 4400


============================================================
CPU — timeit (200 calls)
============================================================
total: 9482.1 ms
avg per call: 47410.5 µs

============================================================
CPU — cProfile (50 calls, top 10 by cumulative time)
============================================================
         2624701 function calls (2477751 primitive calls) in 4.103 seconds

   Ordered by: cumulative time
   List reduced from 1317 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       50    0.000    0.000    4.103    0.082 <ipython-input-1-05431b862058>:128(<lambda>)
       50    0.000    0.000    4.103    0.082 <ipython-input-1-05431b862058>:67(hit_endpoint)
       50    0.000    0.000    4.103    0.082 /usr/local/lib/python3.14/site-packages/django/test/client.py:1113(get)
       50    0.000    0.000    4.103    0.082 /usr/local/lib/python3.14/site-packages/django/test/client.py:467(get)
       50    0.001    0.000    4.103    0.082 /usr/local/lib/python3.14/site-packages/django/test/client.py:633(generic)
       50    0.002    0.000    4.100    0.082 /usr/local/lib/python3.14/site-packages/django/test/client.py:1066(request)
       50    0.001    0.000    4.079    0.082 /usr/local/lib/python3.14/site-packages/django/test/client.py:169(__call__)
       50    0.000    0.000    4.057    0.081 /usr/local/lib/python3.14/site-packages/django/core/handlers/base.py:136(get_response)
   950/50    0.002    0.000    4.055    0.081 /usr/local/lib/python3.14/site-packages/django/core/handlers/exception.py:52(inner)
       50    0.000    0.000    4.055    0.081 /usr/local/lib/python3.14/site-packages/corsheaders/middleware.py:46(__call__)




############################################################
Benchmarking job: GET /api/v1/jobs/fa0cdd31-7bef-40b2-954c-fe5749e2897f/
############################################################

============================================================
MEMORY (memray, 100 calls) -> /tmp/bench_endpoint_mem_job.bin
============================================================
📏 Total allocations:
	54905

📦 Total memory allocated:
	473.858MB

📈 Peak memory usage:
	7.304MB

📊 Histogram of allocation size:
	min: 1.000B
	--------------------------------------------
	< 3.000B   :  5400 ▇▇▇▇▇▇
	< 14.000B  :     0 
	< 56.000B  :   500 ▇
	< 216.000B :  5000 ▇▇▇▇▇
	< 830.000B : 25704 ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇
	< 3.185kB  : 14400 ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇
	< 12.221kB :  1000 ▇
	< 46.879kB :   900 ▇
	< 179.827kB:  1100 ▇▇
	<=689.808kB:   901 ▇
	--------------------------------------------
	max: 689.808kB

📂 Allocator type distribution:
	 MALLOC: 50004
	 REALLOC: 4901

🥇 Top 5 largest allocating locations (by size):
	- iterencode:/usr/local/lib/python3.14/json/encoder.py:263 -> 222.744MB
	- render:/usr/local/lib/python3.14/site-packages/rest_framework/renderers.py:107 -> 91.980MB
	- inner:/usr/local/lib/python3.14/site-packages/django/db/utils.py:98 -> 65.109MB
	- _execute:/usr/local/lib/python3.14/site-packages/django/db/backends/utils.py:105 -> 64.817MB
	- raw_decode:/usr/local/lib/python3.14/json/decoder.py:361 -> 12.034MB

🥇 Top 5 largest allocating locations (by number of allocations):
	- raw_decode:/usr/local/lib/python3.14/json/decoder.py:361 -> 14400
	- iterencode:/usr/local/lib/python3.14/json/encoder.py:263 -> 9000
	- _execute:/usr/local/lib/python3.14/site-packages/django/db/backends/utils.py:105 -> 4301
	- match:/usr/local/lib/python3.14/site-packages/django/urls/resolvers.py:325 -> 3200
	- __init__:/usr/local/lib/python3.14/site-packages/django/utils/datastructures.py:268 -> 2800


============================================================
CPU — timeit (200 calls)
============================================================
total: 8030.1 ms
avg per call: 40150.6 µs

============================================================
CPU — cProfile (50 calls, top 10 by cumulative time)
============================================================
         1061701 function calls (1011251 primitive calls) in 2.345 seconds

   Ordered by: cumulative time
   List reduced from 1107 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       50    0.000    0.000    2.345    0.047 <ipython-input-1-05431b862058>:128(<lambda>)
       50    0.000    0.000    2.345    0.047 <ipython-input-1-05431b862058>:67(hit_endpoint)
       50    0.000    0.000    2.344    0.047 /usr/local/lib/python3.14/site-packages/django/test/client.py:1113(get)
       50    0.000    0.000    2.344    0.047 /usr/local/lib/python3.14/site-packages/django/test/client.py:467(get)
       50    0.001    0.000    2.344    0.047 /usr/local/lib/python3.14/site-packages/django/test/client.py:633(generic)
       50    0.001    0.000    2.342    0.047 /usr/local/lib/python3.14/site-packages/django/test/client.py:1066(request)
       50    0.001    0.000    2.322    0.046 /usr/local/lib/python3.14/site-packages/django/test/client.py:169(__call__)
       50    0.000    0.000    2.302    0.046 /usr/local/lib/python3.14/site-packages/django/core/handlers/base.py:136(get_response)
   950/50    0.002    0.000    2.301    0.046 /usr/local/lib/python3.14/site-packages/django/core/handlers/exception.py:52(inner)
       50    0.000    0.000    2.301    0.046 /usr/local/lib/python3.14/site-packages/corsheaders/middleware.py:46(__call__)



=== Summary ===
[project] endpoint: /api/v1/projects/d3c594b6-97cf-467b-a736-b6d150122562/
  CPU:    47410.5 µs/call
  memory: 74.565MB
[job] endpoint: /api/v1/jobs/fa0cdd31-7bef-40b2-954c-fe5749e2897f/
  CPU:    40150.6 µs/call
  memory: 473.858MB
```

</details>
