### PR TITLE
fix: Worker cleanup by environment and compose project

### DIFF
--- a/docker-app/qfieldcloud/settings.py
+++ b/docker-app/qfieldcloud/settings.py
@@ -57,6 +57,7 @@ if DEBUG:
     ]
 
 ENVIRONMENT = os.environ["ENVIRONMENT"]
+COMPOSE_PROJECT_NAME = os.environ["COMPOSE_PROJECT_NAME"]
 
 # 'DJANGO_ALLOWED_HOSTS' should be a single string of hosts with a space between each.
 # For example: 'DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 [::1]'

--- a/docker-app/worker_wrapper/wrapper.py
+++ b/docker-app/worker_wrapper/wrapper.py
@@ -442,7 +442,9 @@ class JobRun:
             mem_limit=config.WORKER_QGIS_MEMORY_LIMIT,
             cpu_shares=config.WORKER_QGIS_CPU_SHARES,
             labels={
-                "app": f"{settings.ENVIRONMENT}_worker",
+                "qfieldcloud.role": "worker",
+                "qfieldcloud.environment": settings.ENVIRONMENT,
+                "qfieldcloud.compose_project_name": settings.COMPOSE_PROJECT_NAME,
                 "type": self.job.type,
                 "job_id": str(self.job.id),
                 "project_id": str(self.job.project_id),
@@ -721,7 +723,13 @@ def cancel_orphaned_workers() -> None:
 
     try:
         running_workers: list[Container] = client.containers.list(
-            filters={"label": f"app={settings.ENVIRONMENT}_worker"},
+            filters={
+                "label": [
+                    "qfieldcloud.role=worker",
+                    f"qfieldcloud.environment={settings.ENVIRONMENT}",
+                    f"qfieldcloud.compose_project_name={settings.COMPOSE_PROJECT_NAME}",
+                ],
+            },
         )
     except docker.errors.NotFound:
         # We don't mind empty references since they mean there is no


### PR DESCRIPTION
Label QGIS worker containers with the compose project name and use it together with the environment when finding orphaned workers. This prevents one QFieldCloud stack from killing workers owned by another stack on the same Docker host.