### PR TITLE
Fix `'NoneType' object has no attribute 'name'` in `the_qgis_file_name`

### DIFF
--- a/docker-app/qfieldcloud/project/models.py
+++ b/docker-app/qfieldcloud/project/models.py
@@ -603,11 +603,11 @@ class Project(models.Model):
 
     @property
     def has_the_qgis_file(self) -> bool:
-        return self.the_qgis_file_id is not None
+        return self.the_qgis_file is not None
 
     @property
     def the_qgis_file_name(self) -> str | None:
-        if not self.the_qgis_file_id:
+        if self.the_qgis_file is None:
             return None
 
         return self.the_qgis_file.name


### PR DESCRIPTION
`the_qgis_file_id` could reference a file that no longer resolves via`the_qgis_file`, causing `has_the_qgis_file` to report `True` while `the_qgis_file` was None, so accessing `.name` raised `'NoneType' object has no attribute 'name'`. 

This PR makes the check to `the_qgis_file` itself instead of the FK `id`.