### PR TITLE
fix: use advisory lock to prevent deadlock when immediate and scheduled changes get triggered at one time

### DIFF
--- a/docker-app/qfieldcloud/core/utils2/db.py
+++ b/docker-app/qfieldcloud/core/utils2/db.py
@@ -1,6 +1,9 @@
+import zlib
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import TypeVar
 
-from django.db import models
+from django.db import models, transaction
 
 Model = TypeVar("Model", bound=models.Model)
 
@@ -17,3 +20,43 @@ def get_or_none(
         return queryset.get(**kwargs)
     except model.DoesNotExist:
         return None
+
+
+@contextmanager
+def advisory_lock(lock_name: str, lock_timeout: str = "20s") -> Iterator[None]:
+    """
+    Makes transactions that name the same resource run one at a time.
+
+    Reserves a name rather than locking table rows. The first transaction to
+    claim a name holds it until it ends; others wait. Only works if every code
+    path touching the resource uses the same name.
+
+    See https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS
+
+    Args:
+        lock_name: identifier of the guarded resource, e.g. `billing:account:42`.
+        lock_timeout: how long to wait before giving up, as a PostgreSQL interval.
+
+    Raises:
+        RuntimeError: if called outside a transaction, where the lock would be
+            released immediately and protect nothing.
+        django.db.utils.OperationalError: if `lock_timeout` expires (pgcode `55P03`).
+
+    Note:
+        The lock is released when the outermost transaction ends, which may be
+        later than the exit of this block.
+    """
+    connection = transaction.get_connection()
+
+    if not connection.in_atomic_block:
+        raise RuntimeError(
+            "`advisory_lock` must be used inside `transaction.atomic()`."
+        )
+
+    lock_id = zlib.crc32(lock_name.encode())
+
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT set_config('lock_timeout', %s, true)", [lock_timeout])
+        cursor.execute("SELECT pg_advisory_xact_lock(%s)", [lock_id])
+
+    yield

--- a/docker-app/qfieldcloud/subscription/models.py
+++ b/docker-app/qfieldcloud/subscription/models.py
@@ -18,6 +18,7 @@ from django.utils.translation import gettext as _
 from model_utils.managers import InheritanceManagerMixin
 
 from qfieldcloud.core.models import Organization, Person, User, UserAccount
+from qfieldcloud.core.utils2.db import advisory_lock
 from qfieldcloud.subscription.exceptions import NotPremiumPlanException
 
 logger = logging.getLogger(__name__)
@@ -557,6 +558,7 @@ class SubscriptionManager(models.Manager):
 
 class AbstractSubscription(models.Model):
     id: int
+    account_id: int
 
     class Meta:
         abstract = True
@@ -915,29 +917,33 @@ class AbstractSubscription(models.Model):
             return subscription
 
         with transaction.atomic():
-            cls.objects.select_for_update().get(id=subscription.id)  # type: ignore
-            update_fields = []
+            # Using advisory lock to prevent deadlock between concurrent updates in some rare edge cases
+            with advisory_lock(f"billing:account:{subscription.account_id}"):
+                cls.objects.select_for_update().get(id=subscription.id)  # type: ignore
+                update_fields = []
 
-            if (
-                subscription.active_since is None
-                and kwargs.get("active_since") is not None
-            ):
-                cls.objects.current().filter(
-                    account=subscription.account,
-                ).exclude(  # type: ignore
-                    pk=subscription.pk,
-                ).update(
-                    status=Subscription.Status.INACTIVE_CANCELLED,
-                    active_until=kwargs["active_since"],
+                if (
+                    subscription.active_since is None
+                    and kwargs.get("active_since") is not None
+                ):
+                    cls.objects.current().filter(
+                        account=subscription.account,
+                    ).exclude(  # type: ignore
+                        pk=subscription.pk,
+                    ).update(
+                        status=Subscription.Status.INACTIVE_CANCELLED,
+                        active_until=kwargs["active_since"],
+                    )
+
+                for attr_name, attr_value in kwargs.items():
+                    update_fields.append(attr_name)
+                    setattr(subscription, attr_name, attr_value)
+
+                logger.info(
+                    f"Updated subscription's fields: {', '.join(update_fields)}"
                 )
 
-            for attr_name, attr_value in kwargs.items():
-                update_fields.append(attr_name)
-                setattr(subscription, attr_name, attr_value)
-
-            logger.info(f"Updated subscription's fields: {', '.join(update_fields)}")
-
-            subscription.save(update_fields=update_fields)
+                subscription.save(update_fields=update_fields)
 
         return subscription
 


### PR DESCRIPTION
When trying to change a subscription with one immediate change and one scheduled change e.g add 1 seat and decrease 1 storage package, we get a deadlock error.

This is caused by a subscription is being modified locally while a webhook is also received, they both race to modify the local instance. So the deadlock happens, since they wait for each other to release the row lock from select_for_update in a loop.

- Added `advisory_lock` context manager wrapping `pg_advisory_xact_lock`, and use it in `update_subscription` keyed on the account, Transactions naming the same account now queue behind one another, so there is a single lock to wait on and no cycle can form see [FUNCTIONS-ADVISORY-LOCKS](https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS)