### PR TITLE
Add configurable default project team

### DIFF
--- a/docker-app/qfieldcloud/notifs/signals.py
+++ b/docker-app/qfieldcloud/notifs/signals.py
@@ -2,6 +2,7 @@
 This module logs activity streams using the `django-activity-stream` package.
 """
 
+from django.conf import settings
 from django.db.models.signals import post_save, pre_delete
 from django.dispatch import receiver
 from django_currentuser.middleware import get_current_authenticated_user
@@ -19,6 +20,16 @@ from qfieldcloud.core.models import (
 from qfieldcloud.project.enums import ProjectRoleOrigins
 from qfieldcloud.project.models import Project
 
+def _get_default_project_team():
+    team_username = settings.QFIELDCLOUD_DEFAULT_PROJECT_TEAM
+
+    if not team_username:
+        return None
+
+    try:
+        return User.objects.get(username=team_username)
+    except User.DoesNotExist:
+        return None
 
 def _send_notif(verb, action_object, recipient, target=None):
     """
@@ -200,6 +211,17 @@ def project_created(sender, instance, created, **kwargs):
     # We don't notify for simple updates
     if not created:
         return
+
+    default_team = _get_default_project_team()
+
+    if default_team:
+        ProjectCollaborator.objects.get_or_create(
+            project=project,
+            collaborator=default_team,
+            defaults={
+                "role": ProjectCollaborator.Roles.EDITOR,
+            },
+        )
 
     _send_notif(
         verb="created",

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -357,6 +357,12 @@ QFIELDCLOUD_PROJECT_THUMBNAIL_MAX_DIMENSION = 10000
 # 5MB
 QFIELDCLOUD_PROJECT_THUMBNAIL_MAX_BYTES = 5 * 1024 * 1024
 
+# Default team automatically added to newly created projects.
+# Example: @<organisation>/<team>
+QFIELDCLOUD_DEFAULT_PROJECT_TEAM = os.environ.get(
+    "QFIELDCLOUD_DEFAULT_PROJECT_TEAM"
+)
+
 AUTH_USER_MODEL = "core.User"
 
 # QFieldCloud variables


### PR DESCRIPTION
## Summary

This is a proof-of-concept implementation tested on a self-hosted QFieldCloud deployment.

Adds a configurable environment variable:

QFIELDCLOUD_DEFAULT_PROJECT_TEAM

When a new project is created:

- resolve the configured Team
- add the Team as a Project Collaborator
- assign the Editor role

## Example

QFIELDCLOUD_DEFAULT_PROJECT_TEAM=@<organization>/<team>

Result:

All newly created projects automatically receive @<organization>/<team> as an Editor collaborator.

## Motivation

This reduces repetitive project administration and ensures a standard Team is always granted access to new projects.

## Future Direction

This implementation could potentially evolve into a more general:

"Organization Default Collaborators"

feature that supports:

- multiple Teams
- multiple Users
- configurable roles
- organization-level configuration

## Validation

Tested successfully on a self-hosted production deployment.