### PR TITLE
Change "filename" in job feedback from absolute to relative path

### DIFF
--- a/docker-qgis/qfc_worker/utils.py
+++ b/docker-qgis/qfc_worker/utils.py
@@ -51,6 +51,8 @@ from tabulate import tabulate
 # Get environment variables
 JOB_ID = os.environ.get("JOB_ID")
 
+PROJECT_DOWNLOAD_DIR = "/tmp/project"
+
 # Network timeout for QGIS. Reduced from default 60 seconds to fail fast
 # when layers are unreachable (e.g. network outage, blocked external access).
 # This prevents long blocking delays when loading project file.
@@ -501,8 +503,18 @@ def download_project(
     logging.info("Preparing a temporary directory for project files…")
 
     if not destination:
-        # Create a temporary directory
-        destination = Path(tempfile.mkdtemp())
+        destination = Path(PROJECT_DOWNLOAD_DIR)
+        """Download the project files in the project "working" directory from the Object storage.
+
+        The destination may be passed as destination or will be a fixed temporary directory (PROJECT_DOWNLOAD_DIR).
+        Return:
+        the directory path
+        """
+        destination.mkdir(parents=True, exist_ok=True)
+
+    assert destination.is_dir() and not any(destination.iterdir()), (
+        f"Destination directory {destination} must exist and be empty!"
+    )
 
     # Create a local working directory
     working_dir = destination.joinpath("files")
@@ -816,6 +828,9 @@ def get_layers_data(project: QgsProject) -> dict[str, dict]:
                 )
         else:
             fields = None
+
+        if filename:
+            filename = filename.removeprefix(PROJECT_DOWNLOAD_DIR)
 
         # Must be kept in sync with `LayerDetails` in `qfieldcloud/project/type_defs.py`, which consumes this data structure.
         # WARNING: this shape has evolved over time, so feedback stored by older jobs is not guaranteed to match it.

--- a/docker-qgis/qfc_worker/workflow.py
+++ b/docker-qgis/qfc_worker/workflow.py
@@ -2,7 +2,6 @@ import inspect
 import io
 import json
 import sys
-import tempfile
 import traceback
 import uuid
 from collections.abc import Callable
@@ -18,6 +17,7 @@ from qfc_worker.exceptions import (
     WorkflowModificationException,
     WorkflowValidationException,
 )
+from qfc_worker.utils import PROJECT_DOWNLOAD_DIR
 
 
 class Workflow:
@@ -246,7 +246,8 @@ def run_workflow(
     step_returns = {}
 
     try:
-        root_workdir = Path(tempfile.mkdtemp())
+        root_workdir = Path(PROJECT_DOWNLOAD_DIR)
+        root_workdir.mkdir(parents=True, exist_ok=True)
         for step in workflow.steps:
             with logger_context(step):
                 arguments = {


### PR DESCRIPTION
`filename` in job feedback previously contained the full temporary path instead of just the relative path.
This PR extracts the download directory into a `PROJECT_DOWNLOAD_DIR` constant, defined where the worker already handles file downloads, and use it to strip the beginning of the path from `filename`