### PR TITLE
Update active users retrieval to use organization context

### DIFF
--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -732,7 +732,7 @@ class AbstractSubscription(models.Model):
             return None
 
         if self.has_current_period:
-            return self.account.user.active_users(
+            return self.account.user.organization.active_users(
                 self.current_period_since,
                 self.current_period_until,
             )


### PR DESCRIPTION
This PR fixes computing `active_users` and `active_users_count`, because before this fix, computing `active_users` for an organization crashed with:
```
AttributeError: 'User' object has no attribute 'active_users'
```