### PR TITLE
Add ability to order /deltas/{project_id}/ by created_at field

### DIFF
--- a/docker-app/qfieldcloud/core/views/deltas_views.py
+++ b/docker-app/qfieldcloud/core/views/deltas_views.py
@@ -15,6 +15,7 @@ from drf_spectacular.utils import (
     extend_schema_view,
 )
 from qfieldcloud.core import exceptions, pagination, permissions_utils, utils
+from qfieldcloud.core.drf_utils import QfcOrderingFilter
 from qfieldcloud.core.models import Delta, FaultyDeltaFile
 from qfieldcloud.core.serializers import DeltaSerializer
 from qfieldcloud.core.utils2 import jobs
@@ -64,6 +65,8 @@ class ListCreateDeltasView(generics.ListCreateAPIView):
     permission_classes = [permissions.IsAuthenticated, DeltaFilePermissions]
     serializer_class = DeltaSerializer
     pagination_class = pagination.QfcLimitOffsetPagination()
+    filter_backends = [QfcOrderingFilter]
+    ordering_fields = ["created_at"]
 
     def post(self, request, projectid):
         project_obj = Project.objects.select_related("the_qgis_file").get(id=projectid)


### PR DESCRIPTION
In upcoming QField 4.3, we're (dramatically) improved the visibility of the delta/changes history dialog. 

To be on the safe side, we should upgrade that dialog to offer a paginated view, with additional items added (when available) once the user reaches the very bottom of the list view. 

Pagination for the /api/v1/deltas/ endpoint is already in, however ordering is fixed, and serves the delta changes from oldest to newest, which isn't ideal.

This PR adds the ability to order the list by created_at, which QField will then use to get pages of deltas served in reversed created_at order.