### PR TITLE
Use user's saved timezone instead of always falling back to server default

### DIFF
--- a/docker-app/qfieldcloud/core/middleware/timezone.py
+++ b/docker-app/qfieldcloud/core/middleware/timezone.py
@@ -11,6 +11,7 @@ class TimezoneMiddleware:
     def __call__(self, request):
         if request.user.is_authenticated and hasattr(request.user, "useraccount"):
             user_tz = request.user.useraccount.timezone
+            assert user_tz, "UserAccount.timezone must not be empty"
         elif settings.TIME_ZONE:
             user_tz = zoneinfo.ZoneInfo(settings.TIME_ZONE)
         else:

--- a/docker-app/qfieldcloud/core/middleware/timezone.py
+++ b/docker-app/qfieldcloud/core/middleware/timezone.py
@@ -11,7 +11,9 @@ class TimezoneMiddleware:
     def __call__(self, request):
         if request.user.is_authenticated and hasattr(request.user, "useraccount"):
             user_tz = request.user.useraccount.timezone
+
             assert user_tz, "UserAccount.timezone must not be empty"
+
         elif settings.TIME_ZONE:
             user_tz = zoneinfo.ZoneInfo(settings.TIME_ZONE)
         else:

--- a/docker-app/qfieldcloud/core/middleware/timezone.py
+++ b/docker-app/qfieldcloud/core/middleware/timezone.py
@@ -9,9 +9,7 @@ class TimezoneMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        if request.user.is_authenticated and hasattr(
-            request.user.useraccount, "useraccount"
-        ):
+        if request.user.is_authenticated and hasattr(request.user, "useraccount"):
             user_tz = request.user.useraccount.timezone
         elif settings.TIME_ZONE:
             user_tz = zoneinfo.ZoneInfo(settings.TIME_ZONE)

--- a/docker-app/qfieldcloud/core/middleware/timezone.py
+++ b/docker-app/qfieldcloud/core/middleware/timezone.py
@@ -13,7 +13,6 @@ class TimezoneMiddleware:
             user_tz = request.user.useraccount.timezone
 
             assert user_tz, "UserAccount.timezone must not be empty"
-
         elif settings.TIME_ZONE:
             user_tz = zoneinfo.ZoneInfo(settings.TIME_ZONE)
         else:

--- a/docker-app/qfieldcloud/core/tests/test_middleware.py
+++ b/docker-app/qfieldcloud/core/tests/test_middleware.py
@@ -1,0 +1,41 @@
+import logging
+
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
+from django.utils import timezone
+from rest_framework.test import APITransactionTestCase
+
+from qfieldcloud.core.middleware.timezone import TimezoneMiddleware
+from qfieldcloud.core.models import Person
+
+logging.disable(logging.CRITICAL)
+
+
+class QfcTestCase(APITransactionTestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def get_response(self, request):
+        return None
+
+    def test_activates_authenticated_users_saved_timezone(self):
+        u1 = Person.objects.create(username="u1")
+        u1.useraccount.timezone = "Europe/Sofia"
+        u1.useraccount.save()
+
+        request = self.factory.get("/")
+        request.user = u1
+
+        TimezoneMiddleware(self.get_response)(request)
+
+        self.assertEqual(str(timezone.get_current_timezone()), "Europe/Sofia")
+
+    def test_falls_back_to_server_timezone_for_anonymous_user(self):
+        request = self.factory.get("/")
+        request.user = AnonymousUser()
+
+        TimezoneMiddleware(self.get_response)(request)
+
+        self.assertEqual(
+            str(timezone.get_current_timezone()), str(timezone.get_default_timezone())
+        )

--- a/docker-app/qfieldcloud/core/tests/test_middleware.py
+++ b/docker-app/qfieldcloud/core/tests/test_middleware.py
@@ -7,12 +7,14 @@ from rest_framework.test import APITransactionTestCase
 
 from qfieldcloud.core.middleware.timezone import TimezoneMiddleware
 from qfieldcloud.core.models import Person
+from qfieldcloud.core.tests.utils import setup_subscription_plans
 
 logging.disable(logging.CRITICAL)
 
 
 class QfcTestCase(APITransactionTestCase):
     def setUp(self):
+        setup_subscription_plans()
         self.factory = RequestFactory()
 
     def get_response(self, request):


### PR DESCRIPTION
`TimezoneMiddleware` checked `hasattr(request.user.useraccount, "useraccount")`,
which is always `False` since useraccount is a reverse accessor on User. As a result every request rendered timestamps in the server's `TIME_ZONE` instead of the viewer's profile timezone.

This PR fixes this and adds tests for it.