### PR TITLE
Fix CI for building `qfieldcloud-qgis4` image with QGIS 4 installed instead of QGIS 3

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -122,6 +122,7 @@ jobs:
           COMPOSE_SERVICE: ${{ matrix.services.compose_service }}
           DEBUG: "0"
         run: |
+          cp .env.example .env
           {
             echo 'build_args<<EOF'
             docker compose -f docker-compose.yml config --format json \

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -121,8 +121,9 @@ jobs:
         env:
           COMPOSE_SERVICE: ${{ matrix.services.compose_service }}
           DEBUG: "0"
+          QFIELDCLOUD_WORKER_REPLICAS: "1"
+          TMP_DIRECTORY: /tmp
         run: |
-          cp .env.example .env
           {
             echo 'build_args<<EOF'
             docker compose -f docker-compose.yml config --format json \

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -122,6 +122,7 @@ jobs:
           COMPOSE_SERVICE: ${{ matrix.services.compose_service }}
           DEBUG: "0"
           QFIELDCLOUD_WORKER_REPLICAS: "1"
+          TMP_DIRECTORY: /tmp
         run: |
           {
             echo 'build_args<<EOF'

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -122,7 +122,6 @@ jobs:
           COMPOSE_SERVICE: ${{ matrix.services.compose_service }}
           DEBUG: "0"
           QFIELDCLOUD_WORKER_REPLICAS: "1"
-          TMP_DIRECTORY: /tmp
         run: |
           {
             echo 'build_args<<EOF'


### PR DESCRIPTION
Without a `QFIELDCLOUD_WORKER_REPLICAS` and `TMP_DIRECTORY`, `docker compose config` fails on unset vars, so the resolve step yielded empty build-args and the Dockerfile fell back to its QGIS 3 defaults and the published qgis4 image shipped QGIS 3.44.