### PR TITLE
Return the teams that the caller is a member of within the owning organization on project retrieve

### DIFF
--- a/docker-app/qfieldcloud/project/serializers.py
+++ b/docker-app/qfieldcloud/project/serializers.py
@@ -6,6 +6,7 @@ from rest_framework.exceptions import ValidationError
 
 from qfieldcloud.core import exceptions
 from qfieldcloud.core.models import (
+    Team,
     User,
 )
 from qfieldcloud.project.models import (
@@ -244,6 +245,41 @@ class ProjectSerializer(serializers.ModelSerializer):
             "overwrite_conflicts",
         }
         model = Project
+
+
+class ProjectDetailSerializer(ProjectSerializer):
+    """`ProjectSerializer` with the caller's teams in the project owning organization."""
+
+    teams = serializers.SerializerMethodField()
+
+    def get_teams(self, obj: Project) -> list[str]:
+        """Returns the caller's team names in the project's owning organization, without the `@organization/` prefix.
+
+        Empty when a person owns the project or the caller is in no team.
+        """
+        # A person owns the project, so it has no teams.
+        if obj.owner.is_person:
+            return []
+
+        request = self.context["request"]
+
+        teams = Team.objects.filter(
+            team_organization=obj.owner.organization,
+            members__member=request.user,
+        ).select_related("team_organization")
+
+        team_names = []
+        for team in teams:
+            team_names.append(team.teamname)
+
+        return team_names
+
+    class Meta(ProjectSerializer.Meta):
+        fields = (*ProjectSerializer.Meta.fields, "teams")  # type: ignore[assignment]
+        read_only_fields = (
+            *ProjectSerializer.Meta.read_only_fields,
+            "teams",
+        )  # type: ignore[assignment]
 
 
 class ProjectThumbnailSerializer(serializers.ModelSerializer):

--- a/docker-app/qfieldcloud/project/tests/test_project.py
+++ b/docker-app/qfieldcloud/project/tests/test_project.py
@@ -1735,3 +1735,102 @@ class QfcTestCase(APITransactionTestCase):
                     project=project, collaborator=self.user3
                 ).exists()
             )
+
+    def test_project_teams_field(self):
+        """`GET /projects/<id>/` returns `teams`, the caller's team names in the project's owning organization."""
+        # org1 has three teams. Nobody joins gamma.
+        org1 = Organization.objects.create(
+            username="org1", organization_owner=self.user1
+        )
+        team_alpha = Team.objects.create(username="@org1/alpha", team_organization=org1)
+        team_beta = Team.objects.create(username="@org1/beta", team_organization=org1)
+        Team.objects.create(username="@org1/gamma", team_organization=org1)
+
+        # A second org with its own team, to check teams don't leak across orgs.
+        org2 = Organization.objects.create(
+            username="org2", organization_owner=self.user3
+        )
+        team_delta = Team.objects.create(username="@org2/delta", team_organization=org2)
+
+        # user2 is in team alpha and beta (org1), and in delta (org2).
+        OrganizationMember.objects.create(organization=org1, member=self.user2)
+        TeamMember.objects.create(team=team_alpha, member=self.user2)
+        TeamMember.objects.create(team=team_beta, member=self.user2)
+        OrganizationMember.objects.create(organization=org2, member=self.user2)
+        TeamMember.objects.create(team=team_delta, member=self.user2)
+
+        # user3 is an org1 admin but joins no team.
+        OrganizationMember.objects.create(
+            organization=org1, member=self.user3, role=OrganizationMember.Roles.ADMIN
+        )
+
+        # outsider has nothing to do with org1.
+        outsider = Person.objects.create_user(username="outsider", password="abc123")
+        outsider_token = AuthToken.objects.get_or_create(user=outsider)[0]
+
+        org_project = Project.objects.create(
+            name="org_project", is_public=True, owner=org1
+        )
+        person_project = Project.objects.create(
+            name="person_project", is_public=True, owner=self.user1
+        )
+        org_url = f"/api/v1/projects/{org_project.pk}/"
+
+        def get_teams(token, url):
+            self.client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
+            response = self.client.get(url, follow=True)
+            self.assertTrue(status.is_success(response.status_code))
+            return response.json()["teams"]
+
+        # `teams` is the caller's teams in the owning organization unprefixed.
+        with self.subTest(
+            "Test an organization member of alpha and beta returns the correct teams"
+        ):
+            self.assertEqual(get_teams(self.token2, org_url), ["alpha", "beta"])
+
+        with self.subTest(
+            "Test an organization owner without a team returns empty teams"
+        ):
+            self.assertEqual(get_teams(self.token1, org_url), [])
+
+        with self.subTest(
+            "Test an organization admin without a team returns empty teams"
+        ):
+            self.assertEqual(get_teams(self.token3, org_url), [])
+
+        with self.subTest("Test an outsider on a public project returns empty teams"):
+            self.assertEqual(get_teams(outsider_token, org_url), [])
+
+        with self.subTest("Test a person-owned project returns empty teams"):
+            person_url = f"/api/v1/projects/{person_project.pk}/"
+            self.assertEqual(get_teams(self.token1, person_url), [])
+
+        # `teams` is not part of the list or write responses.
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token1.key)
+
+        with self.subTest(
+            "Test that `teams` is not included in every project in the list response"
+        ):
+            response = self.client.get("/api/v1/projects/")
+            self.assertTrue(status.is_success(response.status_code))
+            self.assertGreaterEqual(len(response.json()), 1)
+            for project_data in response.json():
+                self.assertNotIn("teams", project_data)
+
+        with self.subTest("Test that `teams` is not included from the create response"):
+            response = self.client.post(
+                "/api/v1/projects/",
+                {
+                    "name": "created_project",
+                    "owner": "org1",
+                    "description": "desc",
+                    "is_public": False,
+                },
+            )
+            self.assertTrue(status.is_success(response.status_code))
+            self.assertNotIn("teams", response.json())
+
+        with self.subTest("Test that `teams` is not included in the update response"):
+            response = self.client.patch(org_url, {"description": "new desc"})
+            self.assertTrue(status.is_success(response.status_code))
+            self.assertNotIn("teams", response.json())

--- a/docker-app/qfieldcloud/project/views.py
+++ b/docker-app/qfieldcloud/project/views.py
@@ -30,6 +30,7 @@ from qfieldcloud.project.models import (
     get_slim_project_or_raise,
 )
 from qfieldcloud.project.serializers import (
+    ProjectDetailSerializer,
     ProjectSeedSerializer,
     ProjectSerializer,
     ProjectThumbnailSerializer,
@@ -94,7 +95,10 @@ class ProjectViewSetPermissions(permissions.BasePermission):
 
 
 @extend_schema_view(
-    retrieve=extend_schema(description="Retrieve a project"),
+    retrieve=extend_schema(
+        description=("Retrieve a project"),
+        responses=ProjectDetailSerializer,
+    ),
     update=extend_schema(description="Update a project"),
     partial_update=extend_schema(description="Partially update a project"),
     destroy=extend_schema(description="Delete a project"),
@@ -154,6 +158,12 @@ class ProjectViewSet(viewsets.ModelViewSet):
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+    def get_serializer_class(self):
+        if self.action == "retrieve":
+            return ProjectDetailSerializer
+
+        return super().get_serializer_class()
 
     def get_queryset(self):
         projects = Project.objects.with_prefetch().for_user(self.request.user)


### PR DESCRIPTION
QField will add a `@cloud_teams` expression variable. To resolve it, it needs the teams that the signed-in user belongs to in a project's owning organization.

`GET /api/v1/projects/<id>/` now returns a `teams` array. The list, create, and update responses omit it.

- `ProjectDetailSerializer` extends `ProjectSerializer` with a `teams` field and is selected only for the `retrieve` action
- `teams` holds the caller's team names with the `@organization/` prefix removed
- `teams` is empty when a person owns the project, the caller is in no team, owning or administering the organization does not by itself make the caller a team member
- the drf-spectacular `retrieve` response now points at `ProjectDetailSerializer`
- new `test_project_teams_field` covers the membership cases, cross-organization isolation, and the field's absence from the list and write responses