### PR TITLE
Better object representation for File, FileVersion and Project

### DIFF
--- a/docker-app/qfieldcloud/filestorage/models.py
+++ b/docker-app/qfieldcloud/filestorage/models.py
@@ -156,7 +156,7 @@ class File(models.Model):
         return self.versions.aggregate(size=Sum("size", default=0))["size"]
 
     def __repr__(self) -> str:
-        return f'File({self.pk}) in "{self.project_id}" "{self.name}"'  # type: ignore
+        return f"{self.project_id}/{self.name} [id={self.id}]"  # type: ignore
 
     def __str__(self) -> str:
         return self.__repr__()
@@ -391,9 +391,11 @@ class FileVersion(models.Model):
 
     def __repr__(self) -> str:
         if hasattr(self, "file"):
-            return f'FileVersion({self.id}) in "{self.file.project_id}" "{self.file.name}" "{self.display}"'  # type: ignore
+            return (
+                f"{self.file.project_id}/{self.file.name}/{self.display} [id={self.id}]"  # type: ignore
+            )
         else:
-            return f'FileVersion({self.id}) in "UNKNOWN_PROJECT_ID" "UNKNOWN_FILENAME" "{self.display}"'  # type: ignore
+            return f"UNKNOWN_PROJECT_ID/UNKNOWN_FILENAME/{self.display} [id={self.id}]"  # type: ignore
 
     def __str__(self) -> str:
         return self.__repr__()

--- a/docker-app/qfieldcloud/project/models.py
+++ b/docker-app/qfieldcloud/project/models.py
@@ -695,7 +695,7 @@ class Project(models.Model):
         )
 
     def __str__(self):
-        return self.name + " (" + str(self.id) + ")" + " owner: " + self.owner.username
+        return f"{self.owner.username}/{self.name} [id={self.id}]"
 
     @property
     def name_with_owner(self) -> str:


### PR DESCRIPTION
Before:
```
File(<file-id) in "<project-id>" "<filepath>"

FileVersion(<file-version-id) in "<project-id>" "<filepath>" "<version-display>"

<name> (<project-id>) owner:<owner-username>

```

After:
```
<project-id>/<filepath> [id=<file-id>]

<project-id>/<filepath>/<version-display> [id=<file-version-id>]

Project <owner-username>/<name> [id=<project-id>]

```

## Motivation

Before:
<img width="1756" height="83" alt="image" src="https://github.com/user-attachments/assets/e2f579ce-8b8c-467a-b03c-731b1f184201" />

After:

<img width="1756" height="83" alt="image" src="https://github.com/user-attachments/assets/c78d9e05-da8b-4bce-8f6d-d4997c41d4c0" />
