### PR TITLE
Update file storage migration to ensure correct order of migrations

### DIFF
--- a/docker-app/qfieldcloud/filestorage/migrations/0002_file_file_storage.py
+++ b/docker-app/qfieldcloud/filestorage/migrations/0002_file_file_storage.py
@@ -42,6 +42,13 @@ class Migration(migrations.Migration):
         ("core", "0082_project_attachments_file_storage"),
     ]
 
+    # `set_file_storage_for_files` reads the `core_project` table by its original name via raw
+    # SQL. `core.0104_alter_projectcollaborator_project_and_more` renames it to `project_project`,
+    # so this must be pinned to run before that rename rather than relying on incidental ordering.
+    run_before = [
+        ("core", "0104_alter_projectcollaborator_project_and_more"),
+    ]
+
     operations = [
         migrations.AddField(
             model_name="file",


### PR DESCRIPTION
> Linked with:
> - https://github.com/opengisch/QFieldCloud/pull/1796

`filestorage.0002_file_file_storage` reads the `core_project` table by its original name via raw SQL.
`core.0104_alter_projectcollaborator_project_and_more` later renames that table to `project_project`.
These two migrations had no dependency edge between them e.g `filestorage.0002` only happened to run before the rename by coincidence of Django's migration plan, not because anything enforced it. This PR fixes this by adding `run_before` in the migration.