### PR TITLE
Deprecate `is_shared_datasets_project` in `Project` model in favour of `project_type`

### DIFF
--- a/docker-app/qfieldcloud/project/models.py
+++ b/docker-app/qfieldcloud/project/models.py
@@ -614,6 +614,8 @@ class Project(models.Model):
     def is_shared_datasets_project(self) -> bool:
         """
         Returns `True` if the project is the shared datasets project, otherwise `False`.
+
+        Deprecated: use `project_type` instead.
         """
         return self.project_type == self.ProjectType.SHARED_DATASETS
 

--- a/docker-app/qfieldcloud/project/serializers.py
+++ b/docker-app/qfieldcloud/project/serializers.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from drf_spectacular.utils import extend_schema_serializer
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
@@ -15,6 +16,7 @@ from qfieldcloud.project.models import (
 from qfieldcloud.subscription.exceptions import QuotaError
 
 
+@extend_schema_serializer(deprecate_fields=["is_shared_datasets_project"])
 class ProjectSerializer(serializers.ModelSerializer):
     owner = serializers.StringRelatedField()
     project_type = serializers.ChoiceField(


### PR DESCRIPTION
Literally, the title.

Swagger UI schema:
<img width="835" height="106" alt="image" src="https://github.com/user-attachments/assets/188ae868-b92e-430a-829f-229dcf1af0c8" />
