### PR TITLE
Rephrase user-facing strings to a more neutral tone

### DIFF
--- a/docker-app/qfieldcloud/core/templates/admin/project_files_widget.html
+++ b/docker-app/qfieldcloud/core/templates/admin/project_files_widget.html
@@ -224,7 +224,7 @@
 
                         $deleteBtn.addEventListener('click', () => {
                             const passPhrase = file.name;
-                            const confirmation = prompt(`Are you sure you want to delete file "${passPhrase}"? This operation is irreversible, the file is deleted forever and the project may be damaged forever! Type "${passPhrase}" to confirm your destructive action!`);
+                            const confirmation = prompt(`Are you sure you want to delete file "${passPhrase}"? This operation is irreversible, the file is deleted forever and the project may be damaged forever! Type "${passPhrase}" to confirm the destructive action!`);
 
                             if (confirmation !== passPhrase) {
                                 $dialog.close();

--- a/docker-app/qfieldcloud/core/templates/axes/lockedout.html
+++ b/docker-app/qfieldcloud/core/templates/axes/lockedout.html
@@ -13,7 +13,7 @@
     <h5 class="card-title">{% trans 'Account Locked' %}</h5>
     <p class="card-text">
       {% blocktrans with username=username timedelta=cooloff_timedelta|smooth_timedelta %}
-        Too many failed login attempts for {{ username }}! Please try again {{ timedelta }} after your last login attempt.
+        Too many failed login attempts for {{ username }}! Please try again {{ timedelta }} after last login attempt.
       {% endblocktrans %}
     </p>
   </div>

--- a/docker-app/qfieldcloud/notifs/templates/notifs/notification_email_body.html
+++ b/docker-app/qfieldcloud/notifs/templates/notifs/notification_email_body.html
@@ -9,5 +9,5 @@
 {% endblock body %}
 
 {% block footer %}
-{% comment %}You should include an unsubscribe link here in your overrides. You can use {{hostname}} and {{username}}.{% endcomment %}
+{% comment %}You should include an unsubscribe link here in overrides. You can use {{hostname}} and {{username}}.{% endcomment %}
 {% endblock footer %}

--- a/docker-app/qfieldcloud/notifs/templates/notifs/notification_email_body.txt
+++ b/docker-app/qfieldcloud/notifs/templates/notifs/notification_email_body.txt
@@ -7,5 +7,5 @@ Here is what happened recently on QFieldCloud:
 {% endblock body %}
 
 {% block footer %}
-{% comment %}You should include an unsubscribe link here in your overrides. You can use {{hostname}} and {{username}}.{% endcomment %}
+{% comment %}You should include an unsubscribe link here in overrides. You can use {{hostname}} and {{username}}.{% endcomment %}
 {% endblock footer %}


### PR DESCRIPTION
Reword strings to drop direct "you"/"your" phrasing, keeping the tone neutral and consistent. "Your" wrongly implies personal ownership, which breaks for organizations, a project or action may belong to an organization the user belongs to, not to the user themselves.