### PR TITLE
Correct project reference in test case

### DIFF
--- a/docker-app/qfieldcloud/core/tests/test_delta.py
+++ b/docker-app/qfieldcloud/core/tests/test_delta.py
@@ -75,7 +75,7 @@ class QfcTestCase(APITransactionTestCase):
             is_public=False,
             owner=self.user2,
         )
-        self.project1.save()
+        self.project2.save()
 
         self.project3 = Project.objects.create(
             name="project3",


### PR DESCRIPTION
Fix a typo in a test case where the wrong project was being saved. The test was creating `project2` but saving `project1`.