### PR TITLE
Link the project's QGIS file to its admin change page

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -1405,7 +1405,7 @@ class ProjectAdmin(QFieldCloudModelAdmin):
         "owner",
         "status",
         "status_code",
-        "the_qgis_file_name",
+        "the_qgis_file",
         "overwrite_conflicts",
         "has_restricted_projectfiles",
         "file_storage_bytes",
@@ -1440,7 +1440,7 @@ class ProjectAdmin(QFieldCloudModelAdmin):
         "project_details__pre",
         "locked_at",
         "file_storage_migrated_at",
-        "the_qgis_file_name",
+        "the_qgis_file",
     )
     inlines = (
         ProjectSeedInline,
@@ -1482,10 +1482,6 @@ class ProjectAdmin(QFieldCloudModelAdmin):
 
     def project_files(self, instance):
         return instance.pk
-
-    @admin.display(description=_("QGIS project file"))
-    def the_qgis_file_name(self, obj: Project) -> str | None:
-        return obj.the_qgis_file_name
 
     def project_details__pre(self, instance):
         if instance.project_details is None:


### PR DESCRIPTION
Replace the plain-text `the_qgis_file_name` readonly field on `ProjectAdmin` with `the_qgis_file_link`, which renders a clickable link to the `File` object's admin change page, matching how other foreign keys like `owner` are linked.

Before:
<img width="703" height="54" alt="image" src="https://github.com/user-attachments/assets/f436f4c3-a7e8-42cd-972b-73460cfc1635" />

After:
<img width="1288" height="138" alt="image" src="https://github.com/user-attachments/assets/f9b26b43-3acc-4969-9e45-c5b6ebd3edc3" />

