### PR TITLE
Implement multiple query optimizations on the API

### DIFF
--- a/docker-app/qfieldcloud/authentication/auth_backends.py
+++ b/docker-app/qfieldcloud/authentication/auth_backends.py
@@ -3,7 +3,6 @@ from typing import cast
 from allauth.account.auth_backends import (
     AuthenticationBackend as AllAuthAuthenticationBackend,
 )
-from django.contrib.auth import get_user_model
 
 from qfieldcloud.core.models import Person
 
@@ -36,11 +35,9 @@ class AuthenticationBackend(AllAuthAuthenticationBackend):
         Returns:
             In theory it can return any of `Person` | `Organization` | `Team` | `None` types, however it will always be a `Person` or `None`
         """
-        UserModel = get_user_model()
-
         try:
-            user = UserModel.objects.get(pk=user_id)
-        except UserModel.DoesNotExist:
+            user = Person.objects.select_related("useraccount").get(pk=user_id)
+        except Person.DoesNotExist:
             return None
 
         if self.user_can_authenticate(user):

--- a/docker-app/qfieldcloud/core/views/deltas_views.py
+++ b/docker-app/qfieldcloud/core/views/deltas_views.py
@@ -204,9 +204,10 @@ class ListCreateDeltasView(generics.ListCreateAPIView):
 
     def get_queryset(self):
         project_id = self.request.parser_context["kwargs"]["projectid"]
-        project_obj = Project.objects.get(id=project_id)
 
-        return Delta.objects.prefetch_related("created_by").filter(project=project_obj)
+        return Delta.objects.prefetch_related("created_by").filter(
+            project_id=project_id
+        )
 
 
 @extend_schema_view(

--- a/docker-app/qfieldcloud/core/views/jobs_views.py
+++ b/docker-app/qfieldcloud/core/views/jobs_views.py
@@ -7,8 +7,8 @@ from drf_spectacular.utils import (
 )
 from qfieldcloud.core import pagination, permissions_utils, serializers
 from qfieldcloud.core.models import Job
-from qfieldcloud.project.models import Project, get_slim_project_or_raise
-from rest_framework import generics, permissions, viewsets
+from qfieldcloud.project.models import get_slim_project_or_raise
+from rest_framework import permissions, viewsets
 from rest_framework.response import Response
 from rest_framework.status import HTTP_201_CREATED
 
@@ -157,7 +157,6 @@ class JobViewSet(viewsets.ReadOnlyModelViewSet):
 
         if self.action == "list":
             project_id = self.request.GET.get("project_id")
-            project = generics.get_object_or_404(Project, pk=project_id)
-            qs = qs.filter(project=project)
+            qs = qs.filter(project_id=project_id)
 
         return qs

--- a/docker-app/qfieldcloud/core/views/package_views.py
+++ b/docker-app/qfieldcloud/core/views/package_views.py
@@ -86,7 +86,11 @@ class LatestPackageView(views.APIView):
                 "Packaging has never been triggered or successful for this project."
             )
 
-        files_qs = File.objects.filter(
+        files_qs = File.objects.select_related(
+            "latest_version",
+            "project",
+            "project__qgis_project",
+        ).filter(
             project_id=project_id,
             package_job=latest_finished_package_job,
             file_type=File.FileType.PACKAGE_FILE,

--- a/docker-app/qfieldcloud/filestorage/view_helpers.py
+++ b/docker-app/qfieldcloud/filestorage/view_helpers.py
@@ -227,7 +227,10 @@ def download_project_file_version(
                 | Q(file__file_type=File.FileType.PROJECT_FILE)
             )
 
-        file_version = FileVersion.objects.get(filters)
+        file_version = FileVersion.objects.only(
+            "content",
+            "file_storage",
+        ).get(filters)
     else:
         filters = Q(
             project_id=project_id,
@@ -241,7 +244,14 @@ def download_project_file_version(
                 | Q(file_type=File.FileType.PROJECT_FILE)
             )
 
-        file = File.objects.select_related("latest_version").get(filters)
+        file = (
+            File.objects.only(
+                "latest_version__content",
+                "latest_version__file_storage",
+            )
+            .select_related("latest_version")
+            .get(filters)
+        )
 
         assert file.latest_version
 

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -879,7 +879,7 @@ class AbstractSubscription(models.Model):
         try:
             subscription = (
                 cls.objects.current()  # type: ignore
-                .select_related("plan")
+                .select_related("plan", "account", "account__user")
                 .get(account_id=account.pk)
             )
         except cls.DoesNotExist:

--- a/docker-app/qfieldcloud/subscription/views.py
+++ b/docker-app/qfieldcloud/subscription/views.py
@@ -1,13 +1,12 @@
-from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework.generics import RetrieveAPIView
 from rest_framework.permissions import BasePermission, IsAuthenticated
 
 from qfieldcloud.core import permissions_utils
+from qfieldcloud.core.models import User
+from qfieldcloud.subscription.models import Subscription
 from qfieldcloud.subscription.serializers import CurrentSubscriptionSerializer
-
-User = get_user_model()
 
 
 class RetrieveCurrentSubscriptionViewPermissions(BasePermission):
@@ -36,7 +35,9 @@ class RetrieveCurrentSubscriptionView(RetrieveAPIView):
     ]
     serializer_class = CurrentSubscriptionSerializer
 
-    def get_object(self):
-        username = self.kwargs["username"]
-        user = User.objects.get(username=username)
+    def get_object(self) -> Subscription:
+        user = User.objects.select_related("useraccount").get(
+            username=self.kwargs["username"]
+        )
+
         return user.useraccount.current_subscription

--- a/docker-app/qfieldcloud/subscription/views.py
+++ b/docker-app/qfieldcloud/subscription/views.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework.generics import RetrieveAPIView
 from rest_framework.permissions import BasePermission, IsAuthenticated
@@ -37,8 +38,20 @@ class RetrieveCurrentSubscriptionView(RetrieveAPIView):
     serializer_class = CurrentSubscriptionSerializer
 
     def get_object(self) -> Subscription:
-        user = User.objects.select_related("useraccount").get(
-            username=self.kwargs["username"]
+        user = get_object_or_404(
+            User.objects.select_related(
+                # Even though `User` has direct `useraccount` relation, the polymorphic nature of User-Person-Organization
+                # prevents Django to detect that `useraccount` is `select_related`,
+                # so we need to explicitly select the related `useraccount` for both `Person` and `Organization`.
+                "person__useraccount",
+                "organization__useraccount",
+            ),
+            username=self.kwargs["username"],
         )
 
-        return user.useraccount.current_subscription
+        subscription = user.useraccount.current_subscription
+
+        # May raise a permission denied
+        self.check_object_permissions(self.request, subscription)
+
+        return subscription

--- a/docker-app/qfieldcloud/subscription/views.py
+++ b/docker-app/qfieldcloud/subscription/views.py
@@ -1,7 +1,10 @@
-from django.core.exceptions import ObjectDoesNotExist
+from typing import Any
+
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework.generics import RetrieveAPIView
 from rest_framework.permissions import BasePermission, IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.views import APIView
 
 from qfieldcloud.core import permissions_utils
 from qfieldcloud.core.models import User
@@ -10,15 +13,13 @@ from qfieldcloud.subscription.serializers import CurrentSubscriptionSerializer
 
 
 class RetrieveCurrentSubscriptionViewPermissions(BasePermission):
-    def has_permission(self, request, view):
-        username = permissions_utils.get_param_from_request(request, "username")
+    def has_object_permission(self, request: Request, view: APIView, obj: Any) -> bool:
+        user_for_account: User = obj.account.user
 
-        try:
-            user = User.objects.get(username=username)
-        except ObjectDoesNotExist:
-            return False
-
-        return permissions_utils.can_read_current_subscription(request.user, user)
+        return permissions_utils.can_read_current_subscription(
+            request.user,
+            user_for_account,
+        )
 
 
 @extend_schema_view(


### PR DESCRIPTION
Make some of the most commonly used endpoints faster by reducing the number of requests sent.

See individual commits for more.