### PR TITLE
fix: no exception when token auth failed

### DIFF
--- a/docker-app/qfieldcloud/core/exceptions.py
+++ b/docker-app/qfieldcloud/core/exceptions.py
@@ -55,6 +55,7 @@ class AuthenticationViaTokenFailedError(QFieldCloudException):
     code = "token_authentication_failed"
     message = "Token authentication failed"
     status_code = status.HTTP_401_UNAUTHORIZED
+    log_as_error = False
 
 
 class NotAuthenticatedError(QFieldCloudException):


### PR DESCRIPTION
Instead of logging an exception just log as normal INFO log string.

- Before change:
```
app-1  | {"request_id":"bd5d80aabfea01ba21a21a168157122c","ts":"2026-08-13T14:54:28.586258+00:00","level":"ERROR","name":"root","message":"Token authentication failed","filename":"rest_utils.py","lineno":46,"thread":138566713734848,"source":"app","exc_info":"Traceback (most recent call last):\n  File \"/usr/src/app/qfieldcloud/authentication/authentication.py\", line 53, in authenticate_credentials\n    token = model.objects.get(key=key)\n  File \"/usr/local/lib/python3.14/site-packages/django/db/models/manager.py\", line 87, in manager_method\n    return getattr(self.get_queryset(), name)(*args, **kwargs)\n           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.14/site-packages/django/db/models/query.py\", line 635, in get\n    raise self.model.DoesNotExist(\n        \"%s matching query does not exist.\" % self.model._meta.object_name\n    )\nqfieldcloud.authentication.models.AuthToken.DoesNotExist: AuthToken matching query does not exist.\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.14/site-packages/rest_framework/views.py\", line 514, in dispatch\n    self.initial(request, *args, **kwargs)\n    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.14/site-packages/rest_framework/views.py\", line 419, in initial\n    self.perform_authentication(request)\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^\n  File \"/usr/local/lib/python3.14/site-packages/rest_framework/views.py\", line 329, in perform_authentication\n    request.user\n  File \"/usr/local/lib/python3.14/site-packages/rest_framework/request.py\", line 232, in user\n    self._authenticate()\n    ~~~~~~~~~~~~~~~~~~^^\n  File \"/usr/local/lib/python3.14/site-packages/rest_framework/request.py\", line 389, in _authenticate\n    user_auth_tuple = authenticator.authenticate(self)\n  File \"/usr/local/lib/python3.14/site-packages/rest_framework/authentication.py\", line 196, in authenticate\n    return self.authenticate_credentials(token)\n           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^\n  File \"/usr/src/app/qfieldcloud/authentication/authentication.py\", line 55, in authenticate_credentials\n    raise AuthenticationViaTokenFailedError(_(\"Invalid token.\"))\nqfieldcloud.core.exceptions.AuthenticationViaTokenFailedError: Token authentication failed"}
app-1  | Unauthorized: /api/v1/projects/0d0b5327-26be-460f-9656-c6dac71bae4c/
app-1  | [13/Aug/2026 16:54:28] "GET /api/v1/projects/0d0b5327-26be-460f-9656-c6dac71bae4c/ HTTP/1.1" 401 370
app-1  | {"status_code":401,"request":"<WSGIRequest: GET '/api/v1/projects/0d0b5327-26be-460f-9656-c6dac71bae4c/'>","request_id":"bd5d80aabfea01ba21a21a168157122c","ts":"2026-08-13T14:54:28.636988+00:00","level":"WARNING","name":"django.request","message":"Unauthorized: /api/v1/projects/0d0b5327-26be-460f-9656-c6dac71bae4c/","filename":"log.py","lineno":253,"thread":138566713734848,"source":"app"}
```

- After change:
```
app-1  | {"request_id":"c7b0cfcfd1fc8a68d8487a09b6af4635","ts":"2026-08-13T14:51:38.655663+00:00","level":"INFO","name":"root","message":"Token authentication failed","filename":"rest_utils.py","lineno":49,"thread":129621071738560,"source":"app"}
app-1  | Unauthorized: /api/v1/projects/0d0b5327-26be-460f-9656-c6dac71bae4c/
app-1  | {"status_code":401,"request":"<WSGIRequest: GET '/api/v1/projects/0d0b5327-26be-460f-9656-c6dac71bae4c/'>","request_id":"c7b0cfcfd1fc8a68d8487a09b6af4635","ts":"2026-08-13T14:51:38.709176+00:00","level":"WARNING","name":"django.request","message":"Unauthorized: /api/v1/projects/0d0b5327-26be-460f-9656-c6dac71bae4c/","filename":"log.py","lineno":253,"thread":129621071738560,"source":"app"}
app-1  | [13/Aug/2026 16:51:38] "GET /api/v1/projects/0d0b5327-26be-460f-9656-c6dac71bae4c/ HTTP/1.1" 401 370
```

