### PR TITLE
Add option to exclude existing team members from the users API

### DIFF
--- a/docker-app/qfieldcloud/core/querysets_utils.py
+++ b/docker-app/qfieldcloud/core/querysets_utils.py
@@ -39,6 +39,7 @@ def get_users(
     username: str,
     project: Project | None = None,
     organization: Organization | None = None,
+    exclude_members_of_team: Team | None = None,
     exclude_organizations: bool = False,
     exclude_teams: bool = False,
     invert: bool = False,
@@ -104,6 +105,12 @@ def get_users(
             users = users.filter(reduce(and_, [c for c in conditions]))
         else:
             users = users.exclude(reduce(or_, [c for c in conditions]))
+
+    if exclude_members_of_team:
+        team_member_ids = TeamMember.objects.filter(
+            team=exclude_members_of_team
+        ).values_list("member", flat=True)
+        users = users.exclude(pk__in=team_member_ids)
 
     return users.annotate(
         ordering=StrIndex("username", V(username)),

--- a/docker-app/qfieldcloud/core/tests/test_queryset.py
+++ b/docker-app/qfieldcloud/core/tests/test_queryset.py
@@ -271,6 +271,27 @@ class QfcTestCase(APITransactionTestCase):
         self.assertTrue(self.user3.id in queryset_ids)
         self.assertTrue(self.user4.id in queryset_ids)
 
+        # should get all the users, except those already a member of the team
+        queryset_ids = querysets_utils.get_users(
+            "", exclude_members_of_team=self.team1_1
+        ).values_list("id", flat=True)
+        self.assertEqual(len(queryset_ids), 7)
+        self.assertFalse(self.user3.id in queryset_ids)
+
+        # should get the users that are members/owner of the organization
+        # (via `invert`), except those already a member of the team
+        queryset_ids = querysets_utils.get_users(
+            "",
+            organization=self.organization1,
+            invert=True,
+            exclude_members_of_team=self.team1_1,
+        ).values_list("id", flat=True)
+        self.assertEqual(len(queryset_ids), 3)
+        self.assertTrue(self.user1.id in queryset_ids)
+        self.assertTrue(self.user2.id in queryset_ids)
+        self.assertTrue(self.organization1.user_ptr_id in queryset_ids)
+        self.assertFalse(self.user3.id in queryset_ids)
+
     def test_projects_roles_and_role_origins(self):
         """
         Checks user_role and user_role_origin are correctly defined

--- a/docker-app/qfieldcloud/core/views/users_views.py
+++ b/docker-app/qfieldcloud/core/views/users_views.py
@@ -2,7 +2,7 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from qfieldcloud.core import pagination, permissions_utils, querysets_utils
-from qfieldcloud.core.models import Organization
+from qfieldcloud.core.models import Organization, Team
 from qfieldcloud.core.serializers import (
     CompleteUserSerializer,
     CreateUserSerializer,
@@ -53,6 +53,15 @@ class ListCreateUsersView(generics.ListCreateAPIView):
             except Project.DoesNotExist:
                 pass
 
+        exclude_members_of_team = None
+        if params.get("exclude_members_of_team"):
+            try:
+                exclude_members_of_team = Team.objects.get(
+                    pk=params.get("exclude_members_of_team")
+                )
+            except (Team.DoesNotExist, ValueError):
+                pass
+
         # TODO : are these GET paremters documented somewhere ? Shouldn't we use something
         # like django_filters.rest_framework.DjangoFilterBackend so they get auto-documented
         # in DRF's views, or is that supposedly done with swagger ?
@@ -63,6 +72,7 @@ class ListCreateUsersView(generics.ListCreateAPIView):
             query,
             project=project,
             organization=organization,
+            exclude_members_of_team=exclude_members_of_team,
             exclude_organizations=exclude_organizations,
             exclude_teams=exclude_teams,
             invert=invert,


### PR DESCRIPTION
This PR adds a way for the users API to exclude members of a given team from its results.

When adding users to a team, we should exclude the users that are already team members to prevent toasts of sort `User "X" cannot be added to the team. Team member with this Team and Member already exists.`.

Changes:
- Add `exclude_members_of_team` to `querysets_utils.get_users`
- Add `exclude_members_of_team` parsing in `ListCreateUsersView.get_queryset` and pass it to `get_users`
- Add coverage in `test_queryset.py` for the plain team-exclusion case and the combined organization, invert, and team case