### PR TITLE
Ensure `ordered_layer_ids` defaults to an empty list if not provided

### DIFF
--- a/docker-app/qfieldcloud/project/models.py
+++ b/docker-app/qfieldcloud/project/models.py
@@ -1248,7 +1248,7 @@ class QgisProjectQueryset(models.QuerySet):
         )
 
         layers_by_id = details.get("layers_by_id") or {}
-        ordered_layer_ids = details.get("ordered_layer_ids")
+        ordered_layer_ids = details.get("ordered_layer_ids") or []
 
         QgisLayer.objects.update_from_details(  # type: ignore[attr-defined]
             qgis_project, ordered_layer_ids, layers_by_id


### PR DESCRIPTION
When we use `update_from_details` in `QgisProjectQueryset` we have a fallback for `layers_by_id` but we didn't have one for `ordered_layer_ids` and because of this there is a chance that we get `TypeError: 'NoneType' object is not iterable`.
This PR fixes this issue.