### PR TITLE
chore: pin hadolint to v2.14.0 in pre-commit configuration to avoid breaking changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,5 +61,8 @@ repos:
     rev: v2.14.0
     hooks:
       - id: hadolint-docker
+        # Pinning hadolint to v2.14.0 to avoid breaking changes
+        entry: ghcr.io/hadolint/hadolint:v2.14.0 hadolint
+
 
 exclude: '(docker-app/qfieldcloud/locale/.*)|(.vscode/.*)'


### PR DESCRIPTION
Pinning hadolint to `v2.14.0` to avoid breaking changes, since `v2.15.0` introduces issues on github actions