### PR TITLE
Prevent initial packaging on template projects

### DIFF
--- a/docker-app/qfieldcloud/core/permissions_utils.py
+++ b/docker-app/qfieldcloud/core/permissions_utils.py
@@ -530,6 +530,9 @@ def can_read_jobs(user: QfcUser, project: Project) -> bool:
 
 def can_create_jobs(user: QfcUser, project: Project, job_type: Job.Type) -> bool:
     """Check if the user has permission to create a job of the given type."""
+    if job_type == Job.Type.PACKAGE and not project.is_regular_project:
+        return False
+
     if job_type == Job.Type.PACKAGE:
         roles = list(ProjectCollaborator.Roles)
     elif job_type in (Job.Type.PROCESS_PROJECTFILE, Job.Type.DELTA_APPLY):


### PR DESCRIPTION
Currently, a user can make an initial package for a template project for QField, but once they make edits to that project, they cannot repackage it back.

This PR prevents packaging for template projects overall.