### PR TITLE
Use the correct QGIS worker image when cloning a project

### DIFF
--- a/docker-app/qfieldcloud/core/tests/test_jobs.py
+++ b/docker-app/qfieldcloud/core/tests/test_jobs.py
@@ -625,6 +625,58 @@ class QfcTestCase(QfcFilesTestCaseMixin, APITransactionTestCase):
 
         self.assertEqual(cloned_project.qgis_project.crs, self.p1.qgis_project.crs)
 
+    def test_clone_project_uses_source_qgis_version_for_worker_image(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.t1.key)
+
+        ProjectSeed.objects.create(
+            project=self.p1,
+            extent=Polygon.from_bbox(projectseed_utils.DEFAULT_PROJECT_EXTENT),
+            settings={
+                "schemaId": ProjectSeed.SETTINGS_SCHEMA_ID,
+                "basemaps": [],
+                "xlsform": None,
+            },
+        )
+
+        Job.objects.create(
+            project=self.p1,
+            type=Job.Type.CREATE_PROJECT,
+            created_by=self.u1,
+        )
+
+        wait_for_project_ok_status(self.p1)
+
+        # Force the source project to look like it was last saved with QGIS 4,
+        # so the clone's worker image selection has a QGIS 4 version to inherit.
+        self.p1.qgis_version = "4.2.1"
+        self.p1.save(update_fields=["qgis_version"])
+
+        cloned_project = Project.objects.create(name="cloned_project", owner=self.u1)
+
+        ProjectSeed.objects.create(
+            project=cloned_project,
+            clone_from_project=self.p1,
+            settings={
+                "schemaId": ProjectSeed.SETTINGS_SCHEMA_ID,
+                "basemaps": [],
+                "xlsform": None,
+            },
+        )
+
+        job = Job.objects.create(
+            project=cloned_project,
+            type=Job.Type.CREATE_PROJECT,
+            created_by=self.u1,
+        )
+
+        wait_for_project_ok_status(cloned_project)
+
+        job.refresh_from_db()
+
+        # `Job.qgis_version` reports the QGIS app version that actually ran the
+        # job, so this confirms the worker was spawned from the QGIS 4 image.
+        self.assertTrue(job.qgis_version.startswith("4."))
+
     def test_process_projectfile_job_sets_the_qgis_version(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.t1.key)
 

--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -715,6 +715,37 @@ class CreateProjectJobRun(JobRun):
         "%(project__id)s",
     ]
 
+    def get_qgis_image(self) -> str:
+        """Picks the QGIS image with the version of the clone project.
+
+        If the clone project doesn't have one, uses the source project's QGIS version.
+
+        A clone's own `qgis_version` is still unset at this point, so
+        without this, we'd always fall through to `JobRun.get_qgis_image()`'s
+        QGIS 3 default instead of matching the source project's version.
+        """
+        clone_from_project = None
+        if hasattr(self.job.project, "seed"):
+            clone_from_project = self.job.project.seed.clone_from_project
+
+        if (
+            self.job.project.qgis_version
+            or not clone_from_project
+            or not clone_from_project.qgis_version
+        ):
+            return super().get_qgis_image()
+
+        qgis_major_project_version = get_qgis_major_version(
+            clone_from_project.qgis_version
+        )
+
+        if qgis_major_project_version not in self.qgis_images:
+            raise JobException(
+                f"Unsupported QGIS major version {qgis_major_project_version} for project {self.job.project.id} cloned from project {clone_from_project.id} stored with {clone_from_project.qgis_version}."
+            )
+
+        return self.qgis_images[qgis_major_project_version]
+
 
 def cancel_orphaned_workers() -> None:
     client: docker.client.DockerClient = docker.from_env()


### PR DESCRIPTION
Cloning a project always ran its `CREATE_PROJECT` job under QGIS 3, regardless of the source project's actual QGIS version, because the clone's own `qgis_version` is still unset at that point, so the worker image selection fell back to the QGIS 3 default every time.

This PR fixes this by getting the QGIS version from the source project.

Changes:
- Add `resolve_project_qgis_version()`, which falls back to the clone source's `qgis_version` when the project's own is unset
- Use it in `JobRun.get_qgis_image()` instead of reading `project.qgis_version` directly
- Add tests covering the own-version, clone-fallback, and unknown-version cases