### PR TITLE
Optimize GET /projects endpoint by reducing 5 queries per Project

### DIFF
--- a/docker-app/qfieldcloud/core/tests/utils.py
+++ b/docker-app/qfieldcloud/core/tests/utils.py
@@ -209,7 +209,7 @@ def wait_for_project_ok_status(project: Project, wait_s: int = 30):
 
         sleep(1)
 
-    fail(f"Waited for ok status for {wait_s} seconds")
+    fail(f"Waited for ok status for {wait_s} seconds, but got {project.status}")
 
 
 def fail(msg):

--- a/docker-app/qfieldcloud/project/models.py
+++ b/docker-app/qfieldcloud/project/models.py
@@ -235,7 +235,9 @@ class Project(models.Model):
         if qgis_project is None:
             return []
 
-        return list(qgis_project.layers.filter(is_localized=True))
+        # filter the layers in Python to avoid an extra query to the database,
+        # since the `QgisLayer` instances are already fetched in memory via `prefetch_related`
+        return [layer for layer in qgis_project.layers.all() if layer.is_localized]
 
     def _get_file_storage_name(self) -> str:
         """Returns the file storage name where all the files are stored. Used by `DynamicStorageFileField` and `DynamicStorageFieldFile`."""

--- a/docker-app/qfieldcloud/project/models.py
+++ b/docker-app/qfieldcloud/project/models.py
@@ -145,6 +145,19 @@ class ProjectQueryset(models.QuerySet):
                     queryset=QgisLayer.objects.order_by("ordering"),
                 )
             )
+            .annotate(
+                unfinished_jobs_count=Count(
+                    "jobs", filter=Q(jobs__status__in=Job.UNFINISHED_STATUS)
+                ),
+                # ideally we have `has_active_create_job`, but `annotate` does not support `Exists`
+                unfinished_create_jobs_count=Count(
+                    "jobs",
+                    filter=Q(
+                        jobs__type=Job.Type.CREATE_PROJECT,
+                        jobs__status__in=Job.UNFINISHED_STATUS,
+                    ),
+                ),
+            )
         )
 
 
@@ -793,10 +806,14 @@ class Project(models.Model):
             # if the project has online vector layers (PostGIS/WFS/etc) we cannot be sure if there are modification or not, so better say there are
             return True
 
+    @property
     def has_active_create_job(self) -> bool:
         """Check if there's an active create_project job."""
         if not hasattr(self, "seed") or self.seed is None:
             return False
+
+        if hasattr(self, "unfinished_create_jobs_count"):
+            return self.unfinished_create_jobs_count > 0
 
         return (
             self.jobs.unfinished()
@@ -811,7 +828,7 @@ class Project(models.Model):
         problems = []
 
         # If there is an active create job, return empty list
-        if self.has_active_create_job():
+        if self.has_active_create_job:
             problems.append(
                 {
                     "layer": None,
@@ -954,12 +971,17 @@ class Project(models.Model):
 
         return problems
 
+    @property
+    def has_unfinished_jobs(self) -> bool:
+        if hasattr(self, "unfinished_jobs_count"):
+            return self.unfinished_jobs_count > 0
+
+        return self.jobs.unfinished().exists()
+
     @cached_property
     def status(self) -> "Project.Status":
         # NOTE the status is NOT stored in the db, because it might be outdated
-        if (
-            self.jobs.unfinished()  # type: ignore
-        ).exists():
+        if self.has_unfinished_jobs:
             return Project.Status.BUSY
         else:
             status = Project.Status.OK

--- a/docker-app/qfieldcloud/project/models.py
+++ b/docker-app/qfieldcloud/project/models.py
@@ -19,7 +19,7 @@ from django.core.validators import (
     RegexValidator,
 )
 from django.db import transaction
-from django.db.models import Case, Exists, F, OuterRef, Q, When
+from django.db.models import Case, Exists, F, OuterRef, Prefetch, Q, When
 from django.db.models import Value as V
 from django.db.models.aggregates import Count, Sum
 from django.shortcuts import get_object_or_404
@@ -128,6 +128,24 @@ class ProjectQueryset(models.QuerySet):
         request and only need a project's id, owner, and public flag.
         """
         return self.only("id", "name", "is_public", "project_type", "owner_id")
+
+    def with_prefetch(self) -> "ProjectQueryset":
+        """A heavier version of the `Project` with all common `select_related` and `prefetch_related` in place."""
+        return (
+            self.defer("project_details")
+            .select_related(
+                "qgis_project",
+                "owner",
+                "owner__useraccount",
+                "the_qgis_file",
+            )
+            .prefetch_related(
+                Prefetch(
+                    "qgis_project__layers",
+                    queryset=QgisLayer.objects.order_by("ordering"),
+                )
+            )
+        )
 
 
 def get_slim_project_or_raise(project_id: uuid.UUID | str | None) -> "Project":

--- a/docker-app/qfieldcloud/project/models.py
+++ b/docker-app/qfieldcloud/project/models.py
@@ -950,7 +950,7 @@ class Project(models.Model):
 
             # TODO use self.problems to get if there are project problems
             if (
-                not self.has_the_qgis_file or not self.project_details
+                not self.has_the_qgis_file or not self.qgis_project
             ) and not self.is_shared_datasets_project:
                 status = Project.Status.FAILED
                 status_code = Project.StatusCode.FAILED_PROCESS_PROJECTFILE

--- a/docker-app/qfieldcloud/project/utils/project_utils.py
+++ b/docker-app/qfieldcloud/project/utils/project_utils.py
@@ -31,9 +31,11 @@ def has_online_vector_data(project: Project) -> bool:
     if qgis_project is None:
         return False
 
-    vector_layers = qgis_project.layers.filter(layer_type=QgsLayerType.Vector)
+    for layer in qgis_project.layers.all():
+        #  skip vector layers
+        if layer.layer_type != QgsLayerType.Vector:
+            continue
 
-    for layer in vector_layers:
         # memory layers are not having a filename, but should not be considered online
         if layer.provider_name == "memory":
             continue

--- a/docker-app/qfieldcloud/project/views.py
+++ b/docker-app/qfieldcloud/project/views.py
@@ -159,7 +159,8 @@ class ProjectViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         projects = (
-            Project.objects.select_related(
+            Project.objects.defer("project_details")
+            .select_related(
                 "qgis_project",
                 "owner",
                 "owner__useraccount",

--- a/docker-app/qfieldcloud/project/views.py
+++ b/docker-app/qfieldcloud/project/views.py
@@ -159,7 +159,12 @@ class ProjectViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         projects = (
-            Project.objects.select_related("qgis_project")
+            Project.objects.select_related(
+                "qgis_project",
+                "owner",
+                "owner__useraccount",
+                "the_qgis_file",
+            )
             .prefetch_related(
                 Prefetch(
                     "qgis_project__layers",

--- a/docker-app/qfieldcloud/project/views.py
+++ b/docker-app/qfieldcloud/project/views.py
@@ -4,7 +4,6 @@ from uuid import UUID
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
-from django.db.models import Prefetch
 from django.http import Http404, StreamingHttpResponse
 from django_filters import rest_framework as filters
 from drf_spectacular.types import OpenApiTypes
@@ -28,7 +27,6 @@ from qfieldcloud.project.filters import ProjectFilterSet
 from qfieldcloud.project.models import (
     Project,
     ProjectSeed,
-    QgisLayer,
     get_slim_project_or_raise,
 )
 from qfieldcloud.project.serializers import (
@@ -158,22 +156,7 @@ class ProjectViewSet(viewsets.ModelViewSet):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     def get_queryset(self):
-        projects = (
-            Project.objects.defer("project_details")
-            .select_related(
-                "qgis_project",
-                "owner",
-                "owner__useraccount",
-                "the_qgis_file",
-            )
-            .prefetch_related(
-                Prefetch(
-                    "qgis_project__layers",
-                    queryset=QgisLayer.objects.order_by("ordering"),
-                )
-            )
-            .for_user(self.request.user)
-        )
+        projects = Project.objects.with_prefetch().for_user(self.request.user)
 
         if self.action == "list":
             # In the list endpoint, by default we filter out public projects.

--- a/docker-app/qfieldcloud/project/views.py
+++ b/docker-app/qfieldcloud/project/views.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
+from django.db.models import Prefetch
 from django.http import Http404, StreamingHttpResponse
 from django_filters import rest_framework as filters
 from drf_spectacular.types import OpenApiTypes
@@ -24,7 +25,12 @@ from qfieldcloud.core.drf_utils import QfcOrderingFilter
 from qfieldcloud.core.models import Job
 from qfieldcloud.project.enums import ProjectRoleOrigins
 from qfieldcloud.project.filters import ProjectFilterSet
-from qfieldcloud.project.models import Project, ProjectSeed, get_slim_project_or_raise
+from qfieldcloud.project.models import (
+    Project,
+    ProjectSeed,
+    QgisLayer,
+    get_slim_project_or_raise,
+)
 from qfieldcloud.project.serializers import (
     ProjectSeedSerializer,
     ProjectSerializer,
@@ -152,7 +158,16 @@ class ProjectViewSet(viewsets.ModelViewSet):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     def get_queryset(self):
-        projects = Project.objects.for_user(self.request.user)
+        projects = (
+            Project.objects.select_related("qgis_project")
+            .prefetch_related(
+                Prefetch(
+                    "qgis_project__layers",
+                    queryset=QgisLayer.objects.order_by("ordering"),
+                )
+            )
+            .for_user(self.request.user)
+        )
 
         if self.action == "list":
             # In the list endpoint, by default we filter out public projects.


### PR DESCRIPTION
Add selecting/prefetching QGIS project and layers. Since we need only the vector layers for now, prefetch only the vector layer on the `QgisProject` instance.

Sample call of GET https://localhost:8002/api/v1/projects/?format=json with 3 projects.

| before | after |
|-|-|
| <img width="353" height="547" alt="image" src="https://github.com/user-attachments/assets/f5a5b1a1-3b70-44cc-80f6-9d971cb03e62" /> | <img width="353" height="547" alt="image" src="https://github.com/user-attachments/assets/d8209765-8025-4911-ae0b-1457fb16c506" /> |
