### PR TITLE
Enforce a hard limit on the users list endpoint

### DIFF
--- a/docker-app/qfieldcloud/core/tests/test_user.py
+++ b/docker-app/qfieldcloud/core/tests/test_user.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from django.db import IntegrityError
 from django.utils import timezone
 from rest_framework import status
@@ -163,6 +164,20 @@ class QfcTestCase(APITestCase):
         self.assertEqual(json[1]["username"], "user1")
         self.assertEqual(json[2]["username"], "user2")
         self.assertEqual(json[3]["username"], "user3")
+
+    def test_list_users_is_hard_limited(self):
+        """The users endpoint must never return more than `USER_LIST_LIMIT` users, so it cannot be used to enumerate the whole user base."""
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
+
+        # Create enough extra users so that the total matching `?q=user`
+        # exceeds the hard limit.
+        for i in range(settings.USER_LIST_LIMIT + 10):
+            Person.objects.create_user(username=f"listlimituser{i}", password="abc123")
+
+        response = self.client.get("/api/v1/users/?q=user")
+
+        self.assertTrue(status.is_success(response.status_code))
+        self.assertEqual(len(response.json()), settings.USER_LIST_LIMIT)
 
     def test_list_users_filter_exclude_organization(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)

--- a/docker-app/qfieldcloud/core/views/users_views.py
+++ b/docker-app/qfieldcloud/core/views/users_views.py
@@ -1,7 +1,8 @@
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from drf_spectacular.utils import extend_schema, extend_schema_view
-from qfieldcloud.core import pagination, permissions_utils, querysets_utils
+from qfieldcloud.core import permissions_utils, querysets_utils
 from qfieldcloud.core.models import Organization, Team
 from qfieldcloud.core.serializers import (
     CompleteUserSerializer,
@@ -31,7 +32,9 @@ class ListCreateUsersViewPermissions(permissions.BasePermission):
 class ListCreateUsersView(generics.ListCreateAPIView):
     serializer_class = PublicInfoUserSerializer
     permission_classes = [permissions.IsAuthenticated, ListCreateUsersViewPermissions]
-    pagination_class = pagination.QfcLimitOffsetPagination()
+    # This view is intentionally not paginated, `get_queryset` enforces a hard
+    # `USER_LIST_LIMIT` so a single request can never be used to enumerate the whole user base.
+    pagination_class = None
 
     def get_queryset(self):
         params = self.request.GET
@@ -76,7 +79,7 @@ class ListCreateUsersView(generics.ListCreateAPIView):
             exclude_organizations=exclude_organizations,
             exclude_teams=exclude_teams,
             invert=invert,
-        )
+        )[: settings.USER_LIST_LIMIT]
 
     def post(self, request):
         serializer = CreateUserSerializer(data=request.data)

--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -697,6 +697,9 @@ QFIELDCLOUD_ADMIN_EXACT_COUNT_LIMIT = 10000
 # Default limit for paginating data from views using QfcLimitOffsetPagination
 QFIELDCLOUD_API_DEFAULT_PAGE_LIMIT = 50
 
+# Max number of users returned by the `/api/v1/users/` list endpoint.
+USER_LIST_LIMIT = 20
+
 APPLY_DELTAS_LIMIT = 1000
 
 # The value of the "source" key in each logger entry.


### PR DESCRIPTION
GET `/api/v1/users/` is readable by any authenticated user and its `q` parameter matches usernames anywhere in the string. The view was only paginated when the client asked for it, so a request without pagination params returned every matching row, letting anyone enumerate the whole user base (username, type, filename, avatar_url, username_display) in a handful of queries.

- add `USER_LIST_LIMIT = 20` setting
- drop pagination on `ListCreateUsersView`
- cap `get_queryset` at `USER_LIST_LIMIT`, keeping the existing relevance ordering
- add a test asserting the endpoint never returns more than the limit