### PR TITLE
Don't cause `500` error on admin when a delta can't be applied

### DIFF
--- a/docker-app/qfieldcloud/core/admin.py
+++ b/docker-app/qfieldcloud/core/admin.py
@@ -53,7 +53,6 @@ from invitations.admin import InvitationAdmin as InvitationAdminBase
 from invitations.utils import get_invitation_model
 from rest_framework.authtoken.models import TokenProxy
 
-from qfieldcloud.core import exceptions
 from qfieldcloud.core.models import (
     ApplyJob,
     ApplyJobDelta,
@@ -1393,8 +1392,8 @@ class DeltaAdmin(QFieldCloudModelAdmin):
 
     def apply_delta(self, request, delta):
         if not delta.project.has_the_qgis_file:
-            self.message_user(request, "Missing project file")
-            raise exceptions.NoQGISProjectError()
+            self.message_user(request, "Missing project file", level=messages.ERROR)
+            return HttpResponseRedirect(".")
 
         if not jobs.apply_deltas(
             delta.project,
@@ -1403,8 +1402,13 @@ class DeltaAdmin(QFieldCloudModelAdmin):
             delta.project.overwrite_conflicts,
             delta_ids=[str(delta.id)],
         ):
-            self.message_user(request, "No deltas to apply")
-            raise exceptions.NoDeltasToApplyError()
+            self.message_user(
+                request,
+                "No deltas to apply. The delta is likely not in PENDING status, "
+                "is already part of a running apply job, or the project owner is not allowed to create jobs.",
+                level=messages.ERROR,
+            )
+            return HttpResponseRedirect(".")
 
         self.message_user(request, "Delta application started")
 


### PR DESCRIPTION
Clicking "Apply delta" on a delta in the Django admin raised `NoQGISProjectError` or `NoDeltasToApplyError`, which bubbled up as a 500 error page instead of telling the user what went wrong.

Both cases now add an error message and redirect back to the change page. The "no deltas" message also lists the usual reasons: the delta isn't in `PENDING` status, it's already part of a running apply job, or the project owner can't create jobs.

UI:
<img width="1236" height="485" alt="image" src="https://github.com/user-attachments/assets/8f467944-6af6-4079-8d74-992ff4b9adba" />
