### PR TITLE
Provide a nicer view name for /api/v1/deltas/{project_uuid}/ and /api/v1/members/{organization_name}/

### DIFF
--- a/docker-app/qfieldcloud/core/views/deltas_views.py
+++ b/docker-app/qfieldcloud/core/views/deltas_views.py
@@ -196,6 +196,9 @@ class ListCreateDeltasView(generics.ListCreateAPIView):
 
         return faulty_deltafile
 
+    def get_view_name(self):
+        return _("Delta List")
+
     def get_queryset(self):
         project_id = self.request.parser_context["kwargs"]["projectid"]
         project_obj = Project.objects.get(id=project_id)

--- a/docker-app/qfieldcloud/core/views/members_views.py
+++ b/docker-app/qfieldcloud/core/views/members_views.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
+from django.utils.translation import gettext as _
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from qfieldcloud.core import pagination, permissions_utils
 from qfieldcloud.core.models import Organization, OrganizationMember
@@ -39,6 +40,9 @@ class ListCreateMembersView(generics.ListCreateAPIView):
     permission_classes = [permissions.IsAuthenticated, ListCreateMembersViewPermissions]
     serializer_class = OrganizationMemberSerializer
     pagination_class = pagination.QfcLimitOffsetPagination()
+
+    def get_view_name(self):
+        return _("Member List")
 
     def get_queryset(self):
         organization = self.request.parser_context["kwargs"]["organization"]


### PR DESCRIPTION
Spot the difference:

| api/v1/projects/ | api/v1/files/{project_uuid} | api/v1/deltas/{project_uuid} |
| --- | --- | --- |
| <img width="749" height="522" alt="image" src="https://github.com/user-attachments/assets/0b1ef34a-d2fc-4dda-b35b-1dcbcbc84977" /> | <img width="824" height="588" alt="image" src="https://github.com/user-attachments/assets/d71ad62c-ce81-46ef-afc1-ac68adb43a3c" /> | <img width="691" height="595" alt="image" src="https://github.com/user-attachments/assets/025c832f-e555-4842-bc23-6a7c177cfea0" /> |


 