### PR TITLE
feat: add project warning if a layer datasource contains hardcoded pg credentials

### DIFF
--- a/docker-app/qfieldcloud/project/models.py
+++ b/docker-app/qfieldcloud/project/models.py
@@ -979,6 +979,28 @@ class Project(models.Model):
                                 ),
                             }
                         )
+
+                # add a warning if a pg layer has a hard-coded user or pwd in the datasource
+                if layer.provider_name == "postgres" and (
+                    "user=" in layer.datasource or "password=" in layer.datasource
+                ):
+                    problems.append(
+                        {
+                            "layer": layer_name,
+                            "level": "warning",
+                            "code": "hardcoded_pg_credentials",
+                            "description": _(
+                                _(
+                                    'Layer "{}" has hard-coded postgres credentials in the datasource.'
+                                )
+                            ).format(layer_name),
+                            "solution": _(
+                                _(
+                                    "Consider using a pg_service entry and a QFieldCloud Secret instead."
+                                )
+                            ),
+                        }
+                    )
         else:
             problems.append(
                 {

--- a/docker-app/qfieldcloud/project/models.py
+++ b/docker-app/qfieldcloud/project/models.py
@@ -991,7 +991,7 @@ class Project(models.Model):
                             "code": "hardcoded_pg_credentials",
                             "description": _(
                                 _(
-                                    'Layer "{}" has hard-coded postgres credentials in the datasource.'
+                                    'Layer "{}" has a hard-coded postgres credentials in the datasource.'
                                 )
                             ).format(layer_name),
                             "solution": _(


### PR DESCRIPTION
Since the go-to way for PostGIS layers in QGIS / QFieldCloud is to use `pg_service` entries and QFC Secrets, this PR intends to add a warning to a QFieldCloud Project that contains hard-coded pg `user` or `password` values in the `datasource` definition.

Within QGIS, to create such a layer with hard-coded pg user and password in the datasource, run the following `pyqgis` code e.g. in QGIS's python console:

```python
uri = QgsDataSourceUri()
uri.setConnection("the_pg_host", "the_pg_port", "the_pg_dbname", "the_pg_username", "the_pg_password")
uri.setDataSource("the_pg_schema", "the_pg_table", "geom", "", "id")
layer = QgsVectorLayer(uri.uri(False), "the_qgis_layer_name", "postgres")
QgsProject.instance().addMapLayer(layer)
```