### PR TITLE
Bump hadolint from 2.14.0 to 2.15.0 and explicitly set gid & uid for the container user

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,11 +58,8 @@ repos:
         entry: bash -c 'mypy -p docker-app -p docker-qgis "$@"' --
 
   - repo: https://github.com/hadolint/hadolint
-    rev: v2.14.0
+    rev: v2.15.0
     hooks:
       - id: hadolint-docker
-        # Pinning hadolint to v2.14.0 to avoid breaking changes
-        entry: ghcr.io/hadolint/hadolint:v2.14.0 hadolint
-
 
 exclude: '(docker-app/qfieldcloud/locale/.*)|(.vscode/.*)'

--- a/docker-app/Dockerfile
+++ b/docker-app/Dockerfile
@@ -69,7 +69,13 @@ RUN if [ "$DEBUG_BUILD" = "1" ]; then apt-get update && apt-get install -y --no-
 RUN if [ "$DEBUG_BUILD" = "1" ]; then uv pip install --system --no-cache debugpy ipython memray py-spy; fi
 
 # add app group
-RUN addgroup --system app && adduser --system app --ingroup app
+RUN groupadd --system --gid 10001 app \
+    && useradd --system \
+        --uid 10001 \
+        --gid 10001 \
+        --no-log-init \
+        --shell /usr/sbin/nologin \
+        app
 
 # create the appropriate directories
 RUN mkdir staticfiles
@@ -98,7 +104,7 @@ EXPOSE 8000
 
 COPY . .
 RUN chown -R app:app .
-USER app
+USER 10001
 
 ##########################
 # WEBSERVER TEST         #
@@ -113,7 +119,7 @@ EXPOSE 8000
 
 COPY . .
 RUN chown -R app:app .
-USER app
+USER 10001
 
 ##########################
 # WORKER WRAPPER RUNTIME #
@@ -127,4 +133,4 @@ RUN uv pip install --system --no-cache -r requirements/requirements_worker_wrapp
 
 COPY . .
 RUN chown -R app:app .
-USER app
+USER 10001


### PR DESCRIPTION
Fixing failures like this one here: https://github.com/opengisch/QFieldCloud/actions/runs/30550620846/job/90938002257?pr=1735

Continuation of https://github.com/opengisch/QFieldCloud/pull/1738
