### PR TITLE
Revert "Merge pull request #1423 from felixxm/exclusion-constraint"

### DIFF
--- a/docker-app/qfieldcloud/subscription/functions.py
+++ b/docker-app/qfieldcloud/subscription/functions.py
@@ -1,7 +1,0 @@
-from django.contrib.postgres.fields import DateTimeRangeField
-from django.db.models import Func
-
-
-class TsTzRange(Func):
-    function = "TSTZRANGE"
-    output_field = DateTimeRangeField()

--- a/docker-app/qfieldcloud/subscription/migrations/0004_auto_20220923_1602.py
+++ b/docker-app/qfieldcloud/subscription/migrations/0004_auto_20220923_1602.py
@@ -2,17 +2,14 @@
 
 import uuid
 
-import django.contrib.postgres.constraints
-import django.contrib.postgres.fields.ranges
 import django.db.migrations.state
 import django.db.models.deletion
+import migrate_sql.operations
 from django.conf import settings
 from django.contrib.postgres.operations import BtreeGistExtension
 from django.db import migrations, models
 from django.db.models import Q
 from django.utils import timezone
-
-import qfieldcloud.subscription.functions
 
 now = timezone.now()
 
@@ -196,23 +193,10 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.RunPython(populate_subscriptions_model, populate_account_plan_field),
-        migrations.AddConstraint(
-            model_name="subscription",
-            constraint=django.contrib.postgres.constraints.ExclusionConstraint(
-                condition=models.Q(("active_since__isnull", False)),
-                expressions=[
-                    ("account_id", "="),
-                    (
-                        qfieldcloud.subscription.functions.TsTzRange(
-                            "active_since",
-                            "active_until",
-                            django.contrib.postgres.fields.ranges.RangeBoundary(),
-                        ),
-                        "&&",
-                    ),
-                ],
-                name="subscription_subscription_prevent_overlaps",
-            ),
+        migrate_sql.operations.CreateSQL(
+            name="subscription_subscription_prevent_overlaps_idx",
+            sql="\n            ALTER TABLE subscription_subscription\n            ADD CONSTRAINT subscription_subscription_prevent_overlaps\n            EXCLUDE USING gist (\n                account_id WITH =,\n                tstzrange(active_since, active_until) WITH &&\n            )\n            WHERE (active_since IS NOT NULL)\n        ",
+            reverse_sql="\n            ALTER TABLE subscription_subscription DROP CONSTRAINT subscription_subscription_prevent_overlaps\n        ",
         ),
         #################
         # Packages
@@ -293,23 +277,10 @@ class Migration(migrations.Migration):
                 null=False,
             ),
         ),
-        migrations.AddConstraint(
-            model_name="package",
-            constraint=django.contrib.postgres.constraints.ExclusionConstraint(
-                condition=models.Q(("active_since__isnull", False)),
-                expressions=[
-                    ("subscription_id", "="),
-                    (
-                        qfieldcloud.subscription.functions.TsTzRange(
-                            "active_since",
-                            "active_until",
-                            django.contrib.postgres.fields.ranges.RangeBoundary(),
-                        ),
-                        "&&",
-                    ),
-                ],
-                name="subscription_package_prevent_overlaps",
-            ),
+        migrate_sql.operations.CreateSQL(
+            name="subscription_package_prevent_overlaps_idx",
+            sql="\n            ALTER TABLE subscription_package\n            ADD CONSTRAINT subscription_package_prevent_overlaps\n            EXCLUDE USING gist (\n                subscription_id WITH =,\n                tstzrange(active_since, active_until) WITH &&\n            )\n            WHERE (active_since IS NOT NULL)\n        ",
+            reverse_sql="\n            ALTER TABLE subscription_package DROP CONSTRAINT subscription_package_prevent_overlaps\n        ",
         ),
         ####################
         # Add auditing fields to plans and packages

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -8,8 +8,6 @@ from constance import config
 from deprecated import deprecated
 from django.apps import apps
 from django.conf import settings
-from django.contrib.postgres.constraints import ExclusionConstraint
-from django.contrib.postgres.fields import RangeBoundary, RangeOperators
 from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
 from django.db import models, transaction
@@ -21,7 +19,6 @@ from model_utils.managers import InheritanceManagerMixin
 
 from qfieldcloud.core.models import Organization, Person, User, UserAccount
 from qfieldcloud.subscription.exceptions import NotPremiumPlanException
-from qfieldcloud.subscription.functions import TsTzRange
 
 logger = logging.getLogger(__name__)
 
@@ -485,22 +482,6 @@ class Package(models.Model):
             "These notes are for internal purposes only and will never be shown to the end users."
         ),
     )
-
-    class Meta:
-        constraints = [
-            ExclusionConstraint(
-                name="subscription_package_prevent_overlaps",
-                index_type="GIST",
-                expressions=[
-                    ("subscription_id", RangeOperators.EQUAL),
-                    (
-                        TsTzRange("active_since", "active_until", RangeBoundary()),
-                        RangeOperators.OVERLAPS,
-                    ),
-                ],
-                condition=Q(active_since__isnull=False),
-            ),
-        ]
 
 
 # TODO add check constraint makes sure there are no two active additional packages at the same time,
@@ -1152,21 +1133,7 @@ class AbstractSubscription(models.Model):
 
 
 class Subscription(AbstractSubscription):
-    class Meta:
-        constraints = [
-            ExclusionConstraint(
-                name="subscription_subscription_prevent_overlaps",
-                index_type="GIST",
-                expressions=[
-                    ("account_id", RangeOperators.EQUAL),
-                    (
-                        TsTzRange("active_since", "active_until", RangeBoundary()),
-                        RangeOperators.OVERLAPS,
-                    ),
-                ],
-                condition=Q(active_since__isnull=False),
-            ),
-        ]
+    pass
 
 
 class CurrentSubscription(AbstractSubscription):

--- a/docker-app/qfieldcloud/subscription/sql_config.py
+++ b/docker-app/qfieldcloud/subscription/sql_config.py
@@ -2,6 +2,36 @@ from migrate_sql.config import SQLItem
 
 sql_items = [
     SQLItem(
+        "subscription_subscription_prevent_overlaps_idx",
+        r"""
+            ALTER TABLE subscription_subscription
+            ADD CONSTRAINT subscription_subscription_prevent_overlaps
+            EXCLUDE USING gist (
+                account_id WITH =,
+                tstzrange(active_since, active_until) WITH &&
+            )
+            WHERE (active_since IS NOT NULL)
+        """,
+        r"""
+            ALTER TABLE subscription_subscription DROP CONSTRAINT subscription_subscription_prevent_overlaps
+        """,
+    ),
+    SQLItem(
+        "subscription_package_prevent_overlaps_idx",
+        r"""
+            ALTER TABLE subscription_package
+            ADD CONSTRAINT subscription_package_prevent_overlaps
+            EXCLUDE USING gist (
+                subscription_id WITH =,
+                tstzrange(active_since, active_until) WITH &&
+            )
+            WHERE (active_since IS NOT NULL)
+        """,
+        r"""
+            ALTER TABLE subscription_package DROP CONSTRAINT subscription_package_prevent_overlaps
+        """,
+    ),
+    SQLItem(
         "current_subscriptions_vw",
         r"""
             CREATE VIEW current_subscriptions_vw AS


### PR DESCRIPTION
Unfortunately we have to revert this change because Django is trying to be a smartass and send a verification query for the `CheckConstraint` BEFORE the actual database check constraint kicks in. This is problematic because the produced query is returning that constraint is violated when it is not.

This blocks the support team to use Admin to expire existing subscriptions.

<img width="1673" height="282" alt="image" src="https://github.com/user-attachments/assets/633888d8-cab9-477a-a9bb-8ef8c6f33181" />

E.g. for the subscription overlap it sends this query:

```
SELECT
  1 AS "_check"
WHERE
  COALESCE(
    (
      EXISTS(
        SELECT
          1 AS "a"
        FROM
          "subscription_subscription" U0
        WHERE
          (
            U0."account_id" = (U0."ac count_id")
            AND TSTZRANGE(
              U0."active_since", U0."active_until",
              '[)'
            ) && (
              STZRANGE(
                '2026-08-13T11:40:36+02:00' :: timestamptz,
                '2026-08-13T11:45: 18+02:00' :: timestamptz,
                '[)'
              )
            )
            AND NOT (U0."id" = 8)
            AND U0."active_since" IS NOT NULL
          )
        LIMIT
          1
      )
    ), true
  )
```

This reverts commit f29d532c36b8823a9db69ac01bdbd6c4e8b95e6c, reversing changes made to 4f232e0ca3db20160e27fdcf24dfc3a53493acf2.

Related https://github.com/opengisch/QFieldCloud/pull/1423


