### PR TITLE
feat: harden webdav storage with auth and encode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,11 +97,12 @@ LETSENCRYPT_STAGING=1
 
 # WebDav storage setup with `bytemark/WebDAV` docker image:
 # NOTE: HTTP basic auth user and password must be the same as the WEBDAV_USERNAME and WEBDAV_PASSWORD env variables.
+# NOTE: `webdav_url` must NOT contain embedded credentials (`user:pass@host`), since authentication is performed exclusively via the `basic_auth` option.
 # {
 #     "webdav": {
 #         "BACKEND": "qfieldcloud.filestorage.backend.QfcWebDavStorage",
 #         "OPTIONS": {
-#             "webdav_url": "http://qfc_webdav_user:qfc_webdav_pwd@webdav",
+#             "webdav_url": "http://webdav",
 #             "public_url": "http://webdav",
 #             "basic_auth": "qfc_webdav_user:qfc_webdav_pwd"
 #         }
@@ -115,7 +116,7 @@ LETSENCRYPT_STAGING=1
 #     "webdav_nextcloud": {
 #         "BACKEND": "qfieldcloud.filestorage.backend.QfcWebDavStorage",
 #         "OPTIONS": {
-#             "webdav_url": "https://USERNAME:PASSWORD@my.nextcloud.server/remote.php/dav/files/USERNAME",
+#             "webdav_url": "https://my.nextcloud.server/remote.php/dav/files/USERNAME",
 #             "public_url": "https://my.nextcloud.server/public.php/webdav",
 #             "basic_auth": "NEXTCLOUD_SHARE_TOKEN:"
 #         }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
               "webdav": {
                   "BACKEND": "qfieldcloud.filestorage.backend.QfcWebDavStorage",
                   "OPTIONS": {
-                      "webdav_url": "http://qfc_webdav_user:qfc_webdav_pwd@webdav",
+                      "webdav_url": "http://webdav",
                       "public_url": "http://webdav",
                       "basic_auth": "qfc_webdav_user:qfc_webdav_pwd"
                   }

--- a/docker-app/qfieldcloud/filestorage/backend.py
+++ b/docker-app/qfieldcloud/filestorage/backend.py
@@ -3,12 +3,14 @@ import mimetypes
 import os
 from abc import ABC
 from typing import Any
+from urllib.parse import quote
 
 import requests
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import ContentFile
 from django.core.files.storage import Storage
 from django.http import HttpResponse
+from requests.auth import HTTPBasicAuth
 from storages.backends.s3 import S3Storage
 
 from qfieldcloud.filestorage.constants import VERSION_SUFFIX_REGEX
@@ -99,8 +101,6 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
     """
 
     def __init__(self, **options):
-        self.requests = self.get_requests_session(**options)
-
         self.webdav_url = options.get("webdav_url")
         if not self.webdav_url:
             raise ImproperlyConfigured("Please define the `webdav_url` storage option")
@@ -112,6 +112,8 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
         self.basic_auth = options.get("basic_auth")
         if not self.basic_auth:
             raise ImproperlyConfigured("Please define the `basic_auth` storage option")
+
+        self.requests = self.get_requests_session(**options)
 
     def check_status(self) -> bool:
         """Checks if the WebDAV storage is reachable.
@@ -129,8 +131,14 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
     def get_requests_session(self, **kwargs) -> requests.Session:
         """
         Creates a HTTP session for requesting webdav later.
+        Authenticates using the `basic_auth` storage option.
         """
-        return requests.Session()
+        session = requests.Session()
+
+        username, _, password = self.basic_auth.partition(":")
+        session.auth = HTTPBasicAuth(username, password)
+
+        return session
 
     def perform_webdav_request(
         self, method: str, name: str, *args, **kwargs
@@ -152,6 +160,16 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
 
         return response
 
+    def encode_webdav_path(self, name: str) -> str:
+        """
+        Encodes each segment of a relative file path.
+        """
+        segments = []
+        for segment in name.split("/"):
+            segments.append(quote(segment, safe=""))
+
+        return "/".join(segments)
+
     def get_webdav_url(self, name: str) -> str:
         """Returns the HTTP url for a webdav file.
 
@@ -161,7 +179,8 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
         Returns:
             HTTP url for the file.
         """
-        return self.webdav_url.rstrip("/") + "/" + name.lstrip("/")
+        encoded_name = self.encode_webdav_path(name.lstrip("/"))
+        return self.webdav_url.rstrip("/") + "/" + encoded_name
 
     def get_public_url(self, name: str) -> str:
         """Returns the public HTTP url for a webdav file.
@@ -172,7 +191,8 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
         Returns:
             Public HTTP url for the file.
         """
-        return self.public_url.rstrip("/") + "/" + name.lstrip("/")
+        encoded_name = self.encode_webdav_path(name.lstrip("/"))
+        return self.public_url.rstrip("/") + "/" + encoded_name
 
     def _open(self, name: str, mode: str = "rb") -> ContentFile:
         """Reads the content of a file from the configured webdav storage.
@@ -218,14 +238,15 @@ class QfcWebDavStorage(QfcBackendStorageMixin, Storage):
         coll_path = self.webdav_url
 
         for directory in name.split("/")[:-1]:
-            col = os.path.join(coll_path, directory, "")
+            encoded_directory = quote(directory, safe="")
+            col = os.path.join(coll_path, encoded_directory, "")
             resp = self.requests.head(col)
 
             if not resp.ok:
                 resp = self.requests.request("MKCOL", col)
                 resp.raise_for_status()
 
-            coll_path = os.path.join(coll_path, directory)
+            coll_path = os.path.join(coll_path, encoded_directory)
 
     def delete(self, name: str) -> None:
         """Deletes a file from a configured webdav storage.

--- a/docker-app/qfieldcloud/filestorage/tests/test_webdav.py
+++ b/docker-app/qfieldcloud/filestorage/tests/test_webdav.py
@@ -65,3 +65,22 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
         response = self._delete_file(self.u1, self.p1, "file.name")
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_upload_then_download_file_with_spaces(self):
+        # 1) first upload of the file
+        response = self._upload_file(
+            self.u1, self.p1, "file name with spaces.txt", StringIO("Hello!")
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(self.p1.project_files.count(), 1)
+        self.assertEqual(
+            self.p1.get_file("file name with spaces.txt").versions.count(), 1
+        )
+
+        # 2) download file
+        response = self._download_file(self.u1, self.p1, "file name with spaces.txt")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsInstance(response, FileResponse)
+        self.assertEqual(b"".join(response.streaming_content), b"Hello!")


### PR DESCRIPTION
This PR intends to make QFieldCloud's WebDAV storage backend more robust and resilient:

- encode URLs for files that may contain spaces and special characters.
- revamp how HTTP auth is declared in the environment. Note that the credentials **must** not be present in the `webdav_url` option anymore.