### PR TITLE
Handle exceptions during project backfill migration

### DIFF
--- a/docker-app/qfieldcloud/project/management/commands/backfill_project_details.py
+++ b/docker-app/qfieldcloud/project/management/commands/backfill_project_details.py
@@ -66,10 +66,13 @@ class Command(BaseCommand):
             if dry_run:
                 continue
 
-            with transaction.atomic():
-                result = backfill_qgis_project(project)
+            try:
+                with transaction.atomic():
+                    result = backfill_qgis_project(project)
 
-            counts[result] += 1
+                counts[result] += 1
+            except Exception as err:  # noqa: BLE001
+                print(f'Failed project migration "{project.id}": {str(err)}')
 
         if dry_run:
             print(


### PR DESCRIPTION
Catch and log per-project failures in `backfill_project_details` so one dangerous project (e.g. an oversized `qgis_layer_id` blowing the unique index) doesn't abort the entire backfill run.