### PR TITLE
refactor: implement single record trial subscriptions

### DIFF
--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -537,10 +537,15 @@ class SubscriptionQuerySet(models.QuerySet):
                 Subscription.Status.ACTIVE_PAST_DUE,
             )
         )
+        is_trial_condition = Q(status=Subscription.Status.ACTIVE_TRIAL) & Q(
+            trial_expires_at__gt=V("now")
+        )
         return self.annotate(
             is_active=Case(
                 When(
-                    is_period_active_condition & is_status_active_condition, then=True
+                    is_period_active_condition
+                    & (is_status_active_condition | is_trial_condition),
+                    then=True,
                 ),
                 default=False,
             ),
@@ -681,6 +686,9 @@ class AbstractSubscription(models.Model):
 
     @property
     def active_storage_total_bytes(self) -> int:
+        if self.is_trialing:
+            return self.included_storage_bytes
+
         return self.included_storage_bytes + self.active_storage_package_bytes
 
     @property
@@ -928,6 +936,40 @@ class AbstractSubscription(models.Model):
         return result
 
     @classmethod
+    def cancel_current_subscriptions(
+        cls,
+        account: UserAccount,
+        active_until: datetime,
+        exclude_pk: int | None = None,
+    ) -> int:
+        """Cancels all the current subscriptions of a given account at a given moment.
+
+        An account can have at most one subscription active at a time, so whenever a
+        subscription starts being active, the one it replaces must be closed at that
+        exact boundary. Call this before a subscription starts being active, either
+        because it is born with `active_since` set, or because `active_since` is set
+        on it later on (e.g. when the remote system confirms the payment).
+
+        Args:
+            account: the account whose current subscriptions are cancelled.
+            active_until: the moment the cancelled subscriptions stop being active.
+                Usually the `active_since` of the subscription that takes over.
+            exclude_pk: primary key of a subscription that should not be cancelled.
+
+        Returns:
+            the number of cancelled subscriptions.
+        """
+        subscriptions_qs = cls.objects.current().filter(account=account)  # type: ignore
+
+        if exclude_pk is not None:
+            subscriptions_qs = subscriptions_qs.exclude(pk=exclude_pk)
+
+        return subscriptions_qs.update(
+            status=cls.Status.INACTIVE_CANCELLED,
+            active_until=active_until,
+        )
+
+    @classmethod
     def update_subscription(
         cls,
         subscription: Self,
@@ -949,18 +991,13 @@ class AbstractSubscription(models.Model):
             with advisory_lock(f"billing:account:{subscription.account_id}"):
                 cls.objects.select_for_update().get(id=subscription.id)  # type: ignore
                 update_fields = []
+                active_since = kwargs.get("active_since")
 
-                if (
-                    subscription.active_since is None
-                    and kwargs.get("active_since") is not None
-                ):
-                    cls.objects.current().filter(
-                        account=subscription.account,
-                    ).exclude(  # type: ignore
-                        pk=subscription.pk,
-                    ).update(
-                        status=Subscription.Status.INACTIVE_CANCELLED,
-                        active_until=kwargs["active_since"],
+                if subscription.active_since is None and active_since is not None:
+                    cls.cancel_current_subscriptions(
+                        subscription.account,
+                        active_until=cast(datetime, kwargs["active_since"]),
+                        exclude_pk=subscription.pk,
                     )
 
                 for attr_name, attr_value in kwargs.items():
@@ -1018,106 +1055,113 @@ class AbstractSubscription(models.Model):
         if active_since is None:
             active_since = timezone.now()
 
-        _trial_subscription, regular_subscription = cls.create_subscription(
+        subscription = cls.create_subscription(
             account=account,
-            plan=plan,
+            regular_plan=plan,
             created_by=created_by,
             active_since=active_since,
         )
 
-        return regular_subscription
+        return subscription
 
     @classmethod
     def create_subscription(
         cls,
         account: UserAccount,
-        plan: Plan,
+        regular_plan: Plan,
         created_by: Person,
         active_since: datetime | None = None,
-        regular_plan: Plan | None = None,
-    ) -> tuple[Self | None, Self]:
-        """Creates a subscription for a given account to a given plan. If the plan is a trial, create the default subscription in the end of the period.
+        start_trial: bool = False,
+    ) -> Self:
+        """Creates a subscription for a given account to a given plan.
+
+        If `start_trial` is True, the subscription is born as a trial: `regular_plan` stays the
+        commercial commitment of the subscription, but the quotas are resolved through
+        a snapshot of `regular_plan.trial_plan` until `trial_expires_at` (see `plan` property).
 
         Args:
             account: the account the subscription belongs to.
-            plan: the plan to subscribe to. Note if the the plan is a trial, the first return value would be the trial subscription, otherwise it would be None.
+            regular_plan: the plan to subscribe to.
             created_by: created by.
             active_since: active since for the subscription.
-            regular_plan: For trials only: The follow up plan that should be used to create the subscription after the trial period.
+            start_trial: whether to start the subscription as a trial of `regular_plan.trial_plan`.
+                Requires both `active_since` and a `regular_plan` that has a `trial_plan`.
 
         Returns:
-            the created trial subscription if the given plan was a trial and the regular subscription.
+            the created subscription.
         """
         if active_since:
             # remove microseconds as there will be slight shift with the remote system data
             active_since = active_since.replace(microsecond=0)
 
-        regular_active_since: datetime | None = None
-        if plan.is_trial:
-            assert isinstance(active_since, datetime), (
-                "Creating a trial plan requires `active_since` to be a valid datetime object"
-            )
+        if start_trial:
+            if not isinstance(active_since, datetime):
+                raise ValueError(
+                    "Starting a trial requires `active_since` to be a valid datetime object."
+                )
 
-            active_until = active_since + timedelta(days=config.TRIAL_PERIOD_DAYS)
+            if not regular_plan.has_trial_plan:
+                raise ValueError(
+                    f'Starting a trial requires the plan "{regular_plan.code}" to have a `trial_plan`.'
+                )
+
+            # the trial is granted right away, the payment method is collected later
+            status = cls.Status.ACTIVE_TRIAL
+            trial_plan = regular_plan.trial_plan
+            trial_expires_at = active_since + timedelta(days=config.TRIAL_PERIOD_DAYS)
+
             logger.info(
-                f"Creating trial subscription from {active_since=} to {active_until=}"
+                f"Creating trial subscription from {active_since=} to {trial_expires_at=}"
             )
-            trial_subscription = cls.objects.create(
-                regular_plan=plan,
+        else:
+            status = regular_plan.initial_subscription_status
+            trial_plan = None
+            trial_expires_at = None
+
+            logger.info(f"Creating regular subscription from {active_since=}")
+
+        with transaction.atomic():
+            if active_since is not None:
+                # the subscription is born already active, so the one it replaces has to
+                # be closed at the very same moment. Subscriptions born without
+                # `active_since` (e.g. checkout drafts) are closed by `update_subscription`
+                # instead, once the remote system confirms when they start.
+                cls.cancel_current_subscriptions(account, active_until=active_since)
+
+            subscription = cls.objects.create(
+                regular_plan=regular_plan,
                 account=account,
                 created_by=created_by,
-                status=plan.initial_subscription_status,
+                status=status,
                 active_since=active_since,
-                active_until=active_until,
+                trial_plan=trial_plan,
+                trial_expires_at=trial_expires_at,
             )
-            # NOTE to get annotations, mostly `is_active`
-            trial_subscription_obj = cls.objects.get(pk=trial_subscription.pk)
 
-            if (
-                account.user.is_organization
-                and account.user.organization_owner.remaining_trial_organizations > 0
-            ):
-                account.user.organization_owner.remaining_trial_organizations -= 1
-                account.user.organization_owner.save(
-                    update_fields=["remaining_trial_organizations"]
-                )
+            if start_trial:
+                if account.user.is_organization:
+                    organization_owner = Organization.objects.get(
+                        pk=account.pk
+                    ).organization_owner
 
-            if not regular_plan:
-                # If no particular regular follow up plan was specified, choose
-                # the default plan for the given user type.
-                regular_plan = Plan.objects.get(
-                    user_type=account.user.type,
-                    is_default=True,
-                )
+                    if organization_owner.remaining_trial_organizations > 0:
+                        organization_owner.remaining_trial_organizations -= 1
+                        organization_owner.save(
+                            update_fields=["remaining_trial_organizations"]
+                        )
+            else:
+                # NOTE in case the user had a custom amount set (e.g manually set by support) this will
+                # be overwritten by a subscription plan change.
+                # But taking care of this would add quite some complexity.
+                if account.user.is_person:
+                    person = Person.objects.get(pk=account.user.pk)
+                    person.remaining_trial_organizations = (
+                        regular_plan.max_trial_organizations
+                    )
+                    person.save(update_fields=["remaining_trial_organizations"])
 
-            # the end date of the trial is the start date of the regular
-            regular_active_since = active_until
-        else:
-            trial_subscription_obj = None
-            regular_plan = plan
-            regular_active_since = active_since
-
-            # NOTE in case the user had a custom amount set (e.g manually set by support) this will
-            # be overwritten by a subscription plan change.
-            # But taking care of this would add quite some complexity.
-            if account.user.is_person:
-                account.user.remaining_trial_organizations = (
-                    regular_plan.max_trial_organizations
-                )
-                account.user.save(update_fields=["remaining_trial_organizations"])
-
-        logger.info(f"Creating regular subscription from {regular_active_since}")
-        regular_subscription = cls.objects.create(
-            regular_plan=regular_plan,
-            account=account,
-            created_by=created_by,
-            status=regular_plan.initial_subscription_status,
-            active_since=regular_active_since,
-        )
         # NOTE to get annotations, mostly `is_active`
-        regular_subscription_obj = cls.objects.get(pk=regular_subscription.pk)
-
-        return trial_subscription_obj, regular_subscription_obj
+        return cls.objects.get(pk=subscription.pk)
 
     def clean(self):
         """

--- a/docker-app/qfieldcloud/subscription/tests/test_subscription.py
+++ b/docker-app/qfieldcloud/subscription/tests/test_subscription.py
@@ -719,18 +719,26 @@ class QfcTestCase(APITransactionTestCase):
         self.assertIsNotNone(subscription.active_since)
         self.assertIsNone(subscription.active_until)
 
-    def test_create_default_plan_subscription_raises_when_subscription_already_exists(
+    def test_create_default_plan_subscription_replaces_the_existing_subscription(
         self,
     ):
         u1 = Person.objects.create(username="u1")
 
         # the subscription is created anyway
         self.assertEqual(Subscription.objects.count(), 1)
+        old_subscription = u1.useraccount.current_subscription
 
-        with self.assertRaises(django.db.utils.IntegrityError):
-            Subscription.create_default_plan_subscription(u1.useraccount)
+        new_subscription = Subscription.create_default_plan_subscription(u1.useraccount)
 
-    def test_remaining_trial_organizations_is_set_and_decremented(
+        # the new subscription is born active, so the old one is closed at that moment
+        old_subscription.refresh_from_db()
+        self.assertEqual(
+            old_subscription.status, Subscription.Status.INACTIVE_CANCELLED
+        )
+        self.assertEqual(old_subscription.active_until, new_subscription.active_since)
+        self.assertEqual(u1.useraccount.current_subscription, new_subscription)
+
+    def test_remaining_trial_organizations_is_set_from_the_plan(
         self,
     ):
         user_plan = Plan.objects.get(code="default_user")
@@ -743,33 +751,14 @@ class QfcTestCase(APITransactionTestCase):
         self.assertEqual(u1.remaining_trial_organizations, 2)
         self.assertEqual(u2.remaining_trial_organizations, 2)
 
-        trial_plan = Plan.objects.get(code="default_org")
-        trial_plan.is_trial = True
-        trial_plan.save(update_fields=["is_trial"])
-
-        # remaining_trial_organizations is decremented for owner when creating a trial organization
+        # creating an organization does not start a trial, so nothing is consumed
         Organization.objects.create(
             username="org2", organization_owner=u2, created_by=u1
         )
         u2.refresh_from_db()
-        self.assertEqual(u2.remaining_trial_organizations, 1)
-        u1.refresh_from_db()
-        self.assertEqual(u1.remaining_trial_organizations, 2)
+        self.assertEqual(u2.remaining_trial_organizations, 2)
 
-        # remaining_trial_organizations is decremented down to 0
-        Organization.objects.create(
-            username="org3", organization_owner=u2, created_by=u1
-        )
-        u2.refresh_from_db()
-        self.assertEqual(u2.remaining_trial_organizations, 0)
-
-        # It doesn't directly prevent creating more trials, is just a counter that stays at 0
-        Organization.objects.create(
-            username="org4", organization_owner=u2, created_by=u1
-        )
-        u2.refresh_from_db()
-        self.assertEqual(u2.remaining_trial_organizations, 0)
-
+        # NOTE the counter is decremented when a trial is explicitly started,
         # NOTE changing ownership does not affect the `remaining_trial_organizations` and is not tested
 
     def test_project_lists_duplicates_if_multiple_subscriptions(self):

--- a/docker-app/qfieldcloud/subscription/tests/test_trials.py
+++ b/docker-app/qfieldcloud/subscription/tests/test_trials.py
@@ -1,0 +1,187 @@
+import logging
+from datetime import timedelta
+
+from constance import config
+from django.utils import timezone
+from rest_framework.test import APITransactionTestCase
+
+from qfieldcloud.core.models import Organization, Person
+from qfieldcloud.core.tests.utils import setup_subscription_plans
+from qfieldcloud.subscription.models import (
+    CurrentSubscription,
+    Plan,
+    get_subscription_model,
+)
+
+logging.disable(logging.CRITICAL)
+
+Subscription = get_subscription_model()
+
+
+class TrialSubscriptionTestCase(APITransactionTestCase):
+    def _create_plan(self, code, *, is_trial=False, storage_mb=1000, **kwargs):
+        storage_bytes = storage_mb * 1000 * 1000
+        return Plan.objects.create(
+            code=code,
+            display_name=code,
+            is_premium=True,
+            is_trial=is_trial,
+            storage_mb=storage_mb,
+            storage_threshold_warning_bytes=int(storage_bytes * 0.20),
+            storage_threshold_critical_bytes=int(storage_bytes * 0.10),
+            **kwargs,
+        )
+
+    def _expire_trial(self):
+        self.subscription.trial_expires_at = timezone.now() - timedelta(seconds=1)
+        self.subscription.save(update_fields=["trial_expires_at"])
+
+    def _start_trial(self, account=None):
+        return Subscription.create_subscription(
+            account or self.subscription.account,
+            self.regular_plan,
+            self.subscription.created_by,
+            timezone.now(),
+            start_trial=True,
+        )
+
+    def setUp(self):
+        setup_subscription_plans()
+
+        # Regular plan is larger than its trial plan
+        self.trial_plan = self._create_plan("pro_trial", is_trial=True, storage_mb=1000)
+        self.regular_plan = self._create_plan(
+            "pro", storage_mb=5000, trial_plan=self.trial_plan
+        )
+
+        self.subscription = Person.objects.create(
+            username="user1"
+        ).useraccount.current_subscription
+        self.subscription.regular_plan = self.regular_plan
+        self.subscription.trial_plan = self.trial_plan
+        self.subscription.trial_expires_at = timezone.now() + timedelta(days=5)
+        self.subscription.status = Subscription.Status.ACTIVE_TRIAL
+        self.subscription.active_since = timezone.now() - timedelta(days=1)
+        self.subscription.save()
+
+    def test_active_trial_grants_access_until_it_expires(self):
+        self.assertTrue(Subscription.objects.get(pk=self.subscription.pk).is_active)
+
+        self._expire_trial()
+
+        # Still ACTIVE_TRIAL and in-period, but access stops once expired.
+        self.assertFalse(Subscription.objects.get(pk=self.subscription.pk).is_active)
+
+    def test_trial_uses_trial_plan_limits_until_it_expires(self):
+        self.assertEqual(self.subscription.plan, self.trial_plan)
+        self.assertEqual(
+            self.subscription.included_storage_bytes, self.trial_plan.storage_bytes
+        )
+
+        self._expire_trial()
+
+        self.assertEqual(self.subscription.plan, self.regular_plan)
+        self.assertEqual(
+            self.subscription.included_storage_bytes, self.regular_plan.storage_bytes
+        )
+
+    def test_current_subscription_view_resolves_the_plan(self):
+        account_id = self.subscription.account_id
+
+        current = CurrentSubscription.objects.get(account_id=account_id)
+        self.assertEqual(current.plan, self.trial_plan)
+
+        self._expire_trial()
+
+        current = CurrentSubscription.objects.get(account_id=account_id)
+        self.assertEqual(current.regular_plan, self.regular_plan)
+
+    def test_repointing_the_plan_trial_does_not_affect_running_trials(self):
+        other_trial_plan = self._create_plan("pro_trial_v2", is_trial=True)
+
+        self.regular_plan.trial_plan = other_trial_plan
+        self.regular_plan.save(update_fields=["trial_plan"])
+
+        self.subscription.refresh_from_db()
+        self.assertEqual(self.subscription.plan, self.trial_plan)
+
+    def test_start_trial_creates_a_single_trial_subscription(self):
+        account = self.subscription.account
+
+        subscription = self._start_trial()
+
+        self.assertEqual(
+            Subscription.objects.current().filter(account=account).count(), 1
+        )
+        self.assertEqual(account.current_subscription, subscription)
+        self.assertEqual(subscription.regular_plan, self.regular_plan)
+        self.assertEqual(subscription.trial_plan, self.trial_plan)
+        self.assertEqual(subscription.status, Subscription.Status.ACTIVE_TRIAL)
+        self.assertEqual(
+            subscription.trial_expires_at,
+            subscription.active_since + timedelta(days=config.TRIAL_PERIOD_DAYS),
+        )
+        # The trial has no end date of its own, `trial_expires_at` is what ends it.
+        self.assertIsNone(subscription.active_until)
+        self.assertTrue(subscription.is_trialing)
+        # The trial is granted right away, the payment method is collected later.
+        self.assertTrue(subscription.is_active)
+
+    def test_start_trial_closes_the_previous_subscription(self):
+        subscription = self._start_trial()
+
+        self.subscription.refresh_from_db()
+        self.assertEqual(
+            self.subscription.status, Subscription.Status.INACTIVE_CANCELLED
+        )
+        self.assertEqual(self.subscription.active_until, subscription.active_since)
+
+    def test_start_trial_decrements_remaining_trial_organizations(self):
+        owner = Person.objects.create(username="owner")
+        organization = Organization.objects.create(
+            username="org", organization_owner=owner, created_by=owner
+        )
+
+        self.assertEqual(owner.remaining_trial_organizations, 1)
+
+        self._start_trial(organization.useraccount)
+
+        owner.refresh_from_db()
+        self.assertEqual(owner.remaining_trial_organizations, 0)
+
+    def test_plan_with_a_trial_plan_does_not_start_a_trial_on_its_own(self):
+        subscription = Subscription.create_subscription(
+            self.subscription.account,
+            self.regular_plan,
+            self.subscription.created_by,
+            timezone.now(),
+        )
+
+        self.assertIsNone(subscription.trial_plan)
+        self.assertIsNone(subscription.trial_expires_at)
+        self.assertFalse(subscription.is_trialing)
+        self.assertEqual(
+            subscription.status, self.regular_plan.initial_subscription_status
+        )
+        self.assertEqual(subscription.plan, self.regular_plan)
+
+    def test_start_trial_requires_active_since(self):
+        with self.assertRaises(ValueError):
+            Subscription.create_subscription(
+                self.subscription.account,
+                self.regular_plan,
+                self.subscription.created_by,
+                start_trial=True,
+            )
+
+    def test_start_trial_requires_a_plan_with_a_trial_plan(self):
+        plan_without_trial = self._create_plan("pro_without_trial")
+
+        with self.assertRaises(ValueError):
+            Subscription.create_subscription(
+                self.subscription.account,
+                plan_without_trial,
+                self.subscription.created_by,
+                timezone.now(),
+                start_trial=True,
+            )


### PR DESCRIPTION
To simplify managing trial subscriptions, we will now use a single record for trial subscriptions instead of a separate subscription record
This change will help to simplify managing trial subscriptions

- Added `cancel_current_subscriptions` method to handle cancellation of existing subscriptions when a new one is activated
- Adjusted logic in `create_subscription` to ensure proper handling of trial subscriptions
- Adjusted tests accordingly to the changes
- Added `test_trials` test case to verify the behavior of trial subscriptions
- Adjusted `active_storage_total_bytes` to exclude storage packages from the quotas granted by a trial plan