### PR TITLE
Fix project status null by guarding `qgis_project` lookup in `Project.status`

### DIFF
--- a/docker-app/qfieldcloud/project/models.py
+++ b/docker-app/qfieldcloud/project/models.py
@@ -1034,7 +1034,7 @@ class Project(models.Model):
 
             # TODO use self.problems to get if there are project problems
             if (
-                not self.has_the_qgis_file or not self.qgis_project
+                not self.has_the_qgis_file or not getattr(self, "qgis_project", None)
             ) and not self.is_shared_datasets_project:
                 status = Project.Status.FAILED
                 status_code = Project.StatusCode.FAILED_PROCESS_PROJECTFILE


### PR DESCRIPTION
`Project.status` is computed each time it's read, and it decides `FAILED` by checking whether project metadata parsing succeeded. On a timed-out `process_projectfile` job,`QgisProject` row doesn't get created, and status was accessing that reverse one-to-one relation directly instead of through `getattr`. That raised `QgisProject.DoesNotExist`, which DRF's serializer quietly turns into `None`, so the API reported status as `null` instead of failed.

- Swap `self.qgis_project` for `getattr(self, "qgis_project", None)` in the `Project.status` property