### PR TITLE
Add `Team.is_team_username` helper function

### DIFF
--- a/docker-app/qfieldcloud/core/models.py
+++ b/docker-app/qfieldcloud/core/models.py
@@ -921,6 +921,11 @@ class Team(User):
 
         return f"@{organization_name}/{team_name}"
 
+    @staticmethod
+    def is_team_username(username: str) -> bool:
+        """Whether `username` has the `@organization/team` shape of a team's username."""
+        return username.startswith("@") and "/" in username
+
 
 class TeamMemberQuerySet(models.QuerySet):
     def get_by_natural_key(

--- a/docker-app/qfieldcloud/project/utils/projects_utils.py
+++ b/docker-app/qfieldcloud/project/utils/projects_utils.py
@@ -83,8 +83,10 @@ def create_collaborator_by_username_or_email(
     ) + list(Team.objects.filter(username=username, team_organization=project.owner))
 
     if len(users) == 0:
+        if Team.is_team_username(username):
+            message = _('Team "{}" does not exist.').format(username)
         # No user found, if string is an email address, we try to send a link
-        if invitation.is_valid_email(username):
+        elif invitation.is_valid_email(username):
             success, message = invitation.invite_user_by_email(username, created_by)
         else:
             message = _('User "{}" does not exist.').format(username)


### PR DESCRIPTION
- Add `Team.is_team_username(username)`, checks whether a string has the `@organization/team` shape of a team's username.
- Use it in `create_collaborator_by_username_or_email` so a team-shaped username that doesn't match any existing team reports `Team "@org/team" does not exist.`