### PR TITLE
feat: add support for mounting custom instance-specific Nginx configurations

### DIFF
--- a/docker-nginx/templates/default.conf.template
+++ b/docker-nginx/templates/default.conf.template
@@ -89,6 +89,9 @@ server {
   # include additional config from the current QFieldCloud instance. This is different from the default `conf.d` directory.
   include config.d/*.conf;
 
+  # Include optional instance-specific configurations
+  include instance.d/*.conf;
+
   # include proxy settings and location blocks for the QFieldCloud instance.
   include conf.d/includes/qfieldcloud.conf;
 }
@@ -125,6 +128,9 @@ server {
 
   # include additional config from the current QFieldCloud instance. This is different from the default `conf.d` directory.
   include config.d/*.conf;
+
+  # Include optional instance-specific configurations
+  include instance.d/*.conf;
 
   # include proxy settings and location blocks for the QFieldCloud instance.
   include conf.d/includes/qfieldcloud.conf;


### PR DESCRIPTION
- Added an include directive for `instance.d/*.conf` in the Nginx template this allows custom instances to cleanly inject their own Nginx server configurations or location blocks via Docker Compose volumes without shadowing or conflicting with the base `config.d` directory